### PR TITLE
speedup Dataset add() and fix bug

### DIFF
--- a/src/qcvv/data.py
+++ b/src/qcvv/data.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Implementation of Dataset class to store measurements."""
 
+import re
 from abc import abstractmethod
 
 import pandas as pd
@@ -96,8 +97,6 @@ class Dataset(AbstractDataset):
                         Every key should have the following form:
                         ``<name>[<unit>]``.
         """
-        import re
-
         l = len(self)
         for key, value in data.items():
             name = key.split("[")[0]


### PR DESCRIPTION
Hi, 
There was a bug in the storage of the data that caused a gap in the rows of the data files every `len(list(data.keys()))` records. It was caused by this:
```python
self.df.loc[l + l // len(list(data.keys())), name] = value * ureg(unit)
```
Additionally, the loading of libraries and the instantiation of `pint.UnitRegistry` every time one calls `Dataset.add()` was slowing the execution unnecessarily. For the usual routines, we could barely notice, but while developing binning, a large number of records are generated on every execution, and the time taken to save 1024 records was in the range of 30s.

