### PR TITLE
HTML report from live plotting layout

### DIFF
--- a/src/qcvv/report/__init__.py
+++ b/src/qcvv/report/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from qcvv.report.report import create_report

--- a/src/qcvv/report/report.py
+++ b/src/qcvv/report/report.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+import os
+import pathlib
+
+from jinja2 import Environment, FileSystemLoader
+
+
+def parse_dash(element):
+    if element._namespace == "dash_html_components":
+        # Convert dash HTML components to html tags
+        if isinstance(element.children, list):
+            tag = element._type.lower()
+            code = "".join(parse_dash(child) for child in element.children)
+            return f"<{tag}>\n{code}</{tag}>\n"
+
+        elif isinstance(element.children, str):
+            tag = element._type.lower()
+            return f"<{tag}>{element.children}</{tag}>\n"
+
+        elif element.children is None:
+            tag = element._type.lower()
+            return f"<{tag}>\n"
+
+        else:
+            raise NotImplementedError(f"Failed to parse {element}.")
+
+    elif element._type == "Graph":
+        # Parse graphs using ``fig.write_html``
+        from qcvv.live import get_graph
+
+        fig = get_graph(0, element.id)
+        fig.write_html("fig.html", include_plotlyjs=False, full_html=False)
+        with open("fig.html", "r") as file:
+            code = file.read()
+        os.remove("fig.html")
+        return code
+
+    else:
+        # Skip non-HTML (interactive) dash components
+        return ""
+
+
+def create_report(path):
+    """Creates an HTML report for the data in the given path.
+
+    The report is created based on the live plotting layout.
+    """
+    from qcvv.live import serve_layout
+
+    layout = serve_layout(path)
+    layout_html = parse_dash(layout)
+
+    env = Environment(loader=FileSystemLoader(pathlib.Path(__file__).parent))
+    template = env.get_template("template.html")
+    report = template.render(body=layout_html)
+
+    with open(f"{path}/report.html", "w") as file:
+        file.write(report)

--- a/src/qcvv/report/template.html
+++ b/src/qcvv/report/template.html
@@ -1,0 +1,14 @@
+<!-- Template for HTML reports -->
+<!-- The live plotting page layout is rendered in {{ body }} using jinja2 -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <script type="text/javascript">window.PlotlyConfig = {MathJaxConfig: 'local'};</script>
+    <!-- Reading the plotly js library from online to save space (not the latest version) -->
+    <!-- This is required for the report plots to remain interactive -->
+    <script type="text/javascript" src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+</head>
+<body>
+{{ body }}
+</body>
+</html>


### PR DESCRIPTION
Implements a method that converts the dash layout used for live plotting to a static HTML page that can be saved as a report. 

The core idea is implemented in the `qcvv.report.parse_dash` method which loops over the layout tree and converts all dash html components to pure html, all graphs using `fig.write_html` and ignores non-HTML components, such as `dcc.Interval` which is relevant only when live plotting. The resulting html is rendered to a template using jinja2. The plots in the report page are interactive using plotly.js which is included in the template.

I have not integrated this with the `qq` command yet. It can be tested using:
```py
from qcvv.report import create_report

create_report(path to your data folder)
```
which will create a `report.html` in the data folder. If we like this we can put it in the command so that the report is generated automatically for every run. Note that only the layout is used from live plotting, there is no need to execute the dash app for this.

@scarrazza please have a look and let me know if you like this approach. My main concern is that `parse_dash` may break if we change the live plotting layout. The html template could be enhanced to make the report look better. If you like to test this you can use the data I sent via email as this still assumes the previous data format. When Andrea finalizes the new format, I will update #10 and changes will be reflected here.

