### PR TITLE
add Dataset set()

### DIFF
--- a/src/qibocal/calibrations/characterization/allXY.py
+++ b/src/qibocal/calibrations/characterization/allXY.py
@@ -4,7 +4,7 @@ from qibolab.platforms.abstract import AbstractPlatform
 from qibolab.pulses import PulseSequence
 
 from qibocal import plots
-from qibocal.data import Dataset
+from qibocal.data import DataUnits
 from qibocal.decorators import plot
 from qibocal.fitting.methods import drag_tunning_fit
 
@@ -50,7 +50,7 @@ def allXY(
         platform.characterization["single_qubit"][qubit]["state1_voltage"]
     )
 
-    data = Dataset(
+    data = DataUnits(
         name=f"data_q{qubit}",
         quantities={"probability": "dimensionless", "gateNumber": "dimensionless"},
     )
@@ -132,7 +132,7 @@ def allXY_iteration(
         platform.characterization["single_qubit"][qubit]["state1_voltage"]
     )
 
-    data = Dataset(
+    data = DataUnits(
         name=f"data_q{qubit}",
         quantities={
             "probability": "dimensionless",
@@ -201,7 +201,7 @@ def drag_pulse_tunning(
         - qd_pulse_test.frequency
     )
 
-    data = Dataset(name=f"data_q{qubit}", quantities={"beta_param": "dimensionless"})
+    data = DataUnits(name=f"data_q{qubit}", quantities={"beta_param": "dimensionless"})
 
     count = 0
     for beta_param in np.arange(beta_start, beta_end, beta_step).round(4):

--- a/src/qibocal/calibrations/characterization/calibrate_qubit_states.py
+++ b/src/qibocal/calibrations/characterization/calibrate_qubit_states.py
@@ -4,7 +4,7 @@ from qibolab.platforms.abstract import AbstractPlatform
 from qibolab.pulses import PulseSequence
 
 from qibocal import plots
-from qibocal.data import Dataset
+from qibocal.data import DataUnits
 from qibocal.decorators import plot
 
 
@@ -33,7 +33,7 @@ def calibrate_qubit_states(
         - RX_pulse.frequency
     )
 
-    data_exc = Dataset(name=f"data_exc_q{qubit}", quantities={"iteration": "s"})
+    data_exc = DataUnits(name=f"data_exc_q{qubit}", quantities={"iteration": "s"})
 
     count = 0
     for n in np.arange(niter):
@@ -57,7 +57,7 @@ def calibrate_qubit_states(
     ro_pulse = platform.create_qubit_readout_pulse(qubit, start=0)
     gnd_sequence.add(ro_pulse)
 
-    data_gnd = Dataset(name=f"data_gnd_q{qubit}", quantities={"iteration": "s"})
+    data_gnd = DataUnits(name=f"data_gnd_q{qubit}", quantities={"iteration": "s"})
     count = 0
     for n in np.arange(niter):
         if count % points == 0:

--- a/src/qibocal/calibrations/characterization/flipping.py
+++ b/src/qibocal/calibrations/characterization/flipping.py
@@ -4,7 +4,7 @@ from qibolab.platforms.abstract import AbstractPlatform
 from qibolab.pulses import PulseSequence
 
 from qibocal import plots
-from qibocal.data import Dataset
+from qibocal.data import DataUnits
 from qibocal.decorators import plot
 from qibocal.fitting.methods import flipping_fit
 
@@ -22,7 +22,7 @@ def flipping(
         "amplitude"
     ]
 
-    data = Dataset(name=f"data_q{qubit}", quantities={"flips": "dimensionless"})
+    data = DataUnits(name=f"data_q{qubit}", quantities={"flips": "dimensionless"})
 
     sequence = PulseSequence()
     RX90_pulse = platform.create_RX90_pulse(qubit, start=0)

--- a/src/qibocal/calibrations/characterization/qubit_spectroscopy.py
+++ b/src/qibocal/calibrations/characterization/qubit_spectroscopy.py
@@ -4,7 +4,7 @@ from qibolab.platforms.abstract import AbstractPlatform
 from qibolab.pulses import PulseSequence
 
 from qibocal import plots
-from qibocal.data import Dataset
+from qibocal.data import DataUnits
 from qibocal.decorators import plot
 from qibocal.fitting.methods import lorentzian_fit
 
@@ -35,7 +35,7 @@ def qubit_spectroscopy(
 
     freqrange = np.arange(fast_start, fast_end, fast_step) + qubit_frequency
 
-    data = Dataset(quantities={"frequency": "Hz", "attenuation": "dB"})
+    data = DataUnits(quantities={"frequency": "Hz", "attenuation": "dB"})
 
     # FIXME: Waiting for Qblox platform to take care of that
     platform.ro_port[qubit].lo_frequency = (
@@ -43,7 +43,7 @@ def qubit_spectroscopy(
         - ro_pulse.frequency
     )
 
-    data = Dataset(name=f"fast_sweep_q{qubit}", quantities={"frequency": "Hz"})
+    data = DataUnits(name=f"fast_sweep_q{qubit}", quantities={"frequency": "Hz"})
     count = 0
     for _ in range(software_averages):
         for freq in freqrange:
@@ -98,7 +98,7 @@ def qubit_spectroscopy(
             * 1e6
         )
 
-    prec_data = Dataset(
+    prec_data = DataUnits(
         name=f"precision_sweep_q{qubit}", quantities={"frequency": "Hz"}
     )
     freqrange = (
@@ -158,7 +158,7 @@ def qubit_spectroscopy_flux(
     sequence.add(qd_pulse)
     sequence.add(ro_pulse)
 
-    data = Dataset(
+    data = DataUnits(
         name=f"data_q{qubit}", quantities={"frequency": "Hz", "current": "A"}
     )
 

--- a/src/qibocal/calibrations/characterization/qubit_spectroscopy.py
+++ b/src/qibocal/calibrations/characterization/qubit_spectroscopy.py
@@ -74,24 +74,24 @@ def qubit_spectroscopy(
     yield data
 
     if platform.resonator_type == "3D":
-        qubit_frequency = data.df.frequency[
-            data.df.MSR.index[data.df.MSR.argmin()]  # pylint: disable=E1101
+        qubit_frequency = data.data.frequency[
+            data.data.MSR.index[data.data.MSR.argmin()]  # pylint: disable=E1101
         ].magnitude
         avg_voltage = (
             np.mean(
-                data.df.MSR.values[  # pylint: disable=E1101
+                data.data.MSR.values[  # pylint: disable=E1101
                     : ((fast_end - fast_start) // fast_step)
                 ]
             )
             * 1e6
         )
     else:
-        qubit_frequency = data.df.frequency[  # pylint: disable=E1101
-            data.df.MSR.index[data.df.MSR.argmax()]  # pylint: disable=E1101
+        qubit_frequency = data.data.frequency[  # pylint: disable=E1101
+            data.data.MSR.index[data.data.MSR.argmax()]  # pylint: disable=E1101
         ].magnitude
         avg_voltage = (
             np.mean(
-                data.df.MSR.values[  # pylint: disable=E1101
+                data.data.MSR.values[  # pylint: disable=E1101
                     : ((fast_end - fast_start) // fast_step)
                 ]
             )

--- a/src/qibocal/calibrations/characterization/qubit_spectroscopy.py
+++ b/src/qibocal/calibrations/characterization/qubit_spectroscopy.py
@@ -74,26 +74,22 @@ def qubit_spectroscopy(
     yield data
 
     if platform.resonator_type == "3D":
-        qubit_frequency = data.df.frequency[
-            data.df.MSR.index[data.df.MSR.argmin()]  # pylint: disable=E1101
-        ].magnitude
+        qubit_frequency = data.get_values("frequency", "Hz")[
+            np.argmin(data.get_values("MSR", "V"))
+        ]
         avg_voltage = (
             np.mean(
-                data.df.MSR.values[  # pylint: disable=E1101
-                    : ((fast_end - fast_start) // fast_step)
-                ]
+                data.get_values("MSR", "V")[: ((fast_end - fast_start) // fast_step)]
             )
             * 1e6
         )
     else:
-        qubit_frequency = data.df.frequency[  # pylint: disable=E1101
-            data.df.MSR.index[data.df.MSR.argmax()]  # pylint: disable=E1101
-        ].magnitude
+        qubit_frequency = data.get_values("frequency", "Hz")[
+            np.argmax(data.get_values("MSR", "V"))
+        ]
         avg_voltage = (
             np.mean(
-                data.df.MSR.values[  # pylint: disable=E1101
-                    : ((fast_end - fast_start) // fast_step)
-                ]
+                data.get_values("MSR", "V")[: ((fast_end - fast_start) // fast_step)]
             )
             * 1e6
         )

--- a/src/qibocal/calibrations/characterization/qubit_spectroscopy.py
+++ b/src/qibocal/calibrations/characterization/qubit_spectroscopy.py
@@ -74,24 +74,24 @@ def qubit_spectroscopy(
     yield data
 
     if platform.resonator_type == "3D":
-        qubit_frequency = data.data.frequency[
-            data.data.MSR.index[data.data.MSR.argmin()]  # pylint: disable=E1101
+        qubit_frequency = data.df.frequency[
+            data.df.MSR.index[data.df.MSR.argmin()]  # pylint: disable=E1101
         ].magnitude
         avg_voltage = (
             np.mean(
-                data.data.MSR.values[  # pylint: disable=E1101
+                data.df.MSR.values[  # pylint: disable=E1101
                     : ((fast_end - fast_start) // fast_step)
                 ]
             )
             * 1e6
         )
     else:
-        qubit_frequency = data.data.frequency[  # pylint: disable=E1101
-            data.data.MSR.index[data.data.MSR.argmax()]  # pylint: disable=E1101
+        qubit_frequency = data.df.frequency[  # pylint: disable=E1101
+            data.df.MSR.index[data.df.MSR.argmax()]  # pylint: disable=E1101
         ].magnitude
         avg_voltage = (
             np.mean(
-                data.data.MSR.values[  # pylint: disable=E1101
+                data.df.MSR.values[  # pylint: disable=E1101
                     : ((fast_end - fast_start) // fast_step)
                 ]
             )

--- a/src/qibocal/calibrations/characterization/rabi_oscillations.py
+++ b/src/qibocal/calibrations/characterization/rabi_oscillations.py
@@ -4,7 +4,7 @@ from qibolab.platforms.abstract import AbstractPlatform
 from qibolab.pulses import PulseSequence
 
 from qibocal import plots
-from qibocal.data import Dataset
+from qibocal.data import DataUnits
 from qibocal.decorators import plot
 from qibocal.fitting.methods import rabi_fit
 
@@ -21,7 +21,7 @@ def rabi_pulse_length(
 ):
     platform.reload_settings()
 
-    data = Dataset(name=f"data_q{qubit}", quantities={"Time": "ns"})
+    data = DataUnits(name=f"data_q{qubit}", quantities={"Time": "ns"})
 
     sequence = PulseSequence()
     qd_pulse = platform.create_qubit_drive_pulse(qubit, start=0, duration=4)
@@ -88,7 +88,7 @@ def rabi_pulse_gain(
 ):
     platform.reload_settings()
 
-    data = Dataset(name=f"data_q{qubit}", quantities={"gain": "dimensionless"})
+    data = DataUnits(name=f"data_q{qubit}", quantities={"gain": "dimensionless"})
 
     sequence = PulseSequence()
     qd_pulse = platform.create_RX_pulse(qubit, start=0)
@@ -152,7 +152,7 @@ def rabi_pulse_amplitude(
 ):
     platform.reload_settings()
 
-    data = Dataset(name=f"data_q{qubit}", quantities={"amplitude": "dimensionless"})
+    data = DataUnits(name=f"data_q{qubit}", quantities={"amplitude": "dimensionless"})
 
     sequence = PulseSequence()
     qd_pulse = platform.create_RX_pulse(qubit, start=0)
@@ -221,7 +221,7 @@ def rabi_pulse_length_and_gain(
 ):
     platform.reload_settings()
 
-    data = Dataset(
+    data = DataUnits(
         name=f"data_q{qubit}", quantities={"duration": "ns", "gain": "dimensionless"}
     )
 
@@ -287,7 +287,7 @@ def rabi_pulse_length_and_amplitude(
 ):
     platform.reload_settings()
 
-    data = Dataset(
+    data = DataUnits(
         name=f"data_q{qubit}",
         quantities={"duration": "ns", "amplitude": "dimensionless"},
     )

--- a/src/qibocal/calibrations/characterization/ramsey.py
+++ b/src/qibocal/calibrations/characterization/ramsey.py
@@ -4,7 +4,7 @@ from qibolab.platforms.abstract import AbstractPlatform
 from qibolab.pulses import PulseSequence
 
 from qibocal import plots
-from qibocal.data import Dataset
+from qibocal.data import DataUnits
 from qibocal.decorators import plot
 from qibocal.fitting.methods import ramsey_fit
 
@@ -22,7 +22,7 @@ def ramsey_frequency_detuned(
     platform.reload_settings()
     sampling_rate = platform.sampling_rate
 
-    data = Dataset(name=f"data_q{qubit}", quantities={"wait": "ns", "t_max": "ns"})
+    data = DataUnits(name=f"data_q{qubit}", quantities={"wait": "ns", "t_max": "ns"})
 
     RX90_pulse1 = platform.create_RX90_pulse(qubit, start=0)
     RX90_pulse2 = platform.create_RX90_pulse(qubit, start=RX90_pulse1.finish)
@@ -118,7 +118,7 @@ def ramsey_frequency_detuned(
         if (new_t2 > current_T2).bool() and len(t_end) > 1:
             current_qubit_freq = int(corrected_qubit_freq)
             current_T2 = new_t2
-            data = Dataset(
+            data = DataUnits(
                 name=f"data_q{qubit}", quantities={"wait": "ns", "t_max": "ns"}
             )
         else:
@@ -168,7 +168,7 @@ def ramsey(
         - RX90_pulse1.frequency
     )
 
-    data = Dataset(name=f"data_q{qubit}", quantities={"wait": "ns", "t_max": "ns"})
+    data = DataUnits(name=f"data_q{qubit}", quantities={"wait": "ns", "t_max": "ns"})
     count = 0
     for _ in range(software_averages):
         for wait in waits:

--- a/src/qibocal/calibrations/characterization/resonator_spectroscopy.py
+++ b/src/qibocal/calibrations/characterization/resonator_spectroscopy.py
@@ -72,28 +72,28 @@ def resonator_spectroscopy(
     yield fast_sweep_data
 
     if platform.resonator_type == "3D":
-        resonator_frequency = fast_sweep_data.data.frequency[  # pylint: disable=E1101
-            fast_sweep_data.data.MSR.index[  # pylint: disable=E1101
-                fast_sweep_data.data.MSR.argmax()  # pylint: disable=E1101
+        resonator_frequency = fast_sweep_data.df.frequency[  # pylint: disable=E1101
+            fast_sweep_data.df.MSR.index[  # pylint: disable=E1101
+                fast_sweep_data.df.MSR.argmax()  # pylint: disable=E1101
             ]
         ].magnitude
         avg_voltage = (
             np.mean(
-                fast_sweep_data.data.MSR.values[  # pylint: disable=E1101
+                fast_sweep_data.df.MSR.values[  # pylint: disable=E1101
                     : (lowres_width // lowres_step)
                 ]
             )
             * 1e6
         )
     else:
-        resonator_frequency = fast_sweep_data.data.frequency[  # pylint: disable=E1101
-            fast_sweep_data.data.MSR.index[  # pylint: disable=E1101
-                fast_sweep_data.data.MSR.argmin()  # pylint: disable=E1101
+        resonator_frequency = fast_sweep_data.df.frequency[  # pylint: disable=E1101
+            fast_sweep_data.df.MSR.index[  # pylint: disable=E1101
+                fast_sweep_data.df.MSR.argmin()  # pylint: disable=E1101
             ]
         ].magnitude
         avg_voltage = (
             np.mean(
-                fast_sweep_data.data.MSR.values[  # pylint: disable=E1101
+                fast_sweep_data.df.MSR.values[  # pylint: disable=E1101
                     : (lowres_width // lowres_step)
                 ]
             )

--- a/src/qibocal/calibrations/characterization/resonator_spectroscopy.py
+++ b/src/qibocal/calibrations/characterization/resonator_spectroscopy.py
@@ -72,30 +72,22 @@ def resonator_spectroscopy(
     yield fast_sweep_data
 
     if platform.resonator_type == "3D":
-        resonator_frequency = fast_sweep_data.df.frequency[  # pylint: disable=E1101
-            fast_sweep_data.df.MSR.index[  # pylint: disable=E1101
-                fast_sweep_data.df.MSR.argmax()  # pylint: disable=E1101
-            ]
-        ].magnitude
+        resonator_frequency = fast_sweep_data.get_values("frequency", "Hz")[
+            np.argmax(fast_sweep_data.get_values("MSR", "V"))
+        ]
         avg_voltage = (
             np.mean(
-                fast_sweep_data.df.MSR.values[  # pylint: disable=E1101
-                    : (lowres_width // lowres_step)
-                ]
+                fast_sweep_data.get_values("MSR", "V")[: (lowres_width // lowres_step)]
             )
             * 1e6
         )
     else:
-        resonator_frequency = fast_sweep_data.df.frequency[  # pylint: disable=E1101
-            fast_sweep_data.df.MSR.index[  # pylint: disable=E1101
-                fast_sweep_data.df.MSR.argmin()  # pylint: disable=E1101
-            ]
-        ].magnitude
+        resonator_frequency = fast_sweep_data.get_values("frequency", "Hz")[
+            np.argmin(fast_sweep_data.get_values("MSR", "V"))
+        ]
         avg_voltage = (
             np.mean(
-                fast_sweep_data.df.MSR.values[  # pylint: disable=E1101
-                    : (lowres_width // lowres_step)
-                ]
+                fast_sweep_data.get_values("MSR", "V")[: (lowres_width // lowres_step)]
             )
             * 1e6
         )

--- a/src/qibocal/calibrations/characterization/resonator_spectroscopy.py
+++ b/src/qibocal/calibrations/characterization/resonator_spectroscopy.py
@@ -5,7 +5,7 @@ from qibolab.pulses import PulseSequence
 
 from qibocal import plots
 from qibocal.calibrations.characterization.utils import variable_resolution_scanrange
-from qibocal.data import Dataset
+from qibocal.data import DataUnits
 from qibocal.decorators import plot
 from qibocal.fitting.methods import lorentzian_fit
 
@@ -39,7 +39,7 @@ def resonator_spectroscopy(
         )
         + resonator_frequency
     )
-    fast_sweep_data = Dataset(
+    fast_sweep_data = DataUnits(
         name=f"fast_sweep_q{qubit}", quantities={"frequency": "Hz"}
     )
     count = 0
@@ -71,8 +71,6 @@ def resonator_spectroscopy(
             count += 1
     yield fast_sweep_data
 
-    # FIXME: have live ploting work for multiple datasets saved
-
     if platform.resonator_type == "3D":
         resonator_frequency = fast_sweep_data.data.frequency[  # pylint: disable=E1101
             fast_sweep_data.data.MSR.index[  # pylint: disable=E1101
@@ -102,7 +100,7 @@ def resonator_spectroscopy(
             * 1e6
         )
 
-    precision_sweep__data = Dataset(
+    precision_sweep__data = DataUnits(
         name=f"precision_sweep_q{qubit}", quantities={"frequency": "Hz"}
     )
     freqrange = (
@@ -155,7 +153,7 @@ def resonator_punchout(
 ):
     platform.reload_settings()
 
-    data = Dataset(
+    data = DataUnits(
         name=f"data_q{qubit}", quantities={"frequency": "Hz", "attenuation": "dB"}
     )
     ro_pulse = platform.create_qubit_readout_pulse(qubit, start=0)
@@ -221,7 +219,7 @@ def resonator_spectroscopy_flux(
     ro_pulse = platform.create_qubit_readout_pulse(qubit, start=0)
     sequence.add(ro_pulse)
 
-    data = Dataset(
+    data = DataUnits(
         name=f"data_q{qubit}", quantities={"frequency": "Hz", "current": "A"}
     )
 
@@ -298,7 +296,7 @@ def resonator_spectroscopy_flux_matrix(
     for fluxline in fluxlines:
         fluxline = int(fluxline)
         print(fluxline)
-        data = Dataset(
+        data = DataUnits(
             name=f"data_q{qubit}_f{fluxline}",
             quantities={"frequency": "Hz", "current": "A"},
         )
@@ -351,7 +349,7 @@ def dispersive_shift(
         np.arange(-freq_width, freq_width, freq_step) + resonator_frequency
     )
 
-    data_spec = Dataset(name=f"data_q{qubit}", quantities={"frequency": "Hz"})
+    data_spec = DataUnits(name=f"data_q{qubit}", quantities={"frequency": "Hz"})
     count = 0
     for _ in range(software_averages):
         for freq in frequency_range:
@@ -387,7 +385,7 @@ def dispersive_shift(
     sequence.add(RX_pulse)
     sequence.add(ro_pulse)
 
-    data_shifted = Dataset(
+    data_shifted = DataUnits(
         name=f"data_shifted_q{qubit}", quantities={"frequency": "Hz"}
     )
     count = 0

--- a/src/qibocal/calibrations/characterization/resonator_spectroscopy.py
+++ b/src/qibocal/calibrations/characterization/resonator_spectroscopy.py
@@ -74,28 +74,28 @@ def resonator_spectroscopy(
     # FIXME: have live ploting work for multiple datasets saved
 
     if platform.resonator_type == "3D":
-        resonator_frequency = fast_sweep_data.df.frequency[  # pylint: disable=E1101
-            fast_sweep_data.df.MSR.index[  # pylint: disable=E1101
-                fast_sweep_data.df.MSR.argmax()  # pylint: disable=E1101
+        resonator_frequency = fast_sweep_data.data.frequency[  # pylint: disable=E1101
+            fast_sweep_data.data.MSR.index[  # pylint: disable=E1101
+                fast_sweep_data.data.MSR.argmax()  # pylint: disable=E1101
             ]
         ].magnitude
         avg_voltage = (
             np.mean(
-                fast_sweep_data.df.MSR.values[  # pylint: disable=E1101
+                fast_sweep_data.data.MSR.values[  # pylint: disable=E1101
                     : (lowres_width // lowres_step)
                 ]
             )
             * 1e6
         )
     else:
-        resonator_frequency = fast_sweep_data.df.frequency[  # pylint: disable=E1101
-            fast_sweep_data.df.MSR.index[  # pylint: disable=E1101
-                fast_sweep_data.df.MSR.argmin()  # pylint: disable=E1101
+        resonator_frequency = fast_sweep_data.data.frequency[  # pylint: disable=E1101
+            fast_sweep_data.data.MSR.index[  # pylint: disable=E1101
+                fast_sweep_data.data.MSR.argmin()  # pylint: disable=E1101
             ]
         ].magnitude
         avg_voltage = (
             np.mean(
-                fast_sweep_data.df.MSR.values[  # pylint: disable=E1101
+                fast_sweep_data.data.MSR.values[  # pylint: disable=E1101
                     : (lowres_width // lowres_step)
                 ]
             )

--- a/src/qibocal/calibrations/characterization/t1.py
+++ b/src/qibocal/calibrations/characterization/t1.py
@@ -4,7 +4,7 @@ from qibolab.platforms.abstract import AbstractPlatform
 from qibolab.pulses import PulseSequence
 
 from qibocal import plots
-from qibocal.data import Dataset
+from qibocal.data import DataUnits
 from qibocal.decorators import plot
 from qibocal.fitting.methods import t1_fit
 
@@ -39,7 +39,7 @@ def t1(
         - qd_pulse.frequency
     )
 
-    data = Dataset(name=f"data_q{qubit}", quantities={"Time": "ns"})
+    data = DataUnits(name=f"data_q{qubit}", quantities={"Time": "ns"})
 
     count = 0
     for _ in range(software_averages):

--- a/src/qibocal/cli/builders.py
+++ b/src/qibocal/cli/builders.py
@@ -179,7 +179,7 @@ class ActionBuilder:
         except:
             data_fit = Data()
 
-        params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
+        params = [i for i in list(data_fit.data.keys()) if "popt" not in i]
         settings = load_yaml(f"{self.folder}/new_platform.yml")
 
         for param in params:

--- a/src/qibocal/cli/builders.py
+++ b/src/qibocal/cli/builders.py
@@ -179,7 +179,7 @@ class ActionBuilder:
         except:
             data_fit = Data()
 
-        params = [i for i in list(data_fit.data.keys()) if "popt" not in i]
+        params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
         settings = load_yaml(f"{self.folder}/new_platform.yml")
 
         for param in params:

--- a/src/qibocal/data.py
+++ b/src/qibocal/data.py
@@ -117,6 +117,24 @@ class Dataset(AbstractDataset):
             else:
                 self.df.loc[l, key] = value
 
+    def set(self, data):
+        """Add a row to dataset.
+
+        Args:
+            data (dict): dictionary containing the data to be added.
+                        Every key should have the following form:
+                        ``<name>[<unit>]``.
+        """
+        processed_data = {}
+        for key, values in data.items():
+            if "[" in key:
+                name = key.split("[")[0]
+                unit = re.search(r"\[([A-Za-z0-9_]+)\]", key).group(1)
+                processed_data[name] = pd.Series(data=(np.array(values) * self.ureg(unit)), dtype=f"pint[{unit}]")
+            else:
+                processed_data[name] = pd.Series(data=(values), dtype=object)
+        self.df = pd.DataFrame(processed_data)
+
     def get_values(self, key, unit=None):
         """Get values of a quantity in specified units.
 

--- a/src/qibocal/data.py
+++ b/src/qibocal/data.py
@@ -92,7 +92,9 @@ class Dataset(AbstractDataset):
         if options is not None:
             self.options = options
             for option in options:
-                self.data.insert(0, option, pd.Series(dtype=object))
+                self.data.insert(  # pylint: disable=E1101
+                    0, option, pd.Series(dtype=object)
+                )
 
         from pint import UnitRegistry
 
@@ -176,7 +178,7 @@ class Dataset(AbstractDataset):
             obj.data.pop("Unnamed: 0_level_0")
             quantities_label = []
             obj.options = []
-            for column in obj.data.columns:
+            for column in obj.data.columns:  # pylint: disable=E1101
                 if "Unnamed" not in column[1]:
                     quantities_label.append(column[0])
                 else:

--- a/src/qibocal/data.py
+++ b/src/qibocal/data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Implementation of Dataset class to store measurements."""
+"""Implementation of DataUnits and Data class to store calibration routines outputs."""
 
 import re
 from abc import abstractmethod
@@ -11,7 +11,7 @@ import pint_pandas
 from qibocal.config import raise_error
 
 
-class AbstractDataset:
+class AbstractData:
     def __init__(self, name=None):
 
         if name is None:
@@ -31,7 +31,7 @@ class AbstractDataset:
         raise_error(NotImplementedError)
 
     def __len__(self):
-        """Computes the length of the dataset."""
+        """Computes the length of the data."""
         return len(self.data)
 
     @classmethod
@@ -57,7 +57,7 @@ class AbstractDataset:
         self.data.to_pickle(f"{path}/{self.name}.pkl")
 
 
-class Dataset(AbstractDataset):
+class DataUnits(AbstractData):
     """Class to store the data measured during the calibration routines.
     It is a wrapper to a pandas DataFrame with units of measure from the Pint
     library.
@@ -129,7 +129,7 @@ class Dataset(AbstractDataset):
             self._data = pd.DataFrame(processed_data)
 
     def add(self, data):
-        """Add a row to dataset.
+        """Add a row to `DataUnits`.
 
         Args:
             data (dict): dictionary containing the data to be added.
@@ -172,7 +172,7 @@ class Dataset(AbstractDataset):
             format (str): data format. Possible choices are 'csv' and 'pickle'.
 
         Returns:
-            dataset (``Dataset``): dataset object with the loaded data.
+            data (``DataUnits``): dataset object with the loaded data.
         """
         obj = cls()
         if format == "csv":
@@ -209,7 +209,7 @@ class Dataset(AbstractDataset):
         data.to_csv(f"{path}/{self.name}.csv")
 
 
-class Data(AbstractDataset):
+class Data(AbstractData):
     """Class to store the data obtained from calibration routines.
     It is a wrapper to a pandas DataFrame.
 
@@ -278,7 +278,7 @@ class Data(AbstractDataset):
             format (str): data format. Possible choices are 'csv' and 'pickle'.
 
         Returns:
-            dataset (``Dataset``): dataset object with the loaded data.
+            data (``Data``): data object with the loaded data.
         """
         obj = cls()
         if format == "csv":

--- a/src/qibocal/data.py
+++ b/src/qibocal/data.py
@@ -113,17 +113,20 @@ class Dataset(AbstractDataset):
                         Every key should have the following form:
                         ``<name>[<unit>]``.
         """
-        processed_data = {}
-        for key, values in data.items():
-            if "[" in key:
-                name = key.split("[")[0]
-                unit = re.search(r"\[([A-Za-z0-9_]+)\]", key).group(1)
-                processed_data[name] = pd.Series(
-                    data=(np.array(values) * self.ureg(unit)), dtype=f"pint[{unit}]"
-                )
-            else:
-                processed_data[key] = pd.Series(data=(values), dtype=object)
-        self._data = pd.DataFrame(processed_data)
+        if isinstance(data, pd.DataFrame):
+            self._data = data
+        else:
+            processed_data = {}
+            for key, values in data.items():
+                if "[" in key:
+                    name = key.split("[")[0]
+                    unit = re.search(r"\[([A-Za-z0-9_]+)\]", key).group(1)
+                    processed_data[name] = pd.Series(
+                        data=(np.array(values) * self.ureg(unit)), dtype=f"pint[{unit}]"
+                    )
+                else:
+                    processed_data[key] = pd.Series(data=(values), dtype=object)
+            self._data = pd.DataFrame(processed_data)
 
     def add(self, data):
         """Add a row to dataset.
@@ -234,10 +237,13 @@ class Data(AbstractDataset):
         Args:
             data (dict): dictionary containing the data to be added.
         """
-        processed_data = {}
-        for key, values in data.items():
-            processed_data[key] = pd.Series(data=(values), dtype=object)
-        self._data = pd.DataFrame(processed_data)
+        if isinstance(data, pd.DataFrame):
+            self._data = data
+        else:
+            processed_data = {}
+            for key, values in data.items():
+                processed_data[key] = pd.Series(data=(values), dtype=object)
+            self._data = pd.DataFrame(processed_data)
 
     def add(self, data):
         """Add a row to data.

--- a/src/qibocal/data.py
+++ b/src/qibocal/data.py
@@ -101,7 +101,7 @@ class Dataset(AbstractDataset):
     @property
     def data(self):
         return self._data
-    
+
     @data.setter
     def data(self, data):
         """Set data attribute.
@@ -122,7 +122,6 @@ class Dataset(AbstractDataset):
             else:
                 processed_data[key] = pd.Series(data=(values), dtype=object)
         self._data = pd.DataFrame(processed_data)
-
 
     def add(self, data):
         """Add a row to dataset.
@@ -225,7 +224,7 @@ class Data(AbstractDataset):
     @property
     def data(self):
         return self._data
-    
+
     @data.setter
     def data(self, data):
         """Set data attribute.
@@ -235,7 +234,7 @@ class Data(AbstractDataset):
         """
         processed_data = {}
         for key, values in data.items():
-             processed_data[key] = pd.Series(data=(values), dtype=object)
+            processed_data[key] = pd.Series(data=(values), dtype=object)
         self._data = pd.DataFrame(processed_data)
 
     def add(self, data):

--- a/src/qibocal/data.py
+++ b/src/qibocal/data.py
@@ -130,7 +130,9 @@ class Dataset(AbstractDataset):
             if "[" in key:
                 name = key.split("[")[0]
                 unit = re.search(r"\[([A-Za-z0-9_]+)\]", key).group(1)
-                processed_data[name] = pd.Series(data=(np.array(values) * self.ureg(unit)), dtype=f"pint[{unit}]")
+                processed_data[name] = pd.Series(
+                    data=(np.array(values) * self.ureg(unit)), dtype=f"pint[{unit}]"
+                )
             else:
                 processed_data[name] = pd.Series(data=(values), dtype=object)
         self.df = pd.DataFrame(processed_data)

--- a/src/qibocal/plots/heatmaps.py
+++ b/src/qibocal/plots/heatmaps.py
@@ -4,11 +4,11 @@ import os.path
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
-from qibocal.data import Dataset
+from qibocal.data import DataUnits
 
 
 def frequency_flux_msr_phase(folder, routine, qubit, format):
-    data = Dataset.load_data(folder, routine, format, f"data_q{qubit}")
+    data = DataUnits.load_data(folder, routine, format, f"data_q{qubit}")
     fig = make_subplots(
         rows=1,
         cols=2,
@@ -52,7 +52,7 @@ def frequency_flux_msr_phase(folder, routine, qubit, format):
 
 
 def frequency_attenuation_msr_phase(folder, routine, qubit, format):
-    data = Dataset.load_data(folder, routine, format, f"data_q{qubit}")
+    data = DataUnits.load_data(folder, routine, format, f"data_q{qubit}")
     fig = make_subplots(
         rows=1,
         cols=2,
@@ -122,7 +122,7 @@ def frequency_flux_msr_phase__matrix(folder, routine, qubit, format):
             showscale = True
         else:
             showscale = False
-        data = Dataset.load_data(folder, routine, format, f"data_q{qubit}_f{j}")
+        data = DataUnits.load_data(folder, routine, format, f"data_q{qubit}_f{j}")
         fig.add_trace(
             go.Heatmap(
                 x=data.get_values("frequency", "GHz"),
@@ -151,7 +151,7 @@ def frequency_flux_msr_phase__matrix(folder, routine, qubit, format):
 
 
 def duration_gain_msr_phase(folder, routine, qubit, format):
-    data = Dataset.load_data(folder, routine, format, f"data_q{qubit}")
+    data = DataUnits.load_data(folder, routine, format, f"data_q{qubit}")
     fig = make_subplots(
         rows=1,
         cols=2,
@@ -195,7 +195,7 @@ def duration_gain_msr_phase(folder, routine, qubit, format):
 
 
 def duration_amplitude_msr_phase(folder, routine, qubit, format):
-    data = Dataset.load_data(folder, routine, format, f"data_q{qubit}")
+    data = DataUnits.load_data(folder, routine, format, f"data_q{qubit}")
     fig = make_subplots(
         rows=1,
         cols=2,

--- a/src/qibocal/plots/scatters.py
+++ b/src/qibocal/plots/scatters.py
@@ -85,7 +85,7 @@ def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
             max(data_fast.get_values("frequency", "GHz")),
             2 * len(data_fast),
         )
-        params = [i for i in list(data_fit.data.keys()) if "popt" not in i]
+        params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
         fig.add_trace(
             go.Scatter(
                 x=freqrange,
@@ -108,7 +108,7 @@ def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
                 x=0,
                 y=-0.25,
                 showarrow=False,
-                text=f"The estimated {params[0]} is {data_fit.data[params[0]][0]:.1f} Hz.",
+                text=f"The estimated {params[0]} is {data_fit.df[params[0]][0]:.1f} Hz.",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -121,7 +121,7 @@ def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
                 x=0,
                 y=-0.30,
                 showarrow=False,
-                text=f"The estimated {params[1]} is {data_fit.data[params[1]][0]:.3f} uV.",
+                text=f"The estimated {params[1]} is {data_fit.df[params[1]][0]:.3f} uV.",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -145,14 +145,12 @@ def frequency_attenuation_msr_phase__cut(folder, routine, qubit, format):
 
     fig = go.Figure()
     # index data on a specific attenuation value
-    smalldata = data.data[
-        data.get_values("attenuation", "dB") == plot1d_attenuation
-    ].copy()
+    smalldf = data.df[data.get_values("attenuation", "dB") == plot1d_attenuation].copy()
     # split multiple software averages to different datasets
     datasets = []
-    while len(smalldata):
-        datasets.append(smalldata.drop_duplicates("frequency"))
-        smalldata.drop(datasets[-1].index, inplace=True)
+    while len(smalldf):
+        datasets.append(smalldf.drop_duplicates("frequency"))
+        smalldf.drop(datasets[-1].index, inplace=True)
         fig.add_trace(
             go.Scatter(
                 x=datasets[-1]["frequency"].pint.to("GHz").pint.magnitude,
@@ -228,7 +226,7 @@ def time_msr_phase(folder, routine, qubit, format):
             max(data.get_values("Time", "ns")),
             2 * len(data),
         )
-        params = [i for i in list(data_fit.data.keys()) if "popt" not in i]
+        params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
         fig.add_trace(
             go.Scatter(
                 x=timerange,
@@ -253,7 +251,7 @@ def time_msr_phase(folder, routine, qubit, format):
                 x=0,
                 y=-0.20,
                 showarrow=False,
-                text=f"Estimated {params[1]} is {data_fit.data[params[1]][0]:.3f} ns.",
+                text=f"Estimated {params[1]} is {data_fit.df[params[1]][0]:.3f} ns.",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -267,7 +265,7 @@ def time_msr_phase(folder, routine, qubit, format):
                 x=0,
                 y=-0.30,
                 showarrow=False,
-                text=f"Estimated {params[0]} is {data_fit.data[params[0]][0]:.1f} uV.",
+                text=f"Estimated {params[0]} is {data_fit.df[params[0]][0]:.1f} uV.",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -346,7 +344,7 @@ def gain_msr_phase(folder, routine, qubit, format):
             max(data.get_values("gain", "dimensionless")),
             2 * len(data),
         )
-        params = [i for i in list(data_fit.data.keys()) if "popt" not in i]
+        params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
         fig.add_trace(
             go.Scatter(
                 x=gainrange,
@@ -371,7 +369,7 @@ def gain_msr_phase(folder, routine, qubit, format):
                 x=0,
                 y=-0.20,
                 showarrow=False,
-                text=f"Estimated {params[1]} is {data_fit.data[params[1]][0]:.3f}",
+                text=f"Estimated {params[1]} is {data_fit.df[params[1]][0]:.3f}",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -385,7 +383,7 @@ def gain_msr_phase(folder, routine, qubit, format):
                 x=0,
                 y=-0.25,
                 showarrow=False,
-                text=f"Estimated {params[0]} is {data_fit.data[params[0]][0]:.4f} uV",
+                text=f"Estimated {params[0]} is {data_fit.df[params[0]][0]:.4f} uV",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -450,7 +448,7 @@ def amplitude_msr_phase(folder, routine, qubit, format):
             max(data.get_values("amplitude", "dimensionless")),
             2 * len(data),
         )
-        params = [i for i in list(data_fit.data.keys()) if "popt" not in i]
+        params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
         fig.add_trace(
             go.Scatter(
                 x=amplituderange,
@@ -475,7 +473,7 @@ def amplitude_msr_phase(folder, routine, qubit, format):
                 x=0,
                 y=-0.30,
                 showarrow=False,
-                text=f"Estimated {params[0]} is {data_fit.data[params[0]][0]:.3f} uV.",
+                text=f"Estimated {params[0]} is {data_fit.df[params[0]][0]:.3f} uV.",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -489,7 +487,7 @@ def amplitude_msr_phase(folder, routine, qubit, format):
                 x=0,
                 y=-0.25,
                 showarrow=False,
-                text=f"Estimated {params[1]} is {data_fit.data[params[1]][0]:.4f}",
+                text=f"Estimated {params[1]} is {data_fit.df[params[1]][0]:.4f}",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -544,7 +542,7 @@ def time_msr(folder, routine, qubit, format):
             max(data.get_values("wait", "ns")),
             2 * len(data),
         )
-        params = [i for i in list(data_fit.data.keys()) if "popt" not in i]
+        params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
         fig.add_trace(
             go.Scatter(
                 x=timerange,
@@ -569,7 +567,7 @@ def time_msr(folder, routine, qubit, format):
                 x=0,
                 y=-0.30,
                 showarrow=False,
-                text=f"Estimated {params[1]} is {data_fit.data[params[1]][0]:.3f} Hz.",
+                text=f"Estimated {params[1]} is {data_fit.df[params[1]][0]:.3f} Hz.",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -583,7 +581,7 @@ def time_msr(folder, routine, qubit, format):
                 x=0,
                 y=-0.20,
                 showarrow=False,
-                text=f"Estimated {params[0]} is {data_fit.data[params[0]][0]:.1f} ns",
+                text=f"Estimated {params[0]} is {data_fit.df[params[0]][0]:.1f} ns",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -597,7 +595,7 @@ def time_msr(folder, routine, qubit, format):
                 x=0,
                 y=-0.25,
                 showarrow=False,
-                text=f"Estimated {params[2]} is {data_fit.data[params[2]][0]:.3f} Hz",
+                text=f"Estimated {params[2]} is {data_fit.df[params[2]][0]:.3f} Hz",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -663,7 +661,7 @@ def t1_time_msr_phase(folder, routine, qubit, format):
             max(data.get_values("Time", "ns")),
             2 * len(data),
         )
-        params = [i for i in list(data_fit.data.keys()) if "popt" not in i]
+        params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
         fig.add_trace(
             go.Scatter(
                 x=timerange,
@@ -686,7 +684,7 @@ def t1_time_msr_phase(folder, routine, qubit, format):
                 x=0,
                 y=-0.20,
                 showarrow=False,
-                text=f"Estimated {params[0]} is {data_fit.data[params[0]][0]:.1f} ns.",
+                text=f"Estimated {params[0]} is {data_fit.df[params[0]][0]:.1f} ns.",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -755,7 +753,7 @@ def flips_msr_phase(folder, routine, qubit, format):
             max(data.get_values("flips", "dimensionless")),
             2 * len(data),
         )
-        params = [i for i in list(data_fit.data.keys()) if "popt" not in i]
+        params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
         fig.add_trace(
             go.Scatter(
                 x=flipsrange,
@@ -779,7 +777,7 @@ def flips_msr_phase(folder, routine, qubit, format):
                 x=0,
                 y=-0.25,
                 showarrow=False,
-                text=f"Estimated {params[0]} is {data_fit.data[params[0]][0]:.4f}",
+                text=f"Estimated {params[0]} is {data_fit.df[params[0]][0]:.4f}",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -792,7 +790,7 @@ def flips_msr_phase(folder, routine, qubit, format):
                 x=0,
                 y=-0.30,
                 showarrow=False,
-                text=f"Estimated {params[1]} is {data_fit.data[params[1]][0]:.3f}",
+                text=f"Estimated {params[1]} is {data_fit.df[params[1]][0]:.3f}",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -1047,7 +1045,7 @@ def msr_beta(folder, routine, qubit, format):
             max(data.get_values("beta_param", "dimensionless")),
             20,
         )
-        params = [i for i in list(data_fit.data.keys()) if "popt" not in i]
+        params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
         fig.add_trace(
             go.Scatter(
                 x=beta_param,
@@ -1071,7 +1069,7 @@ def msr_beta(folder, routine, qubit, format):
                 x=0,
                 y=-0.20,
                 showarrow=False,
-                text=f"Estimated {params[0]} is {data_fit.data[params[0]][0]:.4f}",
+                text=f"Estimated {params[0]} is {data_fit.df[params[0]][0]:.4f}",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -1191,7 +1189,7 @@ def dispersive_frequency_msr_phase(folder, routine, qubit, formato):
             max(data_spec.get_values("frequency", "GHz")),
             2 * len(data_spec),
         )
-        params = [i for i in list(data_fit.data.keys()) if "popt" not in i]
+        params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
         fig.add_trace(
             go.Scatter(
                 x=freqrange,
@@ -1214,7 +1212,7 @@ def dispersive_frequency_msr_phase(folder, routine, qubit, formato):
                 x=0,
                 y=-0.25,
                 showarrow=False,
-                text=f"The estimated {params[0]} is {data_fit.data[params[0]][0]:.1f} Hz.",
+                text=f"The estimated {params[0]} is {data_fit.df[params[0]][0]:.1f} Hz.",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -1229,7 +1227,7 @@ def dispersive_frequency_msr_phase(folder, routine, qubit, formato):
             max(data_shifted.get_values("frequency", "GHz")),
             2 * len(data_shifted),
         )
-        params = [i for i in list(data_fit_shifted.data.keys()) if "popt" not in i]
+        params = [i for i in list(data_fit_shifted.df.keys()) if "popt" not in i]
         fig.add_trace(
             go.Scatter(
                 x=freqrange,
@@ -1252,7 +1250,7 @@ def dispersive_frequency_msr_phase(folder, routine, qubit, formato):
                 x=0,
                 y=-0.30,
                 showarrow=False,
-                text=f"The estimated shifted {params[0]} is {data_fit_shifted.data[params[0]][0]:.1f} Hz.",
+                text=f"The estimated shifted {params[0]} is {data_fit_shifted.df[params[0]][0]:.1f} Hz.",
                 textangle=0,
                 xanchor="left",
                 xref="paper",

--- a/src/qibocal/plots/scatters.py
+++ b/src/qibocal/plots/scatters.py
@@ -85,7 +85,7 @@ def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
             max(data_fast.get_values("frequency", "GHz")),
             2 * len(data_fast),
         )
-        params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
+        params = [i for i in list(data_fit.data.keys()) if "popt" not in i]
         fig.add_trace(
             go.Scatter(
                 x=freqrange,
@@ -108,7 +108,7 @@ def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
                 x=0,
                 y=-0.25,
                 showarrow=False,
-                text=f"The estimated {params[0]} is {data_fit.df[params[0]][0]:.1f} Hz.",
+                text=f"The estimated {params[0]} is {data_fit.data[params[0]][0]:.1f} Hz.",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -121,7 +121,7 @@ def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
                 x=0,
                 y=-0.30,
                 showarrow=False,
-                text=f"The estimated {params[1]} is {data_fit.df[params[1]][0]:.3f} uV.",
+                text=f"The estimated {params[1]} is {data_fit.data[params[1]][0]:.3f} uV.",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -145,12 +145,14 @@ def frequency_attenuation_msr_phase__cut(folder, routine, qubit, format):
 
     fig = go.Figure()
     # index data on a specific attenuation value
-    smalldf = data.df[data.get_values("attenuation", "dB") == plot1d_attenuation].copy()
+    smalldata = data.data[
+        data.get_values("attenuation", "dB") == plot1d_attenuation
+    ].copy()
     # split multiple software averages to different datasets
     datasets = []
-    while len(smalldf):
-        datasets.append(smalldf.drop_duplicates("frequency"))
-        smalldf.drop(datasets[-1].index, inplace=True)
+    while len(smalldata):
+        datasets.append(smalldata.drop_duplicates("frequency"))
+        smalldata.drop(datasets[-1].index, inplace=True)
         fig.add_trace(
             go.Scatter(
                 x=datasets[-1]["frequency"].pint.to("GHz").pint.magnitude,
@@ -226,7 +228,7 @@ def time_msr_phase(folder, routine, qubit, format):
             max(data.get_values("Time", "ns")),
             2 * len(data),
         )
-        params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
+        params = [i for i in list(data_fit.data.keys()) if "popt" not in i]
         fig.add_trace(
             go.Scatter(
                 x=timerange,
@@ -251,7 +253,7 @@ def time_msr_phase(folder, routine, qubit, format):
                 x=0,
                 y=-0.20,
                 showarrow=False,
-                text=f"Estimated {params[1]} is {data_fit.df[params[1]][0]:.3f} ns.",
+                text=f"Estimated {params[1]} is {data_fit.data[params[1]][0]:.3f} ns.",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -265,7 +267,7 @@ def time_msr_phase(folder, routine, qubit, format):
                 x=0,
                 y=-0.30,
                 showarrow=False,
-                text=f"Estimated {params[0]} is {data_fit.df[params[0]][0]:.1f} uV.",
+                text=f"Estimated {params[0]} is {data_fit.data[params[0]][0]:.1f} uV.",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -344,7 +346,7 @@ def gain_msr_phase(folder, routine, qubit, format):
             max(data.get_values("gain", "dimensionless")),
             2 * len(data),
         )
-        params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
+        params = [i for i in list(data_fit.data.keys()) if "popt" not in i]
         fig.add_trace(
             go.Scatter(
                 x=gainrange,
@@ -369,7 +371,7 @@ def gain_msr_phase(folder, routine, qubit, format):
                 x=0,
                 y=-0.20,
                 showarrow=False,
-                text=f"Estimated {params[1]} is {data_fit.df[params[1]][0]:.3f}",
+                text=f"Estimated {params[1]} is {data_fit.data[params[1]][0]:.3f}",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -383,7 +385,7 @@ def gain_msr_phase(folder, routine, qubit, format):
                 x=0,
                 y=-0.25,
                 showarrow=False,
-                text=f"Estimated {params[0]} is {data_fit.df[params[0]][0]:.4f} uV",
+                text=f"Estimated {params[0]} is {data_fit.data[params[0]][0]:.4f} uV",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -448,7 +450,7 @@ def amplitude_msr_phase(folder, routine, qubit, format):
             max(data.get_values("amplitude", "dimensionless")),
             2 * len(data),
         )
-        params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
+        params = [i for i in list(data_fit.data.keys()) if "popt" not in i]
         fig.add_trace(
             go.Scatter(
                 x=amplituderange,
@@ -473,7 +475,7 @@ def amplitude_msr_phase(folder, routine, qubit, format):
                 x=0,
                 y=-0.30,
                 showarrow=False,
-                text=f"Estimated {params[0]} is {data_fit.df[params[0]][0]:.3f} uV.",
+                text=f"Estimated {params[0]} is {data_fit.data[params[0]][0]:.3f} uV.",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -487,7 +489,7 @@ def amplitude_msr_phase(folder, routine, qubit, format):
                 x=0,
                 y=-0.25,
                 showarrow=False,
-                text=f"Estimated {params[1]} is {data_fit.df[params[1]][0]:.4f}",
+                text=f"Estimated {params[1]} is {data_fit.data[params[1]][0]:.4f}",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -540,7 +542,7 @@ def time_msr(folder, routine, qubit, format):
             max(data.get_values("wait", "ns")),
             2 * len(data),
         )
-        params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
+        params = [i for i in list(data_fit.data.keys()) if "popt" not in i]
         fig.add_trace(
             go.Scatter(
                 x=timerange,
@@ -565,7 +567,7 @@ def time_msr(folder, routine, qubit, format):
                 x=0,
                 y=-0.30,
                 showarrow=False,
-                text=f"Estimated {params[1]} is {data_fit.df[params[1]][0]:.3f} Hz.",
+                text=f"Estimated {params[1]} is {data_fit.data[params[1]][0]:.3f} Hz.",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -579,7 +581,7 @@ def time_msr(folder, routine, qubit, format):
                 x=0,
                 y=-0.20,
                 showarrow=False,
-                text=f"Estimated {params[0]} is {data_fit.df[params[0]][0]:.1f} ns",
+                text=f"Estimated {params[0]} is {data_fit.data[params[0]][0]:.1f} ns",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -593,7 +595,7 @@ def time_msr(folder, routine, qubit, format):
                 x=0,
                 y=-0.25,
                 showarrow=False,
-                text=f"Estimated {params[2]} is {data_fit.df[params[2]][0]:.3f} Hz",
+                text=f"Estimated {params[2]} is {data_fit.data[params[2]][0]:.3f} Hz",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -659,7 +661,7 @@ def t1_time_msr_phase(folder, routine, qubit, format):
             max(data.get_values("Time", "ns")),
             2 * len(data),
         )
-        params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
+        params = [i for i in list(data_fit.data.keys()) if "popt" not in i]
         fig.add_trace(
             go.Scatter(
                 x=timerange,
@@ -682,7 +684,7 @@ def t1_time_msr_phase(folder, routine, qubit, format):
                 x=0,
                 y=-0.20,
                 showarrow=False,
-                text=f"Estimated {params[0]} is {data_fit.df[params[0]][0]:.1f} ns.",
+                text=f"Estimated {params[0]} is {data_fit.data[params[0]][0]:.1f} ns.",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -751,7 +753,7 @@ def flips_msr_phase(folder, routine, qubit, format):
             max(data.get_values("flips", "dimensionless")),
             2 * len(data),
         )
-        params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
+        params = [i for i in list(data_fit.data.keys()) if "popt" not in i]
         fig.add_trace(
             go.Scatter(
                 x=flipsrange,
@@ -775,7 +777,7 @@ def flips_msr_phase(folder, routine, qubit, format):
                 x=0,
                 y=-0.25,
                 showarrow=False,
-                text=f"Estimated {params[0]} is {data_fit.df[params[0]][0]:.4f}",
+                text=f"Estimated {params[0]} is {data_fit.data[params[0]][0]:.4f}",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -788,7 +790,7 @@ def flips_msr_phase(folder, routine, qubit, format):
                 x=0,
                 y=-0.30,
                 showarrow=False,
-                text=f"Estimated {params[1]} is {data_fit.df[params[1]][0]:.3f}",
+                text=f"Estimated {params[1]} is {data_fit.data[params[1]][0]:.3f}",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -1043,7 +1045,7 @@ def msr_beta(folder, routine, qubit, format):
             max(data.get_values("beta_param", "dimensionless")),
             20,
         )
-        params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
+        params = [i for i in list(data_fit.data.keys()) if "popt" not in i]
         fig.add_trace(
             go.Scatter(
                 x=beta_param,
@@ -1067,7 +1069,7 @@ def msr_beta(folder, routine, qubit, format):
                 x=0,
                 y=-0.20,
                 showarrow=False,
-                text=f"Estimated {params[0]} is {data_fit.df[params[0]][0]:.4f}",
+                text=f"Estimated {params[0]} is {data_fit.data[params[0]][0]:.4f}",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -1187,7 +1189,7 @@ def dispersive_frequency_msr_phase(folder, routine, qubit, formato):
             max(data_spec.get_values("frequency", "GHz")),
             2 * len(data_spec),
         )
-        params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
+        params = [i for i in list(data_fit.data.keys()) if "popt" not in i]
         fig.add_trace(
             go.Scatter(
                 x=freqrange,
@@ -1210,7 +1212,7 @@ def dispersive_frequency_msr_phase(folder, routine, qubit, formato):
                 x=0,
                 y=-0.25,
                 showarrow=False,
-                text=f"The estimated {params[0]} is {data_fit.df[params[0]][0]:.1f} Hz.",
+                text=f"The estimated {params[0]} is {data_fit.data[params[0]][0]:.1f} Hz.",
                 textangle=0,
                 xanchor="left",
                 xref="paper",
@@ -1225,7 +1227,7 @@ def dispersive_frequency_msr_phase(folder, routine, qubit, formato):
             max(data_shifted.get_values("frequency", "GHz")),
             2 * len(data_shifted),
         )
-        params = [i for i in list(data_fit_shifted.df.keys()) if "popt" not in i]
+        params = [i for i in list(data_fit_shifted.data.keys()) if "popt" not in i]
         fig.add_trace(
             go.Scatter(
                 x=freqrange,
@@ -1248,7 +1250,7 @@ def dispersive_frequency_msr_phase(folder, routine, qubit, formato):
                 x=0,
                 y=-0.30,
                 showarrow=False,
-                text=f"The estimated shifted {params[0]} is {data_fit_shifted.df[params[0]][0]:.1f} Hz.",
+                text=f"The estimated shifted {params[0]} is {data_fit_shifted.data[params[0]][0]:.1f} Hz.",
                 textangle=0,
                 xanchor="left",
                 xref="paper",

--- a/src/qibocal/plots/scatters.py
+++ b/src/qibocal/plots/scatters.py
@@ -3,21 +3,21 @@ import numpy as np
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
-from qibocal.data import Data, Dataset
+from qibocal.data import Data, DataUnits
 from qibocal.fitting.utils import cos, exp, flipping, lorenzian, rabi, ramsey
 
 
 def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
     try:
-        data_fast = Dataset.load_data(folder, routine, format, f"fast_sweep_q{qubit}")
+        data_fast = DataUnits.load_data(folder, routine, format, f"fast_sweep_q{qubit}")
     except:
-        data_fast = Dataset(quantities={"frequency": "Hz"})
+        data_fast = DataUnits(quantities={"frequency": "Hz"})
     try:
-        data_precision = Dataset.load_data(
+        data_precision = DataUnits.load_data(
             folder, routine, format, f"precision_sweep_q{qubit}"
         )
     except:
-        data_precision = Dataset(quantities={"frequency": "Hz"})
+        data_precision = DataUnits(quantities={"frequency": "Hz"})
     try:
         data_fit = Data.load_data(folder, routine, format, f"fit_q{qubit}")
     except:
@@ -140,7 +140,7 @@ def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
 
 
 def frequency_attenuation_msr_phase__cut(folder, routine, qubit, format):
-    data = Dataset.load_data(folder, routine, format, f"data_q{qubit}")
+    data = DataUnits.load_data(folder, routine, format, f"data_q{qubit}")
     plot1d_attenuation = 30  # attenuation value to use for 1D frequency vs MSR plot
 
     fig = go.Figure()
@@ -172,9 +172,9 @@ def frequency_attenuation_msr_phase__cut(folder, routine, qubit, format):
 # For Rabi oscillations
 def time_msr_phase(folder, routine, qubit, format):
     try:
-        data = Dataset.load_data(folder, routine, format, f"data_q{qubit}")
+        data = DataUnits.load_data(folder, routine, format, f"data_q{qubit}")
     except:
-        data = Dataset(quantities={"Time": "ns"})
+        data = DataUnits(quantities={"Time": "ns"})
 
     try:
         data_fit = Data.load_data(folder, routine, format, f"fit_q{qubit}")
@@ -290,9 +290,9 @@ def time_msr_phase(folder, routine, qubit, format):
 def gain_msr_phase(folder, routine, qubit, format):
 
     try:
-        data = Dataset.load_data(folder, routine, format, f"data_q{qubit}")
+        data = DataUnits.load_data(folder, routine, format, f"data_q{qubit}")
     except:
-        data = Dataset(quantities={"gain", "dimensionless"})
+        data = DataUnits(quantities={"gain", "dimensionless"})
 
     try:
         data_fit = Data.load_data(folder, routine, format, f"fit_q{qubit}")
@@ -405,13 +405,13 @@ def gain_msr_phase(folder, routine, qubit, format):
 def amplitude_msr_phase(folder, routine, qubit, format):
 
     try:
-        data = Dataset.load_data(folder, routine, format, f"data_q{qubit}")
+        data = DataUnits.load_data(folder, routine, format, f"data_q{qubit}")
     except:
-        data = Dataset(quantities={"amplitude", "dimensionless"})
+        data = DataUnits(quantities={"amplitude", "dimensionless"})
     try:
         data_fit = Data.load_data(folder, routine, format, f"fit_q{qubit}")
     except:
-        data_fit = Dataset()
+        data_fit = DataUnits()
 
     fig = make_subplots(
         rows=1,
@@ -509,13 +509,15 @@ def amplitude_msr_phase(folder, routine, qubit, format):
 # For Ramsey oscillations
 def time_msr(folder, routine, qubit, format):
     try:
-        data = Dataset.load_data(folder, routine, format, f"data_q{qubit}")
+        data = DataUnits.load_data(folder, routine, format, f"data_q{qubit}")
     except:
-        data = Dataset(name=f"data_q{qubit}", quantities={"wait": "ns", "t_max": "ns"})
+        data = DataUnits(
+            name=f"data_q{qubit}", quantities={"wait": "ns", "t_max": "ns"}
+        )
     try:
         data_fit = Data.load_data(folder, routine, format, f"fit_q{qubit}")
     except:
-        data_fit = Dataset()
+        data_fit = DataUnits()
 
     fig = make_subplots(
         rows=1,
@@ -615,14 +617,14 @@ def time_msr(folder, routine, qubit, format):
 # T1
 def t1_time_msr_phase(folder, routine, qubit, format):
     try:
-        data = Dataset.load_data(folder, routine, format, f"data_q{qubit}")
+        data = DataUnits.load_data(folder, routine, format, f"data_q{qubit}")
     except:
-        data = Dataset(quantities={"Time": "ns"})
+        data = DataUnits(quantities={"Time": "ns"})
 
     try:
         data_fit = Data.load_data(folder, routine, format, f"fit_q{qubit}")
     except:
-        data_fit = Dataset()
+        data_fit = DataUnits()
 
     fig = make_subplots(
         rows=1,
@@ -707,14 +709,14 @@ def t1_time_msr_phase(folder, routine, qubit, format):
 # Flipping
 def flips_msr_phase(folder, routine, qubit, format):
     try:
-        data = Dataset.load_data(folder, routine, format, f"data_q{qubit}")
+        data = DataUnits.load_data(folder, routine, format, f"data_q{qubit}")
     except:
-        data = Dataset(quantities={"flips": "dimensionless"})
+        data = DataUnits(quantities={"flips": "dimensionless"})
 
     try:
         data_fit = Data.load_data(folder, routine, format, f"fit_q{qubit}")
     except:
-        data_fit = Dataset()
+        data_fit = DataUnits()
 
     fig = make_subplots(
         rows=1,
@@ -814,9 +816,9 @@ def flips_msr_phase(folder, routine, qubit, format):
 def exc_gnd(folder, routine, qubit, format):
 
     try:
-        data_exc = Dataset.load_data(folder, routine, format, f"data_exc_q{qubit}")
+        data_exc = DataUnits.load_data(folder, routine, format, f"data_exc_q{qubit}")
     except:
-        data_exc = Dataset(quantities={"iteration": "dimensionless"})
+        data_exc = DataUnits(quantities={"iteration": "dimensionless"})
 
     fig = make_subplots(
         rows=1,
@@ -839,9 +841,9 @@ def exc_gnd(folder, routine, qubit, format):
     )
 
     try:
-        data_gnd = Dataset.load_data(folder, routine, format, f"data_gnd_q{qubit}")
+        data_gnd = DataUnits.load_data(folder, routine, format, f"data_gnd_q{qubit}")
     except:
-        data_gnd = Dataset(quantities={"iteration": "dimensionless"})
+        data_gnd = DataUnits(quantities={"iteration": "dimensionless"})
 
     fig.add_trace(
         go.Scatter(
@@ -910,9 +912,9 @@ def exc_gnd(folder, routine, qubit, format):
 def prob_gate(folder, routine, qubit, format):
 
     try:
-        data = Dataset.load_data(folder, routine, format, f"data_q{qubit}")
+        data = DataUnits.load_data(folder, routine, format, f"data_q{qubit}")
     except:
-        data = Dataset(
+        data = DataUnits(
             quantities={"probability": "dimensionless", "gateNumber": "dimensionless"}
         )
 
@@ -947,9 +949,9 @@ def prob_gate(folder, routine, qubit, format):
 def prob_gate_iteration(folder, routine, qubit, format):
 
     try:
-        data = Dataset.load_data(folder, routine, format, f"data_q{qubit}")
+        data = DataUnits.load_data(folder, routine, format, f"data_q{qubit}")
     except:
-        data = Dataset(
+        data = DataUnits(
             quantities={
                 "probability": "dimensionless",
                 "gateNumber": "dimensionless",
@@ -957,7 +959,7 @@ def prob_gate_iteration(folder, routine, qubit, format):
             }
         )
 
-    data = Dataset.load_data(folder, routine, format, f"data_q{qubit}")
+    data = DataUnits.load_data(folder, routine, format, f"data_q{qubit}")
     fig = make_subplots(
         rows=1,
         cols=1,
@@ -1008,15 +1010,15 @@ def prob_gate_iteration(folder, routine, qubit, format):
 def msr_beta(folder, routine, qubit, format):
 
     try:
-        data = Dataset.load_data(folder, routine, format, f"data_q{qubit}")
+        data = DataUnits.load_data(folder, routine, format, f"data_q{qubit}")
     except:
-        data = Dataset(
+        data = DataUnits(
             name=f"data_q{qubit}", quantities={"beta_param": "dimensionless"}
         )
     try:
         data_fit = Data.load_data(folder, routine, format, f"fit_q{qubit}")
     except:
-        data_fit = Dataset()
+        data_fit = DataUnits()
 
     fig = make_subplots(
         rows=1,
@@ -1089,16 +1091,16 @@ def msr_beta(folder, routine, qubit, format):
 def dispersive_frequency_msr_phase(folder, routine, qubit, formato):
 
     try:
-        data_spec = Dataset.load_data(folder, routine, formato, f"data_q{qubit}")
+        data_spec = DataUnits.load_data(folder, routine, formato, f"data_q{qubit}")
     except:
-        data_spec = Dataset(name=f"data_q{qubit}", quantities={"frequency": "Hz"})
+        data_spec = DataUnits(name=f"data_q{qubit}", quantities={"frequency": "Hz"})
 
     try:
-        data_shifted = Dataset.load_data(
+        data_shifted = DataUnits.load_data(
             folder, routine, formato, f"data_shifted_q{qubit}"
         )
     except:
-        data_shifted = Dataset(
+        data_shifted = DataUnits(
             name=f"data_shifted_q{qubit}", quantities={"frequency": "Hz"}
         )
 

--- a/src/qibocal/tests/test_data.py
+++ b/src/qibocal/tests/test_data.py
@@ -127,7 +127,7 @@ def test_data_add():
     assert len(data) == 6
 
 
-def test_data_units_set():
+def test_data_units_load_data_from_dict():
     """Test set method of DataUnits class"""
     data_units = DataUnits()
     test = {
@@ -136,7 +136,7 @@ def test_data_units_set():
         "q[V]": np.array([3, 4, 5]),
         "phase[deg]": [6.0, 7.0, 8.0],
     }
-    data_units.df = test
+    data_units.load_data_from_dict(test)
     assert len(data_units) == 3
     assert (data_units.get_values("MSR", "V") == [1, 2, 3]).all()
     assert (data_units.get_values("i", "V") == [3.0, 4.0, 5.0]).all()
@@ -145,13 +145,13 @@ def test_data_units_set():
 
     data_units1 = DataUnits(options=["option1", "option2"])
     test = {"option1": ["one", "two", "three"], "option2": [1, 2, 3]}
-    data_units1.df = test
+    data_units1.load_data_from_dict(test)
     assert len(data_units1) == 3
     assert (data_units1.get_values("option1") == ["one", "two", "three"]).all()
     assert (data_units1.get_values("option2") == [1, 2, 3]).all()
 
 
-def test_data_set():
+def test_data_load_data_from_dict():
     """Test set method of Data class"""
     data = random_data(5)
     test = {
@@ -160,7 +160,7 @@ def test_data_set():
         "string": ["one", "two", "three"],
         "bool": [True, False, True],
     }
-    data.df = test
+    data.load_data_from_dict(test)
     assert len(data) == 3
     assert (data.get_values("int") == [1, 2, 3]).all()
     assert (data.get_values("float") == [3.0, 4.0, 5.0]).all()

--- a/src/qibocal/tests/test_data.py
+++ b/src/qibocal/tests/test_data.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
-"""Some tests for the Dataset class"""
+"""Some tests for the Data and DataUnits class"""
 import numpy as np
 import pytest
 from pint import DimensionalityError, UndefinedUnitError
 
-from qibocal.data import Data, Dataset
+from qibocal.data import Data, DataUnits
 
 
-def random_dataset(length, options=None):
-    data = Dataset(options=options)
+def random_data_units(length, options=None):
+    data = DataUnits(options=options)
     for l in range(length):
         msr, i, q, phase = np.random.rand(4)
         pulse_sequence_result = {
@@ -34,8 +34,8 @@ def random_data(length):
 
 
 def test_data_initialization():
-    """Test Dataset constructor"""
-    data = Dataset()
+    """Test DataUnits constructor"""
+    data = DataUnits()
     assert len(data.data.columns) == 4
     assert list(data.data.columns) == [  # pylint: disable=E1101
         "MSR",
@@ -44,7 +44,7 @@ def test_data_initialization():
         "phase",
     ]
 
-    data1 = Dataset(quantities={"attenuation": "dB"})
+    data1 = DataUnits(quantities={"attenuation": "dB"})
     assert len(data1.data.columns) == 5
     assert list(data1.data.columns) == [  # pylint: disable=E1101
         "attenuation",
@@ -54,7 +54,7 @@ def test_data_initialization():
         "phase",
     ]
 
-    data2 = Dataset(quantities={"attenuation": "dB"}, options=["option1"])
+    data2 = DataUnits(quantities={"attenuation": "dB"}, options=["option1"])
     assert len(data2.data.columns) == 6
     assert list(data2.data.columns) == [  # pylint: disable=E1101
         "option1",
@@ -66,26 +66,26 @@ def test_data_initialization():
     ]
 
 
-def test_dataset_units():
-    """Test units of measure in Dataset"""
-    dataset = Dataset()
-    assert dataset.data.MSR.values.units == "volt"
+def test_data_units_units():
+    """Test units of measure in DataUnits"""
+    data_units = DataUnits()
+    assert data_units.data.MSR.values.units == "volt"
 
-    dataset1 = Dataset(quantities={"frequency": "Hz"})
-    assert dataset1.data.frequency.values.units == "hertz"
+    data_units1 = DataUnits(quantities={"frequency": "Hz"})
+    assert data_units1.data.frequency.values.units == "hertz"
 
     with pytest.raises(UndefinedUnitError):
-        dataset2 = Dataset(quantities={"fake_unit": "fake"})
+        data_units2 = DataUnits(quantities={"fake_unit": "fake"})
 
 
-def test_dataset_add():
-    """Test add method of Dataset"""
-    dataset = random_dataset(5)
-    assert len(dataset) == 5
+def test_data_units_add():
+    """Test add method of DataUnits"""
+    data_units = random_data_units(5)
+    assert len(data_units) == 5
 
-    dataset1 = Dataset(quantities={"attenuation": "dB"})
-    msr, i, q, phase, att = np.random.rand(len(dataset1.data.columns))
-    dataset1.add(
+    data_units1 = DataUnits(quantities={"attenuation": "dB"})
+    msr, i, q, phase, att = np.random.rand(len(data_units1.data.columns))
+    data_units1.add(
         {
             "MSR[V]": msr,
             "i[V]": i,
@@ -94,9 +94,9 @@ def test_dataset_add():
             "attenuation[dB]": att,
         }
     )
-    assert len(dataset1) == 1
+    assert len(data_units1) == 1
 
-    dataset1.add(
+    data_units1.add(
         {
             "MSR[V]": 0,
             "i[V]": 0.0,
@@ -105,18 +105,18 @@ def test_dataset_add():
             "attenuation[dB]": 1,
         }
     )
-    assert len(dataset1) == 2
+    assert len(data_units1) == 2
 
-    dataset2 = Dataset()
-    msr, i, q, phase = np.random.rand(len(dataset2.data.columns))
+    data_units2 = DataUnits()
+    msr, i, q, phase = np.random.rand(len(data_units2.data.columns))
     with pytest.raises(DimensionalityError):
-        dataset2.add({"MSR[dB]": msr, "i[V]": i, "q[V]": q, "phase[deg]": phase})
+        data_units2.add({"MSR[dB]": msr, "i[V]": i, "q[V]": q, "phase[deg]": phase})
 
     with pytest.raises(UndefinedUnitError):
-        dataset2.add({"MSR[test]": msr, "i[V]": i, "q[V]": q, "phase[deg]": phase})
+        data_units2.add({"MSR[test]": msr, "i[V]": i, "q[V]": q, "phase[deg]": phase})
 
-    dataset3 = random_dataset(10, options=["test"])
-    assert len(dataset3) == 10
+    data_units3 = random_data_units(10, options=["test"])
+    assert len(data_units3) == 10
 
 
 def test_data_add():
@@ -127,28 +127,28 @@ def test_data_add():
     assert len(data) == 6
 
 
-def test_dataset_set():
-    """Test set method of Dataset class"""
-    dataset = Dataset()
+def test_data_units_set():
+    """Test set method of DataUnits class"""
+    data_units = DataUnits()
     test = {
         "MSR[V]": [1, 2, 3],
         "i[V]": [3.0, 4.0, 5.0],
         "q[V]": np.array([3, 4, 5]),
         "phase[deg]": [6.0, 7.0, 8.0],
     }
-    dataset.data = test
-    assert len(dataset) == 3
-    assert (dataset.get_values("MSR", "V") == [1, 2, 3]).all()
-    assert (dataset.get_values("i", "V") == [3.0, 4.0, 5.0]).all()
-    assert (dataset.get_values("q", "V") == [3, 4, 5]).all()
-    assert (dataset.get_values("phase", "deg") == [6.0, 7.0, 8.0]).all()
+    data_units.data = test
+    assert len(data_units) == 3
+    assert (data_units.get_values("MSR", "V") == [1, 2, 3]).all()
+    assert (data_units.get_values("i", "V") == [3.0, 4.0, 5.0]).all()
+    assert (data_units.get_values("q", "V") == [3, 4, 5]).all()
+    assert (data_units.get_values("phase", "deg") == [6.0, 7.0, 8.0]).all()
 
-    dataset1 = Dataset(options=["option1", "option2"])
+    data_units1 = DataUnits(options=["option1", "option2"])
     test = {"option1": ["one", "two", "three"], "option2": [1, 2, 3]}
-    dataset1.data = test
-    assert len(dataset1) == 3
-    assert (dataset1.get_values("option1") == ["one", "two", "three"]).all()
-    assert (dataset1.get_values("option2") == [1, 2, 3]).all()
+    data_units1.data = test
+    assert len(data_units1) == 3
+    assert (data_units1.get_values("option1") == ["one", "two", "three"]).all()
+    assert (data_units1.get_values("option2") == [1, 2, 3]).all()
 
 
 def test_data_set():
@@ -168,14 +168,14 @@ def test_data_set():
     assert (data.get_values("bool") == [True, False, True]).all()
 
 
-def test_get_values_dataset():
-    """Test get_values method of Dataset class"""
-    dataset = random_dataset(5, options=["option"])
+def test_get_values_data_units():
+    """Test get_values method of DataUnits class"""
+    data_units = random_data_units(5, options=["option"])
 
-    assert (dataset.get_values("option") == dataset.data["option"]).all()
+    assert (data_units.get_values("option") == data_units.data["option"]).all()
     assert (
-        dataset.get_values("MSR", "uV")
-        == dataset.data["MSR"].pint.to("uV").pint.magnitude
+        data_units.get_values("MSR", "uV")
+        == data_units.data["MSR"].pint.to("uV").pint.magnitude
     ).all()
 
 

--- a/src/qibocal/tests/test_data.py
+++ b/src/qibocal/tests/test_data.py
@@ -36,16 +36,16 @@ def random_data(length):
 def test_data_initialization():
     """Test Dataset constructor"""
     data = Dataset()
-    assert len(data.df.columns) == 4
-    assert list(data.df.columns) == ["MSR", "i", "q", "phase"]
+    assert len(data.data.columns) == 4
+    assert list(data.data.columns) == ["MSR", "i", "q", "phase"]
 
     data1 = Dataset(quantities={"attenuation": "dB"})
-    assert len(data1.df.columns) == 5
-    assert list(data1.df.columns) == ["attenuation", "MSR", "i", "q", "phase"]
+    assert len(data1.data.columns) == 5
+    assert list(data1.data.columns) == ["attenuation", "MSR", "i", "q", "phase"]
 
     data2 = Dataset(quantities={"attenuation": "dB"}, options=["option1"])
-    assert len(data2.df.columns) == 6
-    assert list(data2.df.columns) == [
+    assert len(data2.data.columns) == 6
+    assert list(data2.data.columns) == [
         "option1",
         "attenuation",
         "MSR",
@@ -58,10 +58,10 @@ def test_data_initialization():
 def test_dataset_units():
     """Test units of measure in Dataset"""
     dataset = Dataset()
-    assert dataset.df.MSR.values.units == "volt"
+    assert dataset.data.MSR.values.units == "volt"
 
     dataset1 = Dataset(quantities={"frequency": "Hz"})
-    assert dataset1.df.frequency.values.units == "hertz"
+    assert dataset1.data.frequency.values.units == "hertz"
 
     with pytest.raises(UndefinedUnitError):
         dataset2 = Dataset(quantities={"fake_unit": "fake"})
@@ -73,7 +73,7 @@ def test_dataset_add():
     assert len(dataset) == 5
 
     dataset1 = Dataset(quantities={"attenuation": "dB"})
-    msr, i, q, phase, att = np.random.rand(len(dataset1.df.columns))
+    msr, i, q, phase, att = np.random.rand(len(dataset1.data.columns))
     dataset1.add(
         {
             "MSR[V]": msr,
@@ -97,7 +97,7 @@ def test_dataset_add():
     assert len(dataset1) == 2
 
     dataset2 = Dataset()
-    msr, i, q, phase = np.random.rand(len(dataset2.df.columns))
+    msr, i, q, phase = np.random.rand(len(dataset2.data.columns))
     with pytest.raises(DimensionalityError):
         dataset2.add({"MSR[dB]": msr, "i[V]": i, "q[V]": q, "phase[deg]": phase})
 
@@ -115,19 +115,49 @@ def test_data_add():
     data.add({"int": 123, "float": 123.456, "string": "123", "bool": True})
     assert len(data) == 6
 
+def test_dataset_set():
+    """Test set method of Dataset class"""
+    dataset = Dataset()
+    test = { "MSR[V]" : [1,2,3], "i[V]" : [3., 4., 5.], "q[V]": np.array([3,4,5]), "phase[deg]": [6., 7., 8.]}
+    dataset.data = test
+    assert len(dataset) == 3
+    assert (dataset.get_values('MSR', 'V') == [1,2,3]).all()
+    assert (dataset.get_values('i', 'V') == [3., 4., 5.]).all()
+    assert (dataset.get_values('q', 'V') == [3,4,5]).all()
+    assert (dataset.get_values('phase', 'deg') == [6.,7.,8.]).all()
+
+    dataset1 = Dataset(options=["option1", "option2"])
+    test = {'option1' : ["one", "two", "three"], 'option2' : [1, 2, 3]}
+    dataset1.data = test
+    assert len(dataset1) == 3
+    assert (dataset1.get_values('option1') == ["one","two","three"]).all()
+    assert (dataset1.get_values('option2') == [1,2,3]).all()
+
+
+def test_data_set():
+    """Test set method of Data class"""
+    data = random_data(5)
+    test = { "int" : [1,2,3], "float" : [3., 4., 5.], "string": ["one","two","three"], "bool": [True, False, True]}
+    data.data = test
+    assert len(data) == 3
+    assert (data.get_values('int') == [1,2,3]).all()
+    assert (data.get_values('float') == [3., 4., 5.]).all()
+    assert (data.get_values('string') == ["one", "two", "three"]).all()
+    assert (data.get_values('bool') == [True,False,True]).all()
+
 
 def test_get_values_dataset():
     """Test get_values method of Dataset class"""
     dataset = random_dataset(5, options=["option"])
 
-    assert (dataset.get_values("option") == dataset.df["option"]).all()
+    assert (dataset.get_values("option") == dataset.data["option"]).all()
     assert (
         dataset.get_values("MSR", "uV")
-        == dataset.df["MSR"].pint.to("uV").pint.magnitude
+        == dataset.data["MSR"].pint.to("uV").pint.magnitude
     ).all()
 
 
 def test_get_values_data():
     """Test get_values method of Data class"""
     data = random_data(5)
-    assert (data.get_values("int") == data.df["int"]).all()
+    assert (data.get_values("int") == data.data["int"]).all()

--- a/src/qibocal/tests/test_data.py
+++ b/src/qibocal/tests/test_data.py
@@ -37,15 +37,26 @@ def test_data_initialization():
     """Test Dataset constructor"""
     data = Dataset()
     assert len(data.data.columns) == 4
-    assert list(data.data.columns) == ["MSR", "i", "q", "phase"]
+    assert list(data.data.columns) == [  # pylint: disable=E1101
+        "MSR",
+        "i",
+        "q",
+        "phase",
+    ]
 
     data1 = Dataset(quantities={"attenuation": "dB"})
     assert len(data1.data.columns) == 5
-    assert list(data1.data.columns) == ["attenuation", "MSR", "i", "q", "phase"]
+    assert list(data1.data.columns) == [  # pylint: disable=E1101
+        "attenuation",
+        "MSR",
+        "i",
+        "q",
+        "phase",
+    ]
 
     data2 = Dataset(quantities={"attenuation": "dB"}, options=["option1"])
     assert len(data2.data.columns) == 6
-    assert list(data2.data.columns) == [
+    assert list(data2.data.columns) == [  # pylint: disable=E1101
         "option1",
         "attenuation",
         "MSR",

--- a/src/qibocal/tests/test_data.py
+++ b/src/qibocal/tests/test_data.py
@@ -115,35 +115,46 @@ def test_data_add():
     data.add({"int": 123, "float": 123.456, "string": "123", "bool": True})
     assert len(data) == 6
 
+
 def test_dataset_set():
     """Test set method of Dataset class"""
     dataset = Dataset()
-    test = { "MSR[V]" : [1,2,3], "i[V]" : [3., 4., 5.], "q[V]": np.array([3,4,5]), "phase[deg]": [6., 7., 8.]}
+    test = {
+        "MSR[V]": [1, 2, 3],
+        "i[V]": [3.0, 4.0, 5.0],
+        "q[V]": np.array([3, 4, 5]),
+        "phase[deg]": [6.0, 7.0, 8.0],
+    }
     dataset.data = test
     assert len(dataset) == 3
-    assert (dataset.get_values('MSR', 'V') == [1,2,3]).all()
-    assert (dataset.get_values('i', 'V') == [3., 4., 5.]).all()
-    assert (dataset.get_values('q', 'V') == [3,4,5]).all()
-    assert (dataset.get_values('phase', 'deg') == [6.,7.,8.]).all()
+    assert (dataset.get_values("MSR", "V") == [1, 2, 3]).all()
+    assert (dataset.get_values("i", "V") == [3.0, 4.0, 5.0]).all()
+    assert (dataset.get_values("q", "V") == [3, 4, 5]).all()
+    assert (dataset.get_values("phase", "deg") == [6.0, 7.0, 8.0]).all()
 
     dataset1 = Dataset(options=["option1", "option2"])
-    test = {'option1' : ["one", "two", "three"], 'option2' : [1, 2, 3]}
+    test = {"option1": ["one", "two", "three"], "option2": [1, 2, 3]}
     dataset1.data = test
     assert len(dataset1) == 3
-    assert (dataset1.get_values('option1') == ["one","two","three"]).all()
-    assert (dataset1.get_values('option2') == [1,2,3]).all()
+    assert (dataset1.get_values("option1") == ["one", "two", "three"]).all()
+    assert (dataset1.get_values("option2") == [1, 2, 3]).all()
 
 
 def test_data_set():
     """Test set method of Data class"""
     data = random_data(5)
-    test = { "int" : [1,2,3], "float" : [3., 4., 5.], "string": ["one","two","three"], "bool": [True, False, True]}
+    test = {
+        "int": [1, 2, 3],
+        "float": [3.0, 4.0, 5.0],
+        "string": ["one", "two", "three"],
+        "bool": [True, False, True],
+    }
     data.data = test
     assert len(data) == 3
-    assert (data.get_values('int') == [1,2,3]).all()
-    assert (data.get_values('float') == [3., 4., 5.]).all()
-    assert (data.get_values('string') == ["one", "two", "three"]).all()
-    assert (data.get_values('bool') == [True,False,True]).all()
+    assert (data.get_values("int") == [1, 2, 3]).all()
+    assert (data.get_values("float") == [3.0, 4.0, 5.0]).all()
+    assert (data.get_values("string") == ["one", "two", "three"]).all()
+    assert (data.get_values("bool") == [True, False, True]).all()
 
 
 def test_get_values_dataset():

--- a/src/qibocal/tests/test_data.py
+++ b/src/qibocal/tests/test_data.py
@@ -36,8 +36,8 @@ def random_data(length):
 def test_data_initialization():
     """Test DataUnits constructor"""
     data = DataUnits()
-    assert len(data.data.columns) == 4
-    assert list(data.data.columns) == [  # pylint: disable=E1101
+    assert len(data.df.columns) == 4
+    assert list(data.df.columns) == [  # pylint: disable=E1101
         "MSR",
         "i",
         "q",
@@ -45,8 +45,8 @@ def test_data_initialization():
     ]
 
     data1 = DataUnits(quantities={"attenuation": "dB"})
-    assert len(data1.data.columns) == 5
-    assert list(data1.data.columns) == [  # pylint: disable=E1101
+    assert len(data1.df.columns) == 5
+    assert list(data1.df.columns) == [  # pylint: disable=E1101
         "attenuation",
         "MSR",
         "i",
@@ -55,8 +55,8 @@ def test_data_initialization():
     ]
 
     data2 = DataUnits(quantities={"attenuation": "dB"}, options=["option1"])
-    assert len(data2.data.columns) == 6
-    assert list(data2.data.columns) == [  # pylint: disable=E1101
+    assert len(data2.df.columns) == 6
+    assert list(data2.df.columns) == [  # pylint: disable=E1101
         "option1",
         "attenuation",
         "MSR",
@@ -69,10 +69,10 @@ def test_data_initialization():
 def test_data_units_units():
     """Test units of measure in DataUnits"""
     data_units = DataUnits()
-    assert data_units.data.MSR.values.units == "volt"
+    assert data_units.df.MSR.values.units == "volt"
 
     data_units1 = DataUnits(quantities={"frequency": "Hz"})
-    assert data_units1.data.frequency.values.units == "hertz"
+    assert data_units1.df.frequency.values.units == "hertz"
 
     with pytest.raises(UndefinedUnitError):
         data_units2 = DataUnits(quantities={"fake_unit": "fake"})
@@ -84,7 +84,7 @@ def test_data_units_add():
     assert len(data_units) == 5
 
     data_units1 = DataUnits(quantities={"attenuation": "dB"})
-    msr, i, q, phase, att = np.random.rand(len(data_units1.data.columns))
+    msr, i, q, phase, att = np.random.rand(len(data_units1.df.columns))
     data_units1.add(
         {
             "MSR[V]": msr,
@@ -108,7 +108,7 @@ def test_data_units_add():
     assert len(data_units1) == 2
 
     data_units2 = DataUnits()
-    msr, i, q, phase = np.random.rand(len(data_units2.data.columns))
+    msr, i, q, phase = np.random.rand(len(data_units2.df.columns))
     with pytest.raises(DimensionalityError):
         data_units2.add({"MSR[dB]": msr, "i[V]": i, "q[V]": q, "phase[deg]": phase})
 
@@ -136,7 +136,7 @@ def test_data_units_set():
         "q[V]": np.array([3, 4, 5]),
         "phase[deg]": [6.0, 7.0, 8.0],
     }
-    data_units.data = test
+    data_units.df = test
     assert len(data_units) == 3
     assert (data_units.get_values("MSR", "V") == [1, 2, 3]).all()
     assert (data_units.get_values("i", "V") == [3.0, 4.0, 5.0]).all()
@@ -145,7 +145,7 @@ def test_data_units_set():
 
     data_units1 = DataUnits(options=["option1", "option2"])
     test = {"option1": ["one", "two", "three"], "option2": [1, 2, 3]}
-    data_units1.data = test
+    data_units1.df = test
     assert len(data_units1) == 3
     assert (data_units1.get_values("option1") == ["one", "two", "three"]).all()
     assert (data_units1.get_values("option2") == [1, 2, 3]).all()
@@ -160,7 +160,7 @@ def test_data_set():
         "string": ["one", "two", "three"],
         "bool": [True, False, True],
     }
-    data.data = test
+    data.df = test
     assert len(data) == 3
     assert (data.get_values("int") == [1, 2, 3]).all()
     assert (data.get_values("float") == [3.0, 4.0, 5.0]).all()
@@ -172,14 +172,14 @@ def test_get_values_data_units():
     """Test get_values method of DataUnits class"""
     data_units = random_data_units(5, options=["option"])
 
-    assert (data_units.get_values("option") == data_units.data["option"]).all()
+    assert (data_units.get_values("option") == data_units.df["option"]).all()
     assert (
         data_units.get_values("MSR", "uV")
-        == data_units.data["MSR"].pint.to("uV").pint.magnitude
+        == data_units.df["MSR"].pint.to("uV").pint.magnitude
     ).all()
 
 
 def test_get_values_data():
     """Test get_values method of Data class"""
     data = random_data(5)
-    assert (data.get_values("int") == data.data["int"]).all()
+    assert (data.get_values("int") == data.df["int"]).all()

--- a/src/qibocal/web/app.py
+++ b/src/qibocal/web/app.py
@@ -6,10 +6,10 @@ import yaml
 from dash import Dash, Input, Output, dcc, html
 
 from qibocal import plots
-from qibocal.data import Dataset
+from qibocal.data import DataUnits
 from qibocal.web.server import server
 
-Dataset()  # dummy dataset call to suppress ``pint[V]`` error
+DataUnits()  # dummy dataset call to suppress ``pint[V]`` error
 
 app = Dash(
     server=server,
@@ -40,7 +40,7 @@ app.layout = html.Div(
 def get_graph(n, current_figure, url):
     method, folder, routine, qubit, format = url.split(os.sep)[2:]
     try:
-        # data = Dataset.load_data(folder, routine, format, "precision_sweep")
+        # data = DataUnits.load_data(folder, routine, format, "precision_sweep")
         # with open(f"{folder}/platform.yml", "r") as f:
         #     nqubits = yaml.safe_load(f)["nqubits"]
         # if len(data) > 2:


### PR DESCRIPTION
Hi, In this PR I add a `set()` method to Dataset so that the entire dataframe can be loaded at once from a dictionary, instead of row by row.
I believe this feature had long back been requested by @maxhant .
Row by row is very time consuming, it takes ~5min for adding 1024 rows in a calibrate_qubit_states_binning routine.

example of use:
```python
    exc_sequence = PulseSequence()
    RX_pulse = platform.create_RX_pulse(qubit, start=0)
    ro_pulse = platform.create_qubit_readout_pulse(qubit, start=RX_pulse.duration)
    exc_sequence.add(RX_pulse)
    exc_sequence.add(ro_pulse)
    data_exc = Dataset(name=f"data_exc_q{qubit}", quantities={"iteration": "dimensionless"})
    msr, phase, i, q = platform.execute_pulse_sequence(exc_sequence, nshots)['binned_integrated'][ro_pulse.serial]
    
    iq_exc = i + 1j * q
    results = {
        "MSR[V]": msr,
        "i[V]": i,
        "q[V]": q,
        "phase[rad]": phase,
        "iteration[dimensionless]": np.arange(nshots),
    }
    data_exc.set(results)
    yield data_exc
```