### PR TITLE
Let calibrate_qubit_states_binning() return rotation and threshold parameters

### DIFF
--- a/src/qcvv/calibrations/characterization/calibrate_qubit_states.py
+++ b/src/qcvv/calibrations/characterization/calibrate_qubit_states.py
@@ -25,9 +25,13 @@ def calibrate_qubit_states_binning(
     ro_pulse = platform.create_qubit_readout_pulse(qubit, start=RX_pulse.duration)
     exc_sequence.add(RX_pulse)
     exc_sequence.add(ro_pulse)
-    data_exc = Dataset(name=f"data_exc_q{qubit}", quantities={"iteration": "dimensionless"})
-    shots_results_exc = platform.execute_pulse_sequence(exc_sequence, nshots)['binned_integrated'][ro_pulse.serial]
-    
+    data_exc = Dataset(
+        name=f"data_exc_q{qubit}", quantities={"iteration": "dimensionless"}
+    )
+    shots_results_exc = platform.execute_pulse_sequence(exc_sequence, nshots)[
+        "binned_integrated"
+    ][ro_pulse.serial]
+
     iq_exc = []
     for n in np.arange(nshots):
         msr, phase, i, q = shots_results_exc[n]
@@ -46,9 +50,13 @@ def calibrate_qubit_states_binning(
     ro_pulse = platform.create_qubit_readout_pulse(qubit, start=0)
     gnd_sequence.add(ro_pulse)
 
-    data_gnd = Dataset(name=f"data_gnd_q{qubit}", quantities={"iteration": "dimensionless"})
-    shots_results_gnd = platform.execute_pulse_sequence(gnd_sequence, nshots)['binned_integrated'][ro_pulse.serial]
-    
+    data_gnd = Dataset(
+        name=f"data_gnd_q{qubit}", quantities={"iteration": "dimensionless"}
+    )
+    shots_results_gnd = platform.execute_pulse_sequence(gnd_sequence, nshots)[
+        "binned_integrated"
+    ][ro_pulse.serial]
+
     iq_gnd = []
     for n in np.arange(nshots):
         msr, phase, i, q = shots_results_gnd[n]
@@ -63,12 +71,15 @@ def calibrate_qubit_states_binning(
         data_gnd.add(results)
     yield data_gnd
 
-
-    parameters = Dataset(name=f"parameters_q{qubit}", quantities={
-        "rotation_angle": "dimensionless", # in degrees
-        "threshold": "V",
-        "fidelity": "dimensionless",
-        "assignment_fidelity": "dimensionless"  })
+    parameters = Dataset(
+        name=f"parameters_q{qubit}",
+        quantities={
+            "rotation_angle": "dimensionless",  # in degrees
+            "threshold": "V",
+            "fidelity": "dimensionless",
+            "assignment_fidelity": "dimensionless",
+        },
+    )
 
     iq_mean_exc = np.mean(iq_exc)
     iq_mean_gnd = np.mean(iq_gnd)
@@ -83,18 +94,22 @@ def calibrate_qubit_states_binning(
 
     real_values_exc = [x.real for x in iq_exc_rotated]
     real_values_gnd = [x.real for x in iq_gnd_rotated]
-    
+
     real_values_combined = real_values_exc + real_values_gnd
     real_values_combined.sort()
 
     cum_distribution_exc = [
-        sum(map(lambda x: x.real >= real_value, real_values_exc)) for real_value in real_values_combined
+        sum(map(lambda x: x.real >= real_value, real_values_exc))
+        for real_value in real_values_combined
     ]
     cum_distribution_gnd = [
-        sum(map(lambda x: x.real >= real_value, real_values_gnd)) for real_value in real_values_combined
+        sum(map(lambda x: x.real >= real_value, real_values_gnd))
+        for real_value in real_values_combined
     ]
 
-    cum_distribution_diff = np.abs(np.array(cum_distribution_exc) - np.array(cum_distribution_gnd))
+    cum_distribution_diff = np.abs(
+        np.array(cum_distribution_exc) - np.array(cum_distribution_gnd)
+    )
     argmax = np.argmax(cum_distribution_diff)
     threshold = real_values_combined[argmax]
     errors_exc = nshots - cum_distribution_exc[argmax]
@@ -102,13 +117,13 @@ def calibrate_qubit_states_binning(
     fidelity = cum_distribution_diff[argmax] / nshots
     assignment_fidelity = 1 - (errors_exc + errors_gnd) / nshots / 2
     # assignment_fidelity = 1/2 + (cum_distribution_exc[argmax] - cum_distribution_gnd[argmax])/nshots/2
-    
+
     results = {
-        "rotation_angle[dimensionless]": (rotation_angle * 360 / (2 * np.pi)) % 360, # in degrees
+        "rotation_angle[dimensionless]": (rotation_angle * 360 / (2 * np.pi))
+        % 360,  # in degrees
         "threshold[V]": threshold,
         "fidelity[dimensionless]": fidelity,
-        "assignment_fidelity[dimensionless]": assignment_fidelity 
+        "assignment_fidelity[dimensionless]": assignment_fidelity,
     }
     parameters.add(results)
-    yield(parameters)
-
+    yield (parameters)

--- a/src/qcvv/calibrations/characterization/calibrate_qubit_states.py
+++ b/src/qcvv/calibrations/characterization/calibrate_qubit_states.py
@@ -12,7 +12,7 @@ from qcvv.decorators import plot
 def calibrate_qubit_states_binning(
     platform: AbstractPlatform,
     qubit: int,
-    niter,
+    nshots,
     points=10,
 ):
     platform.reload_settings()
@@ -26,9 +26,12 @@ def calibrate_qubit_states_binning(
     exc_sequence.add(RX_pulse)
     exc_sequence.add(ro_pulse)
     data_exc = Dataset(name=f"data_exc_q{qubit}", quantities={"iteration": "dimensionless"})
-    shots_results = platform.execute_pulse_sequence(exc_sequence, nshots=niter)['binned_integrated'][ro_pulse.serial]
-    for n in np.arange(niter):
-        msr, phase, i, q = shots_results[n]
+    shots_results_exc = platform.execute_pulse_sequence(exc_sequence, nshots)['binned_integrated'][ro_pulse.serial]
+    
+    iq_exc = []
+    for n in np.arange(nshots):
+        msr, phase, i, q = shots_results_exc[n]
+        iq_exc += [complex(i, q)]
         results = {
             "MSR[V]": msr,
             "i[V]": i,
@@ -43,13 +46,13 @@ def calibrate_qubit_states_binning(
     ro_pulse = platform.create_qubit_readout_pulse(qubit, start=0)
     gnd_sequence.add(ro_pulse)
 
-    data_gnd = Dataset(
-        name=f"data_gnd_q{qubit}", quantities={"iteration": "dimensionless"}
-    )
-
-    shots_results = platform.execute_pulse_sequence(gnd_sequence, nshots=niter)['binned_integrated'][ro_pulse.serial]
-    for n in np.arange(niter):
-        msr, phase, i, q = shots_results[n]
+    data_gnd = Dataset(name=f"data_gnd_q{qubit}", quantities={"iteration": "dimensionless"})
+    shots_results_gnd = platform.execute_pulse_sequence(gnd_sequence, nshots)['binned_integrated'][ro_pulse.serial]
+    
+    iq_gnd = []
+    for n in np.arange(nshots):
+        msr, phase, i, q = shots_results_gnd[n]
+        iq_gnd += [complex(i, q)]
         results = {
             "MSR[V]": msr,
             "i[V]": i,
@@ -59,3 +62,53 @@ def calibrate_qubit_states_binning(
         }
         data_gnd.add(results)
     yield data_gnd
+
+
+    parameters = Dataset(name=f"parameters_q{qubit}", quantities={
+        "rotation_angle": "dimensionless", # in degrees
+        "threshold": "V",
+        "fidelity": "dimensionless",
+        "assignment_fidelity": "dimensionless"  })
+
+    iq_mean_exc = np.mean(iq_exc)
+    iq_mean_gnd = np.mean(iq_gnd)
+    origin = iq_mean_gnd
+
+    iq_gnd_translated = iq_gnd - origin
+    iq_exc_translated = iq_exc - origin
+    rotation_angle = np.angle(np.mean(iq_exc_translated))
+
+    iq_exc_rotated = iq_exc_translated * np.exp(-1j * rotation_angle) + origin
+    iq_gnd_rotated = iq_gnd_translated * np.exp(-1j * rotation_angle) + origin
+
+    real_values_exc = [x.real for x in iq_exc_rotated]
+    real_values_gnd = [x.real for x in iq_gnd_rotated]
+    
+    real_values_combined = real_values_exc + real_values_gnd
+    real_values_combined.sort()
+
+    cum_distribution_exc = [
+        sum(map(lambda x: x.real >= real_value, real_values_exc)) for real_value in real_values_combined
+    ]
+    cum_distribution_gnd = [
+        sum(map(lambda x: x.real >= real_value, real_values_gnd)) for real_value in real_values_combined
+    ]
+
+    cum_distribution_diff = np.abs(np.array(cum_distribution_exc) - np.array(cum_distribution_gnd))
+    argmax = np.argmax(cum_distribution_diff)
+    threshold = real_values_combined[argmax]
+    errors_exc = nshots - cum_distribution_exc[argmax]
+    errors_gnd = cum_distribution_gnd[argmax]
+    fidelity = cum_distribution_diff[argmax] / nshots
+    assignment_fidelity = 1 - (errors_exc + errors_gnd) / nshots / 2
+    # assignment_fidelity = 1/2 + (cum_distribution_exc[argmax] - cum_distribution_gnd[argmax])/nshots/2
+    
+    results = {
+        "rotation_angle[dimensionless]": (rotation_angle * 360 / (2 * np.pi)) % 360, # in degrees
+        "threshold[V]": threshold,
+        "fidelity[dimensionless]": fidelity,
+        "assignment_fidelity[dimensionless]": assignment_fidelity 
+    }
+    parameters.add(results)
+    yield(parameters)
+

--- a/src/qcvv/plots/scatters.py
+++ b/src/qcvv/plots/scatters.py
@@ -811,13 +811,19 @@ def exc_gnd(folder, routine, qubit, format):
         rotation_angle = parameters.get_values("rotation_angle", "dimensionless")[0]
         threshold = parameters.get_values("threshold", "V")[0]
         fidelity = parameters.get_values("fidelity", "dimensionless")[0]
-        assignment_fidelity = parameters.get_values("assignment_fidelity", "dimensionless")[0]
+        assignment_fidelity = parameters.get_values(
+            "assignment_fidelity", "dimensionless"
+        )[0]
     except:
-        parameters = Dataset(name=f"parameters_q{qubit}", quantities={
-            "rotation_angle": "dimensionless", # in degrees
-            "threshold": "V",
-            "fidelity": "dimensionless",
-            "assignment_fidelity": "dimensionless"  })
+        parameters = Dataset(
+            name=f"parameters_q{qubit}",
+            quantities={
+                "rotation_angle": "dimensionless",  # in degrees
+                "threshold": "V",
+                "fidelity": "dimensionless",
+                "assignment_fidelity": "dimensionless",
+            },
+        )
 
     try:
         data_exc = Dataset.load_data(folder, routine, format, f"data_exc_q{qubit}")
@@ -908,7 +914,7 @@ def exc_gnd(folder, routine, qubit, format):
         yaxis_title="q (V)",
         width=1000,
     )
-    
+
     title_text = f"""
     rotation_angle = {rotation_angle}<br>
     threshold = {threshold}<br>

--- a/src/qcvv/plots/scatters.py
+++ b/src/qcvv/plots/scatters.py
@@ -807,6 +807,19 @@ def flips_msr_phase(folder, routine, qubit, format):
 def exc_gnd(folder, routine, qubit, format):
 
     try:
+        parameters = Dataset.load_data(folder, routine, format, f"parameters_q{qubit}")
+        rotation_angle = parameters.get_values("rotation_angle", "dimensionless")[0]
+        threshold = parameters.get_values("threshold", "V")[0]
+        fidelity = parameters.get_values("fidelity", "dimensionless")[0]
+        assignment_fidelity = parameters.get_values("assignment_fidelity", "dimensionless")[0]
+    except:
+        parameters = Dataset(name=f"parameters_q{qubit}", quantities={
+            "rotation_angle": "dimensionless", # in degrees
+            "threshold": "V",
+            "fidelity": "dimensionless",
+            "assignment_fidelity": "dimensionless"  })
+
+    try:
         data_exc = Dataset.load_data(folder, routine, format, f"data_exc_q{qubit}")
     except:
         data_exc = Dataset(quantities={"iteration": "dimensionless"})
@@ -895,7 +908,15 @@ def exc_gnd(folder, routine, qubit, format):
         yaxis_title="q (V)",
         width=1000,
     )
+    
+    title_text = f"""
+    rotation_angle = {rotation_angle}<br>
+    threshold = {threshold}<br>
+    fidelity = {fidelity}<br>
+    assignment_fidelity = {assignment_fidelity}
+    """
 
+    fig.update_xaxes(title_text=title_text, row=1, col=1)
     return fig
 
 


### PR DESCRIPTION
This PR adds the calculation and plotting of the results of the classification `rotation_angle` and `threshold` parameters to `calibrate_qubit_states_binning`
![image](https://user-images.githubusercontent.com/55031026/194881768-30b46cc1-3947-4808-b728-46263a26c03a.png)
`rotation_angle` is the rotation that would need to be applied so that the mean of state 0 and the mean of state 1 are both on a horizontal line. Since qblox needs this parameter in degrees the results are calculated in degrees (0 to 360).
`threshold` is the `i` component voltage that better discriminates between the two states once rotated, the one that give the greatest fidelity.