### PR TITLE
removing fixme and adding a few routines

### DIFF
--- a/runcards/actions_qq_5q.yml
+++ b/runcards/actions_qq_5q.yml
@@ -51,6 +51,7 @@ actions:
   #   precision_start: -500_000
   #   precision_end: 500_000
   #   precision_step: 100_000
+  #   attenuation: 46
   #   software_averages: 1
   #   points: 10
 
@@ -60,6 +61,7 @@ actions:
   #   current_min: -0.0012 # -0.0025 # absolute min is -40 mA
   #   current_max: -0.0004 # +0.001 # absolute max is 40 mA
   #   current_step: 0.00002 # 0.0001
+  #   attenuation: 46
   #   fluxline: 1 # Ask alvaro automatic way to obtain fluxline from runcard
   #   software_averages: 2
   #   points: 10

--- a/runcards/actions_qq_5q.yml
+++ b/runcards/actions_qq_5q.yml
@@ -175,3 +175,35 @@ actions:
   #   delay_between_pulses_step: 20
   #   software_averages: 1
   #   points: 5
+
+  # qubit_spectroscopy_flux_track:
+  #   freq_width: 50_000_000
+  #   freq_step: 1_000_000
+  #   current_offset: 10.e-3
+  #   current_step: 4.e-3 # 0.0001
+  #   attenuation: 46
+  #   software_averages: 1
+  #   points: 10
+
+  # rabi_pulse_amplitude_and_attenuation:
+  #   pulse_amplitude_start: 0
+  #   pulse_amplitude_end: 1
+  #   pulse_amplitude_step: 0.01
+  #   qd_pulse_attenuation_range: [10, 18, 24] #range(0,20,4)
+  #   software_averages: 1
+  #   points: 1
+
+  # resonator_drive_noise:
+  #   freq_width: 500_000
+  #   freq_step: 10_000
+  #   min_att: 00
+  #   max_att: 40
+  #   step_att: 10 # attenuation must be a multiple of 2
+  #   software_averages: 1
+  #   points: 10
+
+  # qubit_attenuation:
+  #   freq_start: -50.e+6
+  #   freq_end: +50.e+6
+  #   freq_step: 1.e+6
+  #   attenuation_list: range(0, 60, 2) # Or [2,16,40]

--- a/src/qcvv/calibrations/qubit_spectroscopy.py
+++ b/src/qcvv/calibrations/qubit_spectroscopy.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from smtplib import quotedata
-
 import numpy as np
 from qibolab.platforms.abstract import AbstractPlatform
 from qibolab.pulses import PulseSequence

--- a/src/qcvv/calibrations/qubit_spectroscopy.py
+++ b/src/qcvv/calibrations/qubit_spectroscopy.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
+from smtplib import quotedata
+
 import numpy as np
 from qibolab.platforms.abstract import AbstractPlatform
 from qibolab.pulses import PulseSequence
 
 from qcvv import plots
+from qcvv.calibrations.utils import check_frequency
 from qcvv.data import Dataset
 from qcvv.decorators import plot
 from qcvv.fitting.methods import lorentzian_fit
@@ -19,17 +22,20 @@ def qubit_spectroscopy(
     precision_start,
     precision_end,
     precision_step,
+    attenuation,
     software_averages,
     points=10,
 ):
-
     platform.reload_settings()
+    check_frequency(platform, write=True)
 
     sequence = PulseSequence()
     qd_pulse = platform.create_qubit_drive_pulse(qubit, start=0, duration=5000)
+    qd_pulse.frequency = 1.0e6
     ro_pulse = platform.create_qubit_readout_pulse(qubit, start=5000)
     sequence.add(qd_pulse)
     sequence.add(ro_pulse)
+    platform.qd_port[qubit].attenuation = attenuation
 
     qubit_frequency = platform.characterization["single_qubit"][qubit]["qubit_freq"]
 
@@ -38,10 +44,10 @@ def qubit_spectroscopy(
     data = Dataset(quantities={"frequency": "Hz", "attenuation": "dB"})
 
     # FIXME: Waiting for Qblox platform to take care of that
-    platform.ro_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["resonator_freq"]
-        - ro_pulse.frequency
-    )
+    # platform.ro_port[qubit].lo_frequency = (
+    #     platform.characterization["single_qubit"][qubit]["resonator_freq"]
+    #     - ro_pulse.frequency
+    # )
 
     data = Dataset(name=f"fast_sweep_q{qubit}", quantities={"frequency": "Hz"})
     count = 0
@@ -134,9 +140,12 @@ def qubit_spectroscopy_flux(
     current_min,
     current_step,
     software_averages,
+    attenuation,
     fluxline,
     points=10,
 ):
+    platform.reload_settings()
+    check_frequency(platform, write=True)
     platform.reload_settings()
 
     if fluxline == "qubit":
@@ -144,31 +153,36 @@ def qubit_spectroscopy_flux(
 
     sequence = PulseSequence()
     qd_pulse = platform.create_qubit_drive_pulse(qubit, start=0, duration=5000)
+    qd_pulse.frequency = 1.0e6
     ro_pulse = platform.create_qubit_readout_pulse(qubit, start=5000)
     sequence.add(qd_pulse)
     sequence.add(ro_pulse)
+    platform.qd_port[qubit].attenuation = attenuation
 
     data = Dataset(
         name=f"data_q{qubit}", quantities={"frequency": "Hz", "current": "A"}
     )
 
     qubit_frequency = platform.characterization["single_qubit"][qubit]["qubit_freq"]
-    qubit_biasing_current = platform.characterization["single_qubit"][qubit][
-        "sweetspot"
-    ]
     frequency_range = np.arange(-freq_width, freq_width, freq_step) + qubit_frequency
-    current_range = (
-        np.arange(current_min, current_max, current_step) + qubit_biasing_current
-    )
+    current_range = np.arange(current_min, current_max, current_step)
 
     count = 0
     for _ in range(software_averages):
         for curr in current_range:
+            platform.ro_port[qubit].lo_frequency = (
+                np.poly1d(
+                    platform.characterization["single_qubit"][qubit][
+                        "resonator_polycoef_flux"
+                    ]
+                )(curr)
+                - ro_pulse.frequency
+            )
             for freq in frequency_range:
                 if count % points == 0:
                     yield data
                 platform.qd_port[qubit].lo_frequency = freq - qd_pulse.frequency
-                platform.qf_port[fluxline].current = curr
+                platform.qf_port[qubit].current = curr
                 msr, phase, i, q = platform.execute_pulse_sequence(sequence)[
                     ro_pulse.serial
                 ]
@@ -179,6 +193,142 @@ def qubit_spectroscopy_flux(
                     "phase[rad]": phase,
                     "frequency[Hz]": freq,
                     "current[A]": curr,
+                }
+                # TODO: implement normalization
+                data.add(results)
+                count += 1
+
+    yield data
+
+
+@plot("MSR (row 1) and Phase (row 2)", plots.frequency_flux_msr_phase)
+def qubit_spectroscopy_flux_track(
+    platform: AbstractPlatform,
+    qubit,
+    freq_width,
+    freq_step,
+    current_offset,
+    current_step,
+    software_averages,
+    attenuation=46,
+    points=10,
+):
+    platform.reload_settings()
+    check_frequency(platform, write=True)
+
+    sequence = PulseSequence()
+    qd_pulse = platform.create_qubit_drive_pulse(qubit, start=0, duration=5000)
+    qd_pulse.frequency = 1.0e6
+    ro_pulse = platform.create_qubit_readout_pulse(qubit, start=5000)
+    sequence.add(qd_pulse)
+    sequence.add(ro_pulse)
+    platform.qd_port[qubit].attenuation = attenuation
+
+    data = Dataset(
+        name=f"data_q{qubit}", quantities={"frequency": "Hz", "current": "A"}
+    )
+
+    qubit_frequency = platform.characterization["single_qubit"][qubit]["qubit_freq"]
+    frequency_array = np.arange(-freq_width, freq_width, freq_step)
+    sweetspot = platform.characterization["single_qubit"][qubit]["sweetspot"]
+    current_range = np.arange(0, current_offset, current_step)
+    current_range = np.append(current_range, -current_range) + sweetspot
+
+    count = 0
+    for _ in range(software_averages):
+        for curr in current_range:
+            platform.ro_port[qubit].lo_frequency = (
+                np.poly1d(
+                    platform.characterization["single_qubit"][qubit][
+                        "resonator_polycoef_flux"
+                    ]
+                )(curr)
+                - ro_pulse.frequency
+            )
+
+            if curr == sweetspot:
+                center = qubit_frequency
+                msrs = []
+            else:
+                idx = np.argmax(msrs)
+                center = np.mean(frequency_range[idx])
+                msrs = []
+
+            frequency_range = frequency_array + center
+            for freq in frequency_range:
+                if count % points == 0:
+                    yield data
+                platform.qd_port[qubit].lo_frequency = freq - qd_pulse.frequency
+                platform.qf_port[qubit].current = curr
+                msr, phase, i, q = platform.execute_pulse_sequence(sequence)[
+                    ro_pulse.serial
+                ]
+                results = {
+                    "MSR[V]": msr,
+                    "i[V]": i,
+                    "q[V]": q,
+                    "phase[rad]": phase,
+                    "frequency[Hz]": freq,
+                    "current[A]": curr,
+                }
+                msrs += [msr]
+                # TODO: implement normalization
+                data.add(results)
+                count += 1
+
+    yield data
+
+
+@plot("Frequency vs Attenuation", plots.frequency_attenuation_msr_phase)
+def qubit_attenuation(
+    platform: AbstractPlatform,
+    qubit,
+    freq_start,
+    freq_end,
+    freq_step,
+    attenuation_list,
+    software_averages,
+    points=10,
+):
+    platform.reload_settings()
+    check_frequency(platform, write=True)
+
+    sequence = PulseSequence()
+    qd_pulse = platform.create_qubit_drive_pulse(qubit, start=0, duration=5000)
+    qd_pulse.frequency = 1.0e6
+    ro_pulse = platform.create_qubit_readout_pulse(qubit, start=5000)
+    sequence.add(qd_pulse)
+    sequence.add(ro_pulse)
+
+    data = Dataset(
+        name=f"data_q{qubit}", quantities={"frequency": "Hz", "attenuation": "dB"}
+    )
+
+    lo_qcm_frequency = platform.characterization["single_qubit"][qubit]["qubit_freq"]
+    freqrange = np.arange(freq_start, freq_end, freq_step) + lo_qcm_frequency
+
+    if isinstance(attenuation_list, str):
+        attenuation_list = eval(attenuation_list)
+
+    count = 0
+    attenuation_list = np.array(attenuation_list)
+    for _ in range(software_averages):
+        for att in attenuation_list:
+            for freq in freqrange:
+                if count % points == 0:
+                    yield data
+                platform.qd_port[qubit].lo_frequency = freq - qd_pulse.frequency
+                platform.qd_port[qubit].attenuation = att
+                msr, phase, i, q = platform.execute_pulse_sequence(sequence)[
+                    ro_pulse.serial
+                ]
+                results = {
+                    "MSR[V]": msr,
+                    "i[V]": i,
+                    "q[V]": q,
+                    "phase[deg]": phase,
+                    "frequency[Hz]": freq,
+                    "attenuation[dB]": att,
                 }
                 # TODO: implement normalization
                 data.add(results)

--- a/src/qcvv/calibrations/rabi_oscillations.py
+++ b/src/qcvv/calibrations/rabi_oscillations.py
@@ -4,6 +4,7 @@ from qibolab.platforms.abstract import AbstractPlatform
 from qibolab.pulses import PulseSequence
 
 from qcvv import plots
+from qcvv.calibrations.utils import check_frequency
 from qcvv.data import Dataset
 from qcvv.decorators import plot
 from qcvv.fitting.methods import rabi_fit
@@ -33,15 +34,7 @@ def rabi_pulse_length(
         pulse_duration_start, pulse_duration_end, pulse_duration_step
     )
 
-    # FIXME: Waiting to be able to pass qpucard to qibolab
-    platform.ro_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["resonator_freq"]
-        - ro_pulse.frequency
-    )
-    platform.qd_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["qubit_freq"]
-        - qd_pulse.frequency
-    )
+    check_frequency(platform, write=True)
 
     count = 0
     for _ in range(software_averages):
@@ -99,15 +92,7 @@ def rabi_pulse_gain(
 
     qd_pulse_gain_range = np.arange(pulse_gain_start, pulse_gain_end, pulse_gain_step)
 
-    # FIXME: Waiting to be able to pass qpucard to qibolab
-    platform.ro_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["resonator_freq"]
-        - ro_pulse.frequency
-    )
-    platform.qd_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["qubit_freq"]
-        - qd_pulse.frequency
-    )
+    check_frequency(platform, write=True)
 
     count = 0
     for _ in range(software_averages):
@@ -166,15 +151,7 @@ def rabi_pulse_amplitude(
         pulse_amplitude_start, pulse_amplitude_end, pulse_amplitude_step
     )
 
-    # FIXME: Waiting to be able to pass qpucard to qibolab
-    platform.ro_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["resonator_freq"]
-        - ro_pulse.frequency
-    )
-    platform.qd_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["qubit_freq"]
-        - qd_pulse.frequency
-    )
+    check_frequency(platform, write=True)
 
     count = 0
     for _ in range(software_averages):
@@ -239,15 +216,7 @@ def rabi_pulse_length_and_gain(
     )
     qd_pulse_gain_range = np.arange(pulse_gain_start, pulse_gain_end, pulse_gain_step)
 
-    # FIXME: Waiting to be able to pass qpucard to qibolab
-    platform.ro_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["resonator_freq"]
-        - ro_pulse.frequency
-    )
-    platform.qd_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["qubit_freq"]
-        - qd_pulse.frequency
-    )
+    check_frequency(platform, write=True)
 
     count = 0
     for _ in range(software_averages):
@@ -308,15 +277,7 @@ def rabi_pulse_length_and_amplitude(
         pulse_amplitude_start, pulse_amplitude_end, pulse_amplitude_step
     )
 
-    # FIXME: Waiting to be able to pass qpucard to qibolab
-    platform.ro_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["resonator_freq"]
-        - ro_pulse.frequency
-    )
-    platform.qd_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["qubit_freq"]
-        - qd_pulse.frequency
-    )
+    check_frequency(platform, write=True)
 
     count = 0
     for _ in range(software_averages):
@@ -336,6 +297,65 @@ def rabi_pulse_length_and_amplitude(
                     "q[V]": q,
                     "phase[rad]": phase,
                     "duration[ns]": duration,
+                    "amplitude[dimensionless]": amplitude,
+                }
+                data.add(results)
+                count += 1
+
+    yield data
+
+
+@plot("MSR vs length and amplitude", plots.amplitude_attenuation_msr_phase)
+def rabi_pulse_amplitude_and_attenuation(
+    platform,
+    qubit,
+    pulse_amplitude_start,
+    pulse_amplitude_end,
+    pulse_amplitude_step,
+    qd_pulse_attenuation_range,
+    software_averages,
+    points=10,
+):
+    platform.reload_settings()
+
+    data = Dataset(
+        name=f"data_q{qubit}",
+        quantities={"attenuation": "dB", "amplitude": "dimensionless"},
+    )
+
+    sequence = PulseSequence()
+    qd_pulse = platform.create_qubit_drive_pulse(qubit, start=0, duration=40)
+    ro_pulse = platform.create_qubit_readout_pulse(qubit, start=qd_pulse.duration)
+    sequence.add(qd_pulse)
+    sequence.add(ro_pulse)
+
+    if isinstance(qd_pulse_attenuation_range, str):
+        qd_pulse_attenuation_range = eval(qd_pulse_attenuation_range)
+    qd_pulse_attenuation_range = np.array(qd_pulse_attenuation_range)
+
+    qd_pulse_amplitude_range = np.arange(
+        pulse_amplitude_start, pulse_amplitude_end, pulse_amplitude_step
+    )
+
+    check_frequency(platform, write=True)
+
+    count = 0
+    for _ in range(software_averages):
+        for att in qd_pulse_attenuation_range:
+            platform.qd_port[qubit].attenuation = att
+            for amplitude in qd_pulse_amplitude_range:
+                qd_pulse.amplitude = amplitude
+                if count % points == 0:
+                    yield data
+                msr, phase, i, q = platform.execute_pulse_sequence(sequence)[
+                    ro_pulse.serial
+                ]
+                results = {
+                    "MSR[V]": msr,
+                    "i[V]": i,
+                    "q[V]": q,
+                    "phase[rad]": phase,
+                    "attenuation[dB]": att,
                     "amplitude[dimensionless]": amplitude,
                 }
                 data.add(results)

--- a/src/qcvv/calibrations/resonator_spectroscopy.py
+++ b/src/qcvv/calibrations/resonator_spectroscopy.py
@@ -21,7 +21,6 @@ def resonator_spectroscopy(
     precision_width,
     precision_step,
     software_averages,
-    drive_attenuation=None,
     points=10,
 ):
     platform.reload_settings()
@@ -35,12 +34,6 @@ def resonator_spectroscopy(
     resonator_frequency = platform.characterization["single_qubit"][qubit][
         "resonator_freq"
     ]
-
-    for i in range(platform.settings["nqubits"]):
-        if isinstance(drive_attenuation, list):
-            platform.qd_port[i].attenuation = drive_attenuation[i]
-        else:
-            platform.qd_port[i].attenuation = drive_attenuation
 
     frequency_range = (
         variable_resolution_scanrange(
@@ -156,7 +149,7 @@ def resonator_punchout(
     data = Dataset(
         name=f"data_q{qubit}", quantities={"frequency": "Hz", "attenuation": "dB"}
     )
-    ro_pulse = platform.create_qubit_readout_pulse(qubit, start=0)
+
     sequence = PulseSequence()
     ro_pulse = platform.create_qubit_readout_pulse(qubit, start=0)
     sequence.add(ro_pulse)

--- a/src/qcvv/calibrations/t1.py
+++ b/src/qcvv/calibrations/t1.py
@@ -4,6 +4,7 @@ from qibolab.platforms.abstract import AbstractPlatform
 from qibolab.pulses import PulseSequence
 
 from qcvv import plots
+from qcvv.calibrations.utils import check_frequency
 from qcvv.data import Dataset
 from qcvv.decorators import plot
 from qcvv.fitting.methods import t1_fit
@@ -29,15 +30,7 @@ def t1(
         delay_before_readout_start, delay_before_readout_end, delay_before_readout_step
     )
 
-    # FIXME: Waiting to be able to pass qpucard to qibolab
-    platform.ro_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["resonator_freq"]
-        - ro_pulse.frequency
-    )
-    platform.qd_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["qubit_freq"]
-        - qd_pulse.frequency
-    )
+    check_frequency(platform, write=False)
 
     data = Dataset(name=f"data_q{qubit}", quantities={"Time": "ns"})
 

--- a/src/qcvv/calibrations/utils.py
+++ b/src/qcvv/calibrations/utils.py
@@ -1,5 +1,11 @@
 # -*- coding: utf-8 -*-
+import pathlib
+
 import numpy as np
+import qibolab
+import yaml
+from qibo.config import log, raise_error
+from scipy.optimize import curve_fit
 
 
 def variable_resolution_scanrange(
@@ -13,3 +19,107 @@ def variable_resolution_scanrange(
             np.arange(highres_width, lowres_width, lowres_step),
         )
     )
+
+
+def check_frequency(platform, write=False):
+    """
+    Temporary function to change the IF of the QRM accordingly. It will be depriciated with multiple feedlines.
+    """
+    path = pathlib.Path(qibolab.__file__).parent / "runcards" / platform.runcard
+    with open(path, "r") as f:
+        settings = yaml.safe_load(f)
+
+    for inst in settings["instruments"]:
+        if "readout" in settings["instruments"][inst]["roles"]:
+            freq = []
+            freq_qrm = []
+            for i in range(settings["nqubits"]):
+                freq += [
+                    settings["characterization"]["single_qubit"][i]["resonator_freq"]
+                ]
+                freq_qrm += [
+                    settings["instruments"]["qrm_rf"]["settings"]["ports"]["o1"][
+                        "lo_frequency"
+                    ]
+                    + settings["native_gates"]["single_qubit"][i]["MZ"]["frequency"]
+                ]
+                if abs(freq[i] - freq_qrm[i]) > 1:  # leaving a 1Hz resolution
+                    log.info(
+                        f"WARNING: Instrument parameters not matching with the characterization frequency of qubit {i}: {freq_qrm[i]} for {freq[i]}"
+                    )
+            if write:
+                for i in range(settings["nqubits"]):
+                    settings["instruments"]["qrm_rf"]["settings"]["ports"]["o1"][
+                        "lo_frequency"
+                    ] = (max(freq) + min(freq)) / 2
+                    settings["native_gates"]["single_qubit"][i]["MZ"]["frequency"] = (
+                        freq[i]
+                        - settings["instruments"]["qrm_rf"]["settings"]["ports"]["o1"][
+                            "lo_frequency"
+                        ]
+                    )
+
+        if "flux" in settings["instruments"][inst]["roles"]:
+            sweetspot = []
+            sweetspot_spi = []
+            for i in range(settings["nqubits"]):
+                chan = settings["qubit_channel_map"][i][2]
+                sweetspot += [
+                    settings["characterization"]["single_qubit"][i]["sweetspot"]
+                ]
+                sweetspot_spi += [
+                    settings["instruments"]["SPI"]["settings"]["s4g_modules"][chan][2]
+                ]
+                if (
+                    abs(sweetspot[i] - sweetspot_spi[i]) > 1.0e-9
+                ):  # leaving a 1uA resolution
+                    log.info(
+                        f"WARNING: Instrument parameters not matching with the characterization sweetspot of qubit {i}: {sweetspot[i]} for {sweetspot_spi[i]}"
+                    )
+
+            if write:
+                chan = settings["qubit_channel_map"][i][2]
+                settings["instruments"]["SPI"]["settings"]["s4g_modules"][chan][
+                    2
+                ] = sweetspot[i]
+
+        if "control" in settings["instruments"][inst]["roles"]:
+            freq = {}
+            freq_qcm = {}
+            for i in range(settings["nqubits"]):
+                chan = settings["qubit_channel_map"][i][1]
+                if (
+                    chan
+                    in settings["instruments"][inst]["settings"]["channel_port_map"]
+                ):
+                    port = settings["instruments"][inst]["settings"][
+                        "channel_port_map"
+                    ][chan]
+                    freq[f"{i}"] = settings["characterization"]["single_qubit"][i][
+                        "qubit_freq"
+                    ]
+                    freq_qcm[f"{i}"] = (
+                        settings["instruments"][inst]["settings"]["ports"][port][
+                            "lo_frequency"
+                        ]
+                        + settings["native_gates"]["single_qubit"][i]["RX"]["frequency"]
+                    )
+                    if (
+                        abs(freq[f"{i}"] - freq_qcm[f"{i}"]) > 1
+                    ):  # leaving a 1Hz resolution
+                        log.info(
+                            f"WARNING: Instrument parameters not matching with the characterization frequency of qubit {i}: {freq_qcm[f'{i}']} for {freq[f'{i}']}"
+                        )
+                    if write:
+                        settings["instruments"][inst]["settings"]["ports"][port][
+                            "lo_frequency"
+                        ] = (
+                            freq[f"{i}"]
+                            - settings["native_gates"]["single_qubit"][i]["RX"][
+                                "frequency"
+                            ]
+                        )
+    if write:
+        log.info(f"WARNING: Writting YAML")
+        with open(path, "w") as f:
+            yaml.dump(settings, f, sort_keys=False, indent=4)

--- a/src/qcvv/plots/heatmaps.py
+++ b/src/qcvv/plots/heatmaps.py
@@ -236,3 +236,47 @@ def duration_amplitude_msr_phase(folder, routine, qubit, format):
         yaxis2_title="amplitude (dimensionless)",
     )
     return fig
+
+
+def amplitude_attenuation_msr_phase(folder, routine, qubit, format):
+    data = Dataset.load_data(folder, routine, format, f"data_q{qubit}")
+    fig = make_subplots(
+        rows=1,
+        cols=2,
+        horizontal_spacing=0.1,
+        vertical_spacing=0.1,
+        subplot_titles=(
+            "MSR (V)",
+            "phase (rad)",
+        ),
+    )
+
+    fig.add_trace(
+        go.Heatmap(
+            y=data.get_values("attenuation", "dB"),
+            x=data.get_values("amplitude", "dimensionless"),
+            z=data.get_values("MSR", "V"),
+            colorbar_x=0.45,
+        ),
+        row=1,
+        col=1,
+    )
+    fig.add_trace(
+        go.Heatmap(
+            y=data.get_values("attenuation", "dB"),
+            x=data.get_values("amplitude", "dimensionless"),
+            z=data.get_values("phase", "rad"),
+            colorbar_x=1.0,
+        ),
+        row=1,
+        col=2,
+    )
+    fig.update_layout(
+        showlegend=False,
+        uirevision="0",  # ``uirevision`` allows zooming while live plotting
+        xaxis_title="amplitude (dimensionless)",
+        yaxis_title="attenuation (dB)",
+        xaxis2_title="amplitude (dimensionless)",
+        yaxis2_title="attenuation (dB)",
+    )
+    return fig


### PR DESCRIPTION
- In `qibolab/multiplex`, the IF of the RO is no longer hard coded. Therefore, the `#FIXME` followed by changing the LO is no longer required. However, the runcard needs to be updated accordingly. I made a small function in the `utils.py` to take care of that. 
- Adding to very useful routines which are `qubit_spectroscopy_track`. It avoids using a large frequency span and it corrects for the change in the resonator's spectroscopy. 
- Adding `rabi_attenuation` which takes the rabi for different attenuations. This is important because to avoid noise one needs to maximize the attenuation. 