### PR TITLE
Fix multiqubit sections layout

### DIFF
--- a/src/qcvv/web/templates/template.html
+++ b/src/qcvv/web/templates/template.html
@@ -72,12 +72,6 @@
                   {% for header, method in plotters.get(routine).items() %}
                   <li><a class="link-dark d-inline-flex text-decoration-none rounded"
                       href="#{{ routine }}-{{ method }}">- {{ header }}</a></li>
-                  <ul class="btn-toggle-nav list-unstyled fw-normal pb-1 small">
-                    {% for qubit in runcard.get('qubits') %}
-                    <li><a class="link-dark d-inline-flex text-decoration-none rounded"
-                      href="#{{ routine }}-{{ method }}-{{ qubit }}"> &nbsp; &nbsp; - Qubit {{ qubit }}</a></li>
-                    {% endfor %}
-                  </ul>
                   {% endfor %}
                 </ul>
                 {% endif %}


### PR DESCRIPTION
Fixes #46.

@scarrazza @andrea-pasquale please have a look that the sidebar and the sections look as you had in mind and also that the links work as expected. Here I followed exactly the layout from #46, an alternative is to put the plots refering to the same qubit together, eg. Freq. vs Att Qubit 0, MSR vs Freq. Qubit 0, Freq. vs Att. Qubit 1, MSR vs Freq Qubit 1, etc.. Let me know what you prefer.

@scarrazza do you know how I can add an additiona indent to the qubit sections in the sidebar? Now it is aligned with the plot title, I would like to push it a bit further inside. 