### PR TITLE
Align with qibolab refactor included in qibolab PR#175 (richer acquisition results)

### DIFF
--- a/src/qcvv/calibrations/characterization/calibrate_qubit_states.py
+++ b/src/qcvv/calibrations/characterization/calibrate_qubit_states.py
@@ -25,12 +25,8 @@ def calibrate_qubit_states_binning(
     ro_pulse = platform.create_qubit_readout_pulse(qubit, start=RX_pulse.duration)
     exc_sequence.add(RX_pulse)
     exc_sequence.add(ro_pulse)
-    data_exc = Dataset(
-        name=f"data_exc_q{qubit}", quantities={"iteration": "dimensionless"}
-    )
-    shots_results = platform.execute_pulse_sequence(exc_sequence, nshots=niter)[
-        "shots"
-    ][ro_pulse.serial]
+    data_exc = Dataset(name=f"data_exc_q{qubit}", quantities={"iteration": "dimensionless"})
+    shots_results = platform.execute_pulse_sequence(exc_sequence, nshots=niter)['binned_integrated'][ro_pulse.serial]
     for n in np.arange(niter):
         msr, phase, i, q = shots_results[n]
         results = {
@@ -51,9 +47,7 @@ def calibrate_qubit_states_binning(
         name=f"data_gnd_q{qubit}", quantities={"iteration": "dimensionless"}
     )
 
-    shots_results = platform.execute_pulse_sequence(gnd_sequence, nshots=niter)[
-        "shots"
-    ][ro_pulse.serial]
+    shots_results = platform.execute_pulse_sequence(gnd_sequence, nshots=niter)['binned_integrated'][ro_pulse.serial]
     for n in np.arange(niter):
         msr, phase, i, q = shots_results[n]
         results = {


### PR DESCRIPTION
A new version of PR #87, pointing to `add_routines`
This PR aligns the code in calibrate_qubit_states_binning() so that it matches with the new dictionaries implemented in qibolab PR # 175: https://github.com/qiboteam/qibolab/pull/175