### PR TITLE
Fix double connection issue

### DIFF
--- a/src/qibocal/cli/builders.py
+++ b/src/qibocal/cli/builders.py
@@ -76,14 +76,8 @@ class ActionBuilder:
     def _allocate_backend(self, backend_name, platform_name, path):
         """Allocate the platform using Qibolab."""
         from qibo.backends import GlobalBackend, set_backend
-        from qibolab.platform import Platform
-        from qibolab.platforms.abstract import AbstractPlatform
-
-        set_backend(backend=backend_name, platform=platform_name)
-        backend = GlobalBackend()
 
         if backend_name == "qibolab":
-            from qibolab import Platform
             from qibolab.paths import qibolab_folder
 
             original_runcard = qibolab_folder / "runcards" / f"{platform_name}.yml"
@@ -92,12 +86,16 @@ class ActionBuilder:
             # copy of the original runcard that will be modified during calibration
             updated_runcard = f"{self.folder}/new_platform.yml"
             shutil.copy(original_runcard, updated_runcard)
-            # create platform using the runcard that is modified
-            platform = Platform(platform_name, runcard=updated_runcard)
+            # allocate backend with updated_runcard
+            set_backend(
+                backend=backend_name, platform=platform_name, runcard=updated_runcard
+            )
+            backend = GlobalBackend()
+            return backend, backend.platform
         else:
-            platform = None
-
-        return backend, platform
+            set_backend(backend=backend_name, platform=platform_name)
+            backend = GlobalBackend()
+            return backend, None
 
     def save_meta(self, path, folder):
         import qibocal


### PR DESCRIPTION
Closes #114.
As noted by @aorgazf, when running `qq` the platform was connecting twice to the instruments.
The double connection was caused by:

- `set_backend` which for qibolab performs also the connection with the instruments
- allocating a platform with the `updated_runcard`, i.e. the platform runcard which is continuosly updated when we run multiple routines.

In this PR I solved this issue by calling `set_backend` once with the `updated_runcard` directly.
Let me know what you think.