### PR TITLE
qq-compare

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ build-backend = "poetry.core.masonry.api"
 qq = "qibocal:command"
 qq-live = "qibocal:live_plot"
 qq-upload = "qibocal:upload"
+qq-compare = "qibocal:compare"
 
 [tool.poe.tasks]
 test = "pytest src/qibocal/tests"

--- a/runcards/actions_qq_1q.yml
+++ b/runcards/actions_qq_1q.yml
@@ -101,10 +101,10 @@ actions:
   #   software_averages: 1
   #   points: 5
 
-  flipping:
-    niter: 10
-    step: 2
-    points: 1
+  # flipping:
+  #   niter: 10
+  #   step: 2
+  #   points: 1
 
   # ramsey_frequency_detuned:
   #   t_start: 4
@@ -151,3 +151,10 @@ actions:
   #   delay_between_pulses_step: 20
   #   software_averages: 1
   #   points: 5
+
+  spin_echo_3pulses:
+    delay_between_pulses_start: 4
+    delay_between_pulses_end: 20000
+    delay_between_pulses_step: 20
+    software_averages: 1
+    points: 5

--- a/runcards/actions_qq_1q.yml
+++ b/runcards/actions_qq_1q.yml
@@ -101,9 +101,10 @@ actions:
   #   software_averages: 1
   #   points: 5
 
-  # flipping:
-  #   niter: 10
-  #   step: 2
+  flipping:
+    niter: 10
+    step: 2
+    points: 1
 
   # ramsey_frequency_detuned:
   #   t_start: 4

--- a/runcards/actions_qq_5q.yml
+++ b/runcards/actions_qq_5q.yml
@@ -1,19 +1,19 @@
 platform: tii5q
 
-qubits: [2, 3]
+qubits: [2]
 
 format: csv
 
 actions:
-  resonator_spectroscopy:
-    lowres_width: 5_000_000
-    lowres_step: 2_000_000
-    highres_width: 1_500_000
-    highres_step: 200_000
-    precision_width: 1_500_000
-    precision_step: 100_000
-    software_averages: 1
-    points: 1
+  # resonator_spectroscopy:
+  #   lowres_width: 5_000_000
+  #   lowres_step: 2_000_000
+  #   highres_width: 1_500_000
+  #   highres_step: 200_000
+  #   precision_width: 1_500_000
+  #   precision_step: 100_000
+  #   software_averages: 1
+  #   points: 1
 
   # resonator_spectroscopy_flux:
   #   freq_width: 3_000_000

--- a/runcards/actions_qq_5q.yml
+++ b/runcards/actions_qq_5q.yml
@@ -25,15 +25,15 @@ actions:
   #   software_averages: 1
   #   points: 10
 
-  resonator_spectroscopy_flux_matrix:
-    freq_width: 3_000_000
-    freq_step: 200_000
-    current_max: +0.000 # absolute max is 40 mA
-    current_min: -10.e-3 # absolute min is -40 mA
-    current_step: 3.e-3
-    fluxlines: [1, 2] # Ask alvaro automatic way to obtain fluxline from runcard
-    software_averages: 2
-    points: 10
+  # resonator_spectroscopy_flux_matrix:
+  #   freq_width: 3_000_000
+  #   freq_step: 200_000
+  #   current_max: +0.000 # absolute max is 40 mA
+  #   current_min: -10.e-3 # absolute min is -40 mA
+  #   current_step: 3.e-3
+  #   fluxlines: [1, 2] # Ask alvaro automatic way to obtain fluxline from runcard
+  #   software_averages: 2
+  #   points: 10
 
   # resonator_punchout:
   #   freq_width: 10_000_000
@@ -162,3 +162,10 @@ actions:
   #   beta_end: 1
   #   beta_step: 0.01
   #   points: 1
+
+  spin_echo_3pulses:
+    delay_between_pulses_start: 4
+    delay_between_pulses_end: 20000
+    delay_between_pulses_step: 20
+    software_averages: 1
+    points: 5

--- a/runcards/actions_qq_5q.yml
+++ b/runcards/actions_qq_5q.yml
@@ -5,15 +5,15 @@ qubits: [2, 3]
 format: csv
 
 actions:
-  # resonator_spectroscopy:
-  #   lowres_width: 5_000_000
-  #   lowres_step: 2_000_000
-  #   highres_width: 1_500_000
-  #   highres_step: 200_000
-  #   precision_width: 1_500_000
-  #   precision_step: 100_000
-  #   software_averages: 1
-  #   points: 1
+  resonator_spectroscopy:
+    lowres_width: 5_000_000
+    lowres_step: 2_000_000
+    highres_width: 1_500_000
+    highres_step: 200_000
+    precision_width: 1_500_000
+    precision_step: 100_000
+    software_averages: 1
+    points: 1
 
   # resonator_spectroscopy_flux:
   #   freq_width: 3_000_000
@@ -145,12 +145,12 @@ actions:
   #   nshots: 1024
   #   points: 1
 
-  allXY_iteration:
-    beta_start: -0.09
-    beta_end: 0.2
-    beta_step: 0.09
-    software_averages: 1
-    points: 1
+  # allXY_iteration:
+  #   beta_start: -0.09
+  #   beta_end: 0.2
+  #   beta_step: 0.09
+  #   software_averages: 1
+  #   points: 1
 
   # allXY:
   #   beta_param: Null

--- a/runcards/actions_qq_5q.yml
+++ b/runcards/actions_qq_5q.yml
@@ -25,15 +25,15 @@ actions:
   #   software_averages: 1
   #   points: 10
 
-  # resonator_spectroscopy_flux_matrix:
-  #   freq_width: 3_000_000
-  #   freq_step: 200_000
-  #   current_max: +0.000 # absolute max is 40 mA
-  #   current_min: -10.e-3 # absolute min is -40 mA
-  #   current_step: 3.e-3
-  #   fluxlines: [1, 2] # Ask alvaro automatic way to obtain fluxline from runcard
-  #   software_averages: 2
-  #   points: 10
+  resonator_spectroscopy_flux_matrix:
+    freq_width: 3_000_000
+    freq_step: 200_000
+    current_max: +0.000 # absolute max is 40 mA
+    current_min: -10.e-3 # absolute min is -40 mA
+    current_step: 3.e-3
+    fluxlines: [1, 2] # Ask alvaro automatic way to obtain fluxline from runcard
+    software_averages: 2
+    points: 10
 
   # resonator_punchout:
   #   freq_width: 10_000_000

--- a/runcards/actions_qq_5q.yml
+++ b/runcards/actions_qq_5q.yml
@@ -1,6 +1,6 @@
 platform: tii5q
 
-qubits: [2]
+qubits: [2, 3]
 
 format: csv
 
@@ -70,12 +70,12 @@ actions:
   #   software_averages: 2
   #   points: 10
 
-  rabi_pulse_length:
-    pulse_duration_start: 4 # minimum 4ns
-    pulse_duration_end: 200
-    pulse_duration_step: 4
-    software_averages: 1
-    points: 10
+  # rabi_pulse_length:
+  #  pulse_duration_start: 4 # minimum 4ns
+  #  pulse_duration_end: 200
+  #  pulse_duration_step: 4
+  #  software_averages: 1
+  #  points: 10
 
   # rabi_pulse_gain:
   #   pulse_gain_start: 0 # -1.0<=g<=1.0
@@ -145,12 +145,12 @@ actions:
   #   nshots: 1024
   #   points: 1
 
-  # allXY_iteration:
-  #   beta_start: -0.09
-  #   beta_end: 0.2
-  #   beta_step: 0.01
-  #   software_averages: 1
-  #   points: 1
+  allXY_iteration:
+    beta_start: -0.09
+    beta_end: 0.2
+    beta_step: 0.09
+    software_averages: 1
+    points: 1
 
   # allXY:
   #   beta_param: Null

--- a/src/qibocal/__init__.py
+++ b/src/qibocal/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from .cli import command, live_plot, upload
+from .cli import command, compare, live_plot, upload
 
 """qibocal: Quantum Calibration Verification and Validation using Qibo."""
 import importlib.metadata as im

--- a/src/qibocal/calibrations/__init__.py
+++ b/src/qibocal/calibrations/__init__.py
@@ -6,5 +6,6 @@ from qibocal.calibrations.characterization.qubit_spectroscopy import *
 from qibocal.calibrations.characterization.rabi_oscillations import *
 from qibocal.calibrations.characterization.ramsey import *
 from qibocal.calibrations.characterization.resonator_spectroscopy import *
+from qibocal.calibrations.characterization.spin_echos import *
 from qibocal.calibrations.characterization.t1 import *
 from qibocal.calibrations.protocols.test import *

--- a/src/qibocal/calibrations/characterization/allXY.py
+++ b/src/qibocal/calibrations/characterization/allXY.py
@@ -43,6 +43,8 @@ def allXY(
     points=10,
 ):
 
+    platform.reload_settings()
+
     state0_voltage = complex(
         platform.characterization["single_qubit"][qubit]["state0_voltage"]
     )
@@ -53,19 +55,6 @@ def allXY(
     data = DataUnits(
         name=f"data_q{qubit}",
         quantities={"probability": "dimensionless", "gateNumber": "dimensionless"},
-    )
-
-    # FIXME: Waiting to be able to pass qpucard to qibolab
-    ro_pulse_test = platform.create_qubit_readout_pulse(qubit, start=4)
-    platform.ro_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["resonator_freq"]
-        - ro_pulse_test.frequency
-    )
-
-    qd_pulse_test = platform.create_qubit_drive_pulse(qubit, start=0, duration=4)
-    platform.qd_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["qubit_freq"]
-        - qd_pulse_test.frequency
     )
 
     count = 0
@@ -112,18 +101,7 @@ def allXY_iteration(
     points=10,
 ):
 
-    # FIXME: Waiting to be able to pass qpucard to qibolab
-    ro_pulse_test = platform.create_qubit_readout_pulse(qubit, start=4)
-    platform.ro_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["resonator_freq"]
-        - ro_pulse_test.frequency
-    )
-
-    qd_pulse_test = platform.create_qubit_drive_pulse(qubit, start=0, duration=4)
-    platform.qd_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["qubit_freq"]
-        - qd_pulse_test.frequency
-    )
+    platform.reload_settings()
 
     state0_voltage = complex(
         platform.characterization["single_qubit"][qubit]["state0_voltage"]
@@ -186,20 +164,7 @@ def drag_pulse_tunning(
     points=10,
 ):
 
-    # platform.reload_settings()
-
-    # FIXME: Waiting to be able to pass qpucard to qibolab
-    ro_pulse_test = platform.create_qubit_readout_pulse(qubit, start=4)
-    platform.ro_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["resonator_freq"]
-        - ro_pulse_test.frequency
-    )
-
-    qd_pulse_test = platform.create_qubit_drive_pulse(qubit, start=0, duration=4)
-    platform.qd_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["qubit_freq"]
-        - qd_pulse_test.frequency
-    )
+    platform.reload_settings()
 
     data = DataUnits(name=f"data_q{qubit}", quantities={"beta_param": "dimensionless"})
 

--- a/src/qibocal/calibrations/characterization/qubit_spectroscopy.py
+++ b/src/qibocal/calibrations/characterization/qubit_spectroscopy.py
@@ -55,7 +55,7 @@ def qubit_spectroscopy(
                     y="MSR[uV]",
                     qubit=qubit,
                     nqubits=platform.settings["nqubits"],
-                    labels=["qubit_freq", "peak_voltage"],
+                    labels=["qubit_freq", "peak_voltage", "MZ_freq"],
                 )
 
             platform.qd_port[qubit].lo_frequency = freq - qd_pulse.frequency
@@ -111,7 +111,7 @@ def qubit_spectroscopy(
                     y="MSR[uV]",
                     qubit=qubit,
                     nqubits=platform.settings["nqubits"],
-                    labels=["qubit_freq", "peak_voltage"],
+                    labels=["qubit_freq", "peak_voltage", "MZ_freq"],
                 )
             platform.qd_port[qubit].lo_frequency = freq - qd_pulse.frequency
             msr, phase, i, q = platform.execute_pulse_sequence(sequence)[

--- a/src/qibocal/calibrations/characterization/rabi_oscillations.py
+++ b/src/qibocal/calibrations/characterization/rabi_oscillations.py
@@ -33,16 +33,6 @@ def rabi_pulse_length(
         pulse_duration_start, pulse_duration_end, pulse_duration_step
     )
 
-    # FIXME: Waiting to be able to pass qpucard to qibolab
-    platform.ro_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["resonator_freq"]
-        - ro_pulse.frequency
-    )
-    platform.qd_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["qubit_freq"]
-        - qd_pulse.frequency
-    )
-
     count = 0
     for _ in range(software_averages):
         for duration in qd_pulse_duration_range:
@@ -98,16 +88,6 @@ def rabi_pulse_gain(
 
     qd_pulse_gain_range = np.arange(pulse_gain_start, pulse_gain_end, pulse_gain_step)
 
-    # FIXME: Waiting to be able to pass qpucard to qibolab
-    platform.ro_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["resonator_freq"]
-        - ro_pulse.frequency
-    )
-    platform.qd_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["qubit_freq"]
-        - qd_pulse.frequency
-    )
-
     count = 0
     for _ in range(software_averages):
         for gain in qd_pulse_gain_range:
@@ -162,16 +142,6 @@ def rabi_pulse_amplitude(
 
     qd_pulse_amplitude_range = np.arange(
         pulse_amplitude_start, pulse_amplitude_end, pulse_amplitude_step
-    )
-
-    # FIXME: Waiting to be able to pass qpucard to qibolab
-    platform.ro_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["resonator_freq"]
-        - ro_pulse.frequency
-    )
-    platform.qd_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["qubit_freq"]
-        - qd_pulse.frequency
     )
 
     count = 0
@@ -236,16 +206,6 @@ def rabi_pulse_length_and_gain(
     )
     qd_pulse_gain_range = np.arange(pulse_gain_start, pulse_gain_end, pulse_gain_step)
 
-    # FIXME: Waiting to be able to pass qpucard to qibolab
-    platform.ro_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["resonator_freq"]
-        - ro_pulse.frequency
-    )
-    platform.qd_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["qubit_freq"]
-        - qd_pulse.frequency
-    )
-
     count = 0
     for _ in range(software_averages):
         for duration in qd_pulse_duration_range:
@@ -303,16 +263,6 @@ def rabi_pulse_length_and_amplitude(
     )
     qd_pulse_amplitude_range = np.arange(
         pulse_amplitude_start, pulse_amplitude_end, pulse_amplitude_step
-    )
-
-    # FIXME: Waiting to be able to pass qpucard to qibolab
-    platform.ro_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["resonator_freq"]
-        - ro_pulse.frequency
-    )
-    platform.qd_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["qubit_freq"]
-        - qd_pulse.frequency
     )
 
     count = 0

--- a/src/qibocal/calibrations/characterization/ramsey.py
+++ b/src/qibocal/calibrations/characterization/ramsey.py
@@ -42,16 +42,6 @@ def ramsey_frequency_detuned(
     current_qubit_freq = runcard_qubit_freq
     current_T2 = runcard_T2
 
-    # FIXME: Waiting to be able to pass qpucard to qibolab
-    platform.ro_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["resonator_freq"]
-        - ro_pulse.frequency
-    )
-    platform.qd_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["qubit_freq"]
-        - RX90_pulse1.frequency
-    )
-
     t_end = np.array(t_end)
     for t_max in t_end:
         count = 0
@@ -115,7 +105,7 @@ def ramsey_frequency_detuned(
         corrected_qubit_freq = data_fit.get_values("corrected_qubit_frequency")
 
         # if ((new_t2 * 3.5) > t_max):
-        if (new_t2 > current_T2).bool() and len(t_end) > 1:
+        if (new_t2 > current_T2) and len(t_end) > 1:
             current_qubit_freq = int(corrected_qubit_freq)
             current_T2 = new_t2
             data = DataUnits(
@@ -156,16 +146,6 @@ def ramsey(
         delay_between_pulses_start,
         delay_between_pulses_end,
         delay_between_pulses_step,
-    )
-
-    # FIXME: Waiting to be able to pass qpucard to qibolab
-    platform.ro_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["resonator_freq"]
-        - ro_pulse.frequency
-    )
-    platform.qd_port[qubit].lo_frequency = (
-        platform.characterization["single_qubit"][qubit]["qubit_freq"]
-        - RX90_pulse1.frequency
     )
 
     data = DataUnits(name=f"data_q{qubit}", quantities={"wait": "ns", "t_max": "ns"})

--- a/src/qibocal/calibrations/characterization/resonator_spectroscopy.py
+++ b/src/qibocal/calibrations/characterization/resonator_spectroscopy.py
@@ -33,7 +33,7 @@ def resonator_spectroscopy(
         "resonator_freq"
     ]
 
-    qrm_LO=platform.qrm[qubit].ports["o1"].lo_frequency
+    qrm_LO = platform.qrm[qubit].ports["o1"].lo_frequency
 
     frequency_range = (
         variable_resolution_scanrange(
@@ -341,7 +341,7 @@ def dispersive_shift(
         "resonator_freq"
     ]
 
-    qrm_LO=platform.qrm[qubit].ports["o1"].lo_frequency
+    qrm_LO = platform.qrm[qubit].ports["o1"].lo_frequency
 
     frequency_range = (
         np.arange(-freq_width, freq_width, freq_step) + resonator_frequency

--- a/src/qibocal/calibrations/characterization/resonator_spectroscopy.py
+++ b/src/qibocal/calibrations/characterization/resonator_spectroscopy.py
@@ -33,6 +33,8 @@ def resonator_spectroscopy(
         "resonator_freq"
     ]
 
+    qrm_LO=platform.qrm[qubit].ports["o1"].lo_frequency
+
     frequency_range = (
         variable_resolution_scanrange(
             lowres_width, lowres_step, highres_width, highres_step
@@ -53,7 +55,8 @@ def resonator_spectroscopy(
                     y="MSR[uV]",
                     qubit=qubit,
                     nqubits=platform.settings["nqubits"],
-                    labels=["resonator_freq", "peak_voltage"],
+                    labels=["resonator_freq", "peak_voltage", "MZ_freq"],
+                    qrm_lo=qrm_LO,
                 )
 
             platform.ro_port[qubit].lo_frequency = freq - ro_pulse.frequency
@@ -111,7 +114,8 @@ def resonator_spectroscopy(
                     y="MSR[uV]",
                     qubit=qubit,
                     nqubits=platform.settings["nqubits"],
-                    labels=["resonator_freq", "peak_voltage"],
+                    labels=["resonator_freq", "peak_voltage", "MZ_freq"],
+                    qrm_lo=qrm_LO,
                 )
 
             platform.ro_port[qubit].lo_frequency = freq - ro_pulse.frequency
@@ -337,6 +341,8 @@ def dispersive_shift(
         "resonator_freq"
     ]
 
+    qrm_LO=platform.qrm[qubit].ports["o1"].lo_frequency
+
     frequency_range = (
         np.arange(-freq_width, freq_width, freq_step) + resonator_frequency
     )
@@ -353,7 +359,8 @@ def dispersive_shift(
                     y="MSR[uV]",
                     qubit=qubit,
                     nqubits=platform.settings["nqubits"],
-                    labels=["resonator_freq", "peak_voltage"],
+                    labels=["resonator_freq", "peak_voltage", "MZ_freq"],
+                    qrm_lo=qrm_LO,
                 )
             platform.ro_port[qubit].lo_frequency = freq - ro_pulse.frequency
             msr, phase, i, q = platform.execute_pulse_sequence(sequence)[
@@ -391,8 +398,9 @@ def dispersive_shift(
                     y="MSR[uV]",
                     qubit=qubit,
                     nqubits=platform.settings["nqubits"],
-                    labels=["resonator_freq", "peak_voltage"],
+                    labels=["resonator_freq", "peak_voltage", "MZ_freq"],
                     fit_file_name="fit_shifted",
+                    qrm_lo=qrm_LO,
                 )
             platform.ro_port[qubit].lo_frequency = freq - ro_pulse.frequency
             msr, phase, i, q = platform.execute_pulse_sequence(sequence)[

--- a/src/qibocal/calibrations/characterization/spin_echos.py
+++ b/src/qibocal/calibrations/characterization/spin_echos.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+import numpy as np
+from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.pulses import PulseSequence
+
+from qibocal import plots
+from qibocal.data import DataUnits
+from qibocal.decorators import plot
+from qibocal.fitting.methods import spin_echo_fit
+
+
+@plot("MSR vs Time", plots.spin_echo_time_msr_phase)
+def spin_echo_3pulses(
+    platform: AbstractPlatform,
+    qubit: int,
+    delay_between_pulses_start,
+    delay_between_pulses_end,
+    delay_between_pulses_step,
+    software_averages,
+    points=10,
+):
+
+    """Spin echo calibration routine:
+    The two routines are a modified Ramsey sequence with an additional Rx(pi) pulse placed symmetrically between the two Rx(pi/2) pulses.
+    The random phases accumulated before and after the pi pulse compensate exactly if the frequency does not change during the sequence.
+    After the additional pi rotation the qubit is expected to go always (ideally) to the ground state. An exponential fit to this data
+    gives a spin echo decay time T2.
+
+    Args:
+        platfform (AbstrcatPlatform): Qibolab object that allows the user to communicate with the experimental setup (QPU)
+        qubit (int): Target qubit to characterize
+        delay_between_pulses_start (int): initial delay between pulses
+        delay_between_pulses_end (int): end delay between pulses
+        delay_between_pulses_step (int): step size for delay between pulses range
+        software_averages (int): Number of software repetitions of the experiment
+        points (int): Number of points obtained to executed the save method of the results in a file
+    """
+
+    platform.reload_settings()
+
+    # Spin Echo 3 Pulses: RX(pi/2) - wait t(rotates z) - RX(pi) - wait t(rotates z) - RX(pi/2) - readout
+    sequence = PulseSequence()
+    RX90_pulse1 = platform.create_RX90_pulse(qubit, start=0)
+    RX_pulse = platform.create_RX_pulse(qubit, start=RX90_pulse1.finish)
+    RX90_pulse2 = platform.create_RX90_pulse(qubit, start=RX_pulse.finish)
+    ro_pulse = platform.create_qubit_readout_pulse(qubit, start=RX90_pulse2.finish)
+
+    sequence.add(RX90_pulse1)
+    sequence.add(RX_pulse)
+    sequence.add(RX90_pulse2)
+    sequence.add(ro_pulse)
+
+    ro_wait_range = np.arange(
+        delay_between_pulses_start, delay_between_pulses_end, delay_between_pulses_step
+    )
+
+    data = DataUnits(name=f"data_q{qubit}", quantities={"Time": "ns"})
+
+    count = 0
+    for _ in range(software_averages):
+        for wait in ro_wait_range:
+            if count % points == 0 and count > 0:
+                yield data
+                yield spin_echo_fit(
+                    data,
+                    x="Time[ns]",
+                    y="MSR[uV]",
+                    qubit=qubit,
+                    nqubits=platform.settings["nqubits"],
+                    labels=["t2"],
+                )
+            RX_pulse.start = RX_pulse.duration + wait
+            RX90_pulse2.start = 2 * RX_pulse.duration + 2 * wait
+            ro_pulse.start = 3 * RX_pulse.duration + 2 * wait
+
+            msr, i, q, phase = platform.execute_pulse_sequence(sequence)[
+                ro_pulse.serial
+            ]
+            results = {
+                "MSR[V]": msr,
+                "i[V]": i,
+                "q[V]": q,
+                "phase[deg]": phase,
+                "Time[ns]": wait,
+            }
+            data.add(results)
+            count += 1
+    yield data

--- a/src/qibocal/cli/__init__.py
+++ b/src/qibocal/cli/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """CLI entry point."""
-from ._base import command, live_plot, upload
+from ._base import command, compare, live_plot, upload

--- a/src/qibocal/cli/_base.py
+++ b/src/qibocal/cli/_base.py
@@ -7,16 +7,16 @@ import shutil
 import socket
 import subprocess
 import uuid
-import yaml
-from qibocal.cli.builders import load_yaml
 from datetime import date, datetime
 from glob import glob
 from importlib import import_module
 from urllib.parse import urljoin
 
 import click
+import yaml
 from qibo.config import log, raise_error
-from qibocal.cli.builders import ActionBuilder
+
+from qibocal.cli.builders import ActionBuilder, load_yaml
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
@@ -215,6 +215,7 @@ def compare(folders):
 
         log.info(f"Upload completed")
         i += 1
+
 
 def folders_exists(folders):
     foldernames = []

--- a/src/qibocal/cli/_base.py
+++ b/src/qibocal/cli/_base.py
@@ -166,7 +166,7 @@ def upload(output_folder):
 @click.argument("folders", metavar="FOLDER", type=click.Path(exists=True), nargs=-1)
 def compare(folders):
     """Creates a comparision folder given N different data folders following qq-live data structure to be visualized
-    
+
     Args:
         folder1 (string): absolute or relative path of data folder 1 to be compared
         ...
@@ -225,8 +225,8 @@ def compare(folders):
 
 
 def folders_exists(folders):
-    """ Check if a list of folders exists
-    
+    """Check if a list of folders exists
+
     Args:
         folders (list): list of absolute or relative path to folders
     """
@@ -241,7 +241,7 @@ def folders_exists(folders):
 
 
 def check_folder_structure(folderList):
-    """ Check if a list of folders share structure between them
+    """Check if a list of folders share structure between them
 
     Args:
         folders (list): list of absolute or relative path to folders
@@ -257,7 +257,7 @@ def check_folder_structure(folderList):
 
 
 def update_meta(metadata, metadata_new):
-    """ Update meta.yml file
+    """Update meta.yml file
 
     Args:
         metadata (dict): dictionary with the meta.yml actual parameters and values
@@ -287,7 +287,7 @@ def update_meta(metadata, metadata_new):
 
 
 def update_runcard(rundata, rundata_new):
-    """ Update runcard.yml file
+    """Update runcard.yml file
 
     Args:
         rundata (dict): dictionary with the runcard.yml actual parameters and values

--- a/src/qibocal/cli/_base.py
+++ b/src/qibocal/cli/_base.py
@@ -222,6 +222,7 @@ def compare(folders):
     log.info(f"Upload completed")
 
     from qibocal.web.report import create_report
+
     create_report(TARGET_COMPARE_DIR)
     log.info(f"HTML report generated")
 

--- a/src/qibocal/cli/_base.py
+++ b/src/qibocal/cli/_base.py
@@ -180,7 +180,8 @@ def compare(folders):
         log.info(f"Folders are comparable.")
 
     # move old compare folder and remove
-    tmp_folder = "qq-compare_" + str(datetime.now())
+    now = str(datetime.today())
+    tmp_folder = "qq-compare_" + now
     if os.path.isdir(TARGET_COMPARE_DIR):
         os.rename(TARGET_COMPARE_DIR, tmp_folder)
 

--- a/src/qibocal/cli/_base.py
+++ b/src/qibocal/cli/_base.py
@@ -181,7 +181,7 @@ def compare(folders):
 
     # move old compare folder and remove
     now = str(datetime.today())
-    tmp_folder = "qq-compare_" + now
+    tmp_folder = "qq-compare_" + now.replace(" ", "_")
     if os.path.isdir(TARGET_COMPARE_DIR):
         os.rename(TARGET_COMPARE_DIR, tmp_folder)
 

--- a/src/qibocal/cli/_base.py
+++ b/src/qibocal/cli/_base.py
@@ -196,8 +196,7 @@ def compare(folders):
     shutil.copy(f"{foldernames[0]}/meta.yml", TARGET_COMPARE_DIR)
     shutil.copy(f"{foldernames[0]}/runcard.yml", TARGET_COMPARE_DIR)
 
-    i = 0
-    for folder in foldernames:
+    for i, folder in enumerate(foldernames):
         newdir = TARGET_COMPARE_DIR + f"data{i}"
         log.info(f"Copying ({folder}) into {newdir}")
         try:
@@ -221,7 +220,10 @@ def compare(folders):
             update_runcard(rundata, rundata_new)
 
         log.info(f"Upload completed")
-        i += 1
+
+        from qibocal.web.report import create_report
+        create_report(TARGET_COMPARE_DIR)
+        log.info(f"HTML report generated")
 
 
 def folders_exists(folders):

--- a/src/qibocal/cli/_base.py
+++ b/src/qibocal/cli/_base.py
@@ -165,7 +165,13 @@ def upload(output_folder):
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.argument("folders", metavar="FOLDER", type=click.Path(exists=True), nargs=-1)
 def compare(folders):
-    """Uploads list of folders to be compared into server"""
+    """Creates a comparision folder given N different data folders following qq-live data structure to be visualized
+    
+    Args:
+        folder1 (string): absolute or relative path of data folder 1 to be compared
+        ...
+        folderN (string): absolute or relative path of data folder N to be compared
+    """
 
     # check list of folders exists.
     foldernames = folders_exists(folders)
@@ -219,6 +225,11 @@ def compare(folders):
 
 
 def folders_exists(folders):
+    """ Check if a list of folders exists
+    
+    Args:
+        folders (list): list of absolute or relative path to folders
+    """
     foldernames = []
     for foldername in folders:
         expanded = list(glob(foldername))
@@ -230,6 +241,11 @@ def folders_exists(folders):
 
 
 def check_folder_structure(folderList):
+    """ Check if a list of folders share structure between them
+
+    Args:
+        folders (list): list of absolute or relative path to folders
+    """
     all_subdirList = []
     for folder in folderList:
         folder_subdirList = []
@@ -241,6 +257,13 @@ def check_folder_structure(folderList):
 
 
 def update_meta(metadata, metadata_new):
+    """ Update meta.yml file
+
+    Args:
+        metadata (dict): dictionary with the meta.yml actual parameters and values
+        metadata_new (dict): dictionary with the new parameters and values to update in the actual meta.yml
+    """
+
     metadata["backend"] = metadata["backend"] + " , " + metadata_new["backend"]
     metadata["date"] = metadata["date"] + " , " + metadata_new["date"]
     metadata["end-time"] = metadata["end-time"] + " , " + metadata_new["end-time"]
@@ -264,6 +287,13 @@ def update_meta(metadata, metadata_new):
 
 
 def update_runcard(rundata, rundata_new):
+    """ Update runcard.yml file
+
+    Args:
+        rundata (dict): dictionary with the runcard.yml actual parameters and values
+        rundata_new (dict): dictionary with the new parameters and values to update in the actual runcard.yml
+    """
+
     rundata["platform"] = rundata["platform"] + " , " + rundata_new["platform"]
     unique = list(set(rundata["qubits"] + rundata_new["qubits"]))
     rundata["qubits"] = unique

--- a/src/qibocal/cli/_base.py
+++ b/src/qibocal/cli/_base.py
@@ -219,11 +219,11 @@ def compare(folders):
             rundata = load_yaml(os.path.join(TARGET_COMPARE_DIR, "runcard.yml"))
             update_runcard(rundata, rundata_new)
 
-        log.info(f"Upload completed")
+    log.info(f"Upload completed")
 
-        from qibocal.web.report import create_report
-        create_report(TARGET_COMPARE_DIR)
-        log.info(f"HTML report generated")
+    from qibocal.web.report import create_report
+    create_report(TARGET_COMPARE_DIR)
+    log.info(f"HTML report generated")
 
 
 def folders_exists(folders):

--- a/src/qibocal/cli/builders.py
+++ b/src/qibocal/cli/builders.py
@@ -172,7 +172,7 @@ class ActionBuilder:
 
         try:
             data_fit = Data.load_data(
-                self.folder, routine, self.format, f"fit_q{qubit}"
+                self.folder, "data", routine, self.format, f"fit_q{qubit}"
             )
         except:
             data_fit = Data()

--- a/src/qibocal/data.py
+++ b/src/qibocal/data.py
@@ -35,7 +35,7 @@ class AbstractData:
         return len(self.df)
 
     @classmethod
-    def load_data(cls, folder, routine, format, name):
+    def load_data(cls, folder, subfolder, routine, format, name):
         raise_error(NotImplementedError)
 
     @abstractmethod

--- a/src/qibocal/data.py
+++ b/src/qibocal/data.py
@@ -302,7 +302,7 @@ class Data(AbstractData):
             obj.df = pd.read_csv(file)
             obj.df.pop("Unnamed: 0")
         elif format == "pickle":
-            file = f"{folder}/data/{routine}/{name}.pkl"
+            file = f"{folder}/{subfolder}/{routine}/{name}.pkl"
             obj.df = pd.read_pickle(file)
         else:
             raise_error(ValueError, f"Cannot load data using {format} format.")

--- a/src/qibocal/data.py
+++ b/src/qibocal/data.py
@@ -172,7 +172,7 @@ class DataUnits(AbstractData):
             return self.df[key].pint.to(unit).pint.magnitude
 
     @classmethod
-    def load_data(cls, folder, routine, format, name):
+    def load_data(cls, folder, subfolder, routine, format, name):
         """Load data from specific format.
 
         Args:
@@ -185,7 +185,7 @@ class DataUnits(AbstractData):
         """
         obj = cls()
         if format == "csv":
-            file = f"{folder}/data/{routine}/{name}.csv"
+            file = f"{folder}/{subfolder}/{routine}/{name}.csv"
             obj.df = pd.read_csv(file, header=[0, 1])
             obj.df.pop("Unnamed: 0_level_0")
             quantities_label = []
@@ -284,7 +284,7 @@ class Data(AbstractData):
         return self.df[quantity].values
 
     @classmethod
-    def load_data(cls, folder, routine, format, name):
+    def load_data(cls, folder, subfolder, routine, format, name):
         """Load data from specific format.
 
         Args:
@@ -297,7 +297,7 @@ class Data(AbstractData):
         """
         obj = cls()
         if format == "csv":
-            file = f"{folder}/data/{routine}/{name}.csv"
+            file = f"{folder}/{subfolder}/{routine}/{name}.csv"
             obj.df = pd.read_csv(file)
             obj.df.pop("Unnamed: 0")
         elif format == "pickle":

--- a/src/qibocal/data.py
+++ b/src/qibocal/data.py
@@ -295,7 +295,7 @@ class Data(AbstractData):
         Returns:
             data (``Data``): data object with the loaded data.
         """
-        
+
         obj = cls()
         if format == "csv":
             file = f"{folder}/{subfolder}/{routine}/{name}.csv"

--- a/src/qibocal/data.py
+++ b/src/qibocal/data.py
@@ -295,6 +295,9 @@ class Data(AbstractData):
         Returns:
             data (``Data``): data object with the loaded data.
         """
+        if(subfolder==None):
+            subfolder="data"
+            
         obj = cls()
         if format == "csv":
             file = f"{folder}/{subfolder}/{routine}/{name}.csv"

--- a/src/qibocal/data.py
+++ b/src/qibocal/data.py
@@ -295,9 +295,7 @@ class Data(AbstractData):
         Returns:
             data (``Data``): data object with the loaded data.
         """
-        if(subfolder==None):
-            subfolder="data"
-            
+        
         obj = cls()
         if format == "csv":
             file = f"{folder}/{subfolder}/{routine}/{name}.csv"

--- a/src/qibocal/fitting/methods.py
+++ b/src/qibocal/fitting/methods.py
@@ -9,7 +9,7 @@ from qibocal.data import Data
 from qibocal.fitting.utils import cos, exp, flipping, lorenzian, parse, rabi, ramsey
 
 
-def lorentzian_fit(data, x, y, qubit, nqubits, labels, fit_file_name=None):
+def lorentzian_fit(data, x, y, qubit, nqubits, labels, fit_file_name=None, qrm_lo=None):
     """Fitting routine for resonator spectroscopy"""
     if fit_file_name == None:
         data_fit = Data(
@@ -19,8 +19,9 @@ def lorentzian_fit(data, x, y, qubit, nqubits, labels, fit_file_name=None):
                 "popt1",
                 "popt2",
                 "popt3",
-                labels[1],
                 labels[0],
+                labels[1],
+                labels[2],
             ],
         )
     else:
@@ -31,8 +32,9 @@ def lorentzian_fit(data, x, y, qubit, nqubits, labels, fit_file_name=None):
                 "popt1",
                 "popt2",
                 "popt3",
-                labels[1],
                 labels[0],
+                labels[1],
+                labels[2],
             ],
         )
 
@@ -92,10 +94,15 @@ def lorentzian_fit(data, x, y, qubit, nqubits, labels, fit_file_name=None):
 
     freq = f0 * 1e9
 
+    MZ_freq = 0
+    if (qrm_lo != None):
+        MZ_freq = freq - qrm_lo 
+
     data_fit.add(
         {
-            labels[1]: peak_voltage,
             labels[0]: freq,
+            labels[1]: peak_voltage,
+            labels[2]: MZ_freq,
             "popt0": fit_res.best_values["amplitude"],
             "popt1": fit_res.best_values["center"],
             "popt2": fit_res.best_values["sigma"],

--- a/src/qibocal/fitting/methods.py
+++ b/src/qibocal/fitting/methods.py
@@ -363,3 +363,52 @@ def drag_tunning_fit(data, x, y, qubit, nqubits, labels):
         }
     )
     return data_fit
+
+
+def spin_echo_fit(data, x, y, qubit, nqubits, labels):
+
+    data_fit = Data(
+        name=f"fit_q{qubit}",
+        quantities=[
+            "popt0",
+            "popt1",
+            "popt2",
+            labels[0],
+        ],
+    )
+
+    time = data.get_values(*parse(x))
+    voltages = data.get_values(*parse(y))
+
+    if nqubits == 1:
+        pguess = [
+            max(voltages.values),
+            (max(voltages.values) - min(voltages.values)),
+            1 / 250,
+        ]
+    else:
+        pguess = [
+            min(voltages.values),
+            (max(voltages.values) - min(voltages.values)),
+            1 / 250,
+        ]
+
+    try:
+        popt, pcov = curve_fit(
+            exp, time.values, voltages.values, p0=pguess, maxfev=2000000
+        )
+        t2 = abs(1 / popt[2])
+
+    except:
+        log.warning("The fitting was not succesful")
+        return data_fit
+
+    data_fit.add(
+        {
+            "popt0": popt[0],
+            "popt1": popt[1],
+            "popt2": popt[2],
+            labels[0]: t2,
+        }
+    )
+    return data_fit

--- a/src/qibocal/fitting/methods.py
+++ b/src/qibocal/fitting/methods.py
@@ -95,8 +95,8 @@ def lorentzian_fit(data, x, y, qubit, nqubits, labels, fit_file_name=None, qrm_l
     freq = f0 * 1e9
 
     MZ_freq = 0
-    if (qrm_lo != None):
-        MZ_freq = freq - qrm_lo 
+    if qrm_lo != None:
+        MZ_freq = freq - qrm_lo
 
     data_fit.add(
         {

--- a/src/qibocal/plots/heatmaps.py
+++ b/src/qibocal/plots/heatmaps.py
@@ -6,6 +6,7 @@ from plotly.subplots import make_subplots
 
 from qibocal.data import DataUnits
 
+
 def get_data_subfolders(folder):
     # iterate over multiple data folders
     subfolders = []
@@ -13,8 +14,9 @@ def get_data_subfolders(folder):
         d = os.path.join(folder, file)
         if os.path.isdir(d):
             subfolders.append(os.path.basename(d))
-    
+
     return subfolders[::-1]
+
 
 # Resonator spectroscopy flux
 def frequency_flux_msr_phase(folder, routine, qubit, format):
@@ -35,7 +37,7 @@ def frequency_flux_msr_phase(folder, routine, qubit, format):
 
     i = 1
     for subfolder in subfolders:
- 
+
         data = DataUnits.load_data(folder, subfolder, routine, format, f"data_q{qubit}")
 
         fig.add_trace(
@@ -64,34 +66,35 @@ def frequency_flux_msr_phase(folder, routine, qubit, format):
             uirevision="0",  # ``uirevision`` allows zooming while live plotting
         )
 
-        if(i == 1):
-            fig['layout']['xaxis']['title']=f'q{qubit}/r{i-1}: Frequency (GHz)'
-            fig['layout']['yaxis']['title']='Current (A)'
+        if i == 1:
+            fig["layout"]["xaxis"]["title"] = f"q{qubit}/r{i-1}: Frequency (GHz)"
+            fig["layout"]["yaxis"]["title"] = "Current (A)"
             xaxis = f"xaxis{i+1}"
             yaxis = f"yaxis{i+1}"
-            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: Frequency (GHz)'
-            fig['layout'][yaxis]['title']='Current (A)'
+            fig["layout"][xaxis]["title"] = f"q{qubit}/r{i-1}: Frequency (GHz)"
+            fig["layout"][yaxis]["title"] = "Current (A)"
 
         else:
             xaxis = f"xaxis{2*i-1}"
             yaxis = f"yaxis{2*i-1}"
-            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: Frequency (GHz)'
-            fig['layout'][yaxis]['title']='Current (A)'
+            fig["layout"][xaxis]["title"] = f"q{qubit}/r{i-1}: Frequency (GHz)"
+            fig["layout"][yaxis]["title"] = "Current (A)"
             xaxis = f"xaxis{2*i}"
             yaxis = f"yaxis{2*i}"
-            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: Frequency (GHz)'
-            fig['layout'][yaxis]['title']='Current (A)'
+            fig["layout"][xaxis]["title"] = f"q{qubit}/r{i-1}: Frequency (GHz)"
+            fig["layout"][yaxis]["title"] = "Current (A)"
 
         i += 1
 
     return fig
+
 
 # Punchout
 def frequency_attenuation_msr_phase(folder, routine, qubit, format):
 
     # iterate over multiple data folders
     subfolders = get_data_subfolders(folder)
-    
+
     fig = make_subplots(
         rows=len(subfolders),
         cols=2,
@@ -105,7 +108,7 @@ def frequency_attenuation_msr_phase(folder, routine, qubit, format):
 
     i = 1
     for subfolder in subfolders:
-        data = DataUnits.load_data(folder, subfolder, routine, format, f"data_q{qubit}")       
+        data = DataUnits.load_data(folder, subfolder, routine, format, f"data_q{qubit}")
 
         fig.add_trace(
             go.Heatmap(
@@ -127,58 +130,59 @@ def frequency_attenuation_msr_phase(folder, routine, qubit, format):
             row=i,
             col=2,
         )
-        
+
         fig.update_layout(
             showlegend=False,
             uirevision="0",  # ``uirevision`` allows zooming while live plotting
         )
 
-        if(i == 1):
-            fig['layout']['xaxis']['title']=f'q{qubit}/r{i-1}: Frequency (GHz)'
-            fig['layout']['yaxis']['title']='Attenuation (dB)'
+        if i == 1:
+            fig["layout"]["xaxis"]["title"] = f"q{qubit}/r{i-1}: Frequency (GHz)"
+            fig["layout"]["yaxis"]["title"] = "Attenuation (dB)"
             xaxis = f"xaxis{i+1}"
             yaxis = f"yaxis{i+1}"
-            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: Frequency (GHz)'
-            fig['layout'][yaxis]['title']='Attenuation (dB)'
+            fig["layout"][xaxis]["title"] = f"q{qubit}/r{i-1}: Frequency (GHz)"
+            fig["layout"][yaxis]["title"] = "Attenuation (dB)"
 
         else:
             xaxis = f"xaxis{2*i-1}"
             yaxis = f"yaxis{2*i-1}"
-            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: Frequency (GHz)'
-            fig['layout'][yaxis]['title']='Attenuation (dB)'
+            fig["layout"][xaxis]["title"] = f"q{qubit}/r{i-1}: Frequency (GHz)"
+            fig["layout"][yaxis]["title"] = "Attenuation (dB)"
             xaxis = f"xaxis{2*i}"
             yaxis = f"yaxis{2*i}"
-            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: Frequency (GHz)'
-            fig['layout'][yaxis]['title']='Attenuation (dB)'
+            fig["layout"][xaxis]["title"] = f"q{qubit}/r{i-1}: Frequency (GHz)"
+            fig["layout"][yaxis]["title"] = "Attenuation (dB)"
 
         i += 1
 
     return fig
 
+
 # Resonator spectroscopy flux matrix
 def frequency_flux_msr_phase__matrix(folder, routine, qubit, format):
-    
+
     # iterate over multiple data folders
     subfolders = get_data_subfolders(folder)
 
     k = 1
     last_axis_index = 1
     for subfolder in subfolders:
-        
+
         fluxes = []
         for i in range(25):  # FIXME: 25 is hardcoded
             file = f"{folder}/{subfolder}/{routine}/data_q{qubit}_f{i}.csv"
             if os.path.exists(file):
                 fluxes += [i]
-        
+
         if len(fluxes) < 1:
             nb = 1
         else:
             nb = len(fluxes)
-            
-        if(k == 1):
+
+        if k == 1:
             fig = make_subplots(
-                rows=len(subfolders)*2,
+                rows=len(subfolders) * 2,
                 cols=nb,
                 horizontal_spacing=0.1,
                 vertical_spacing=0.2,
@@ -187,14 +191,16 @@ def frequency_flux_msr_phase__matrix(folder, routine, qubit, format):
             )
 
         for j in fluxes:
-            
+
             if j == fluxes[-1]:
                 showscale = True
             else:
                 showscale = False
-            
-            data = DataUnits.load_data(folder, subfolder, routine, format, f"data_q{qubit}_f{j}")
-            
+
+            data = DataUnits.load_data(
+                folder, subfolder, routine, format, f"data_q{qubit}_f{j}"
+            )
+
             fig.add_trace(
                 go.Heatmap(
                     x=data.get_values("frequency", "GHz"),
@@ -212,44 +218,44 @@ def frequency_flux_msr_phase__matrix(folder, routine, qubit, format):
                     z=data.get_values("phase", "rad"),
                     showscale=showscale,
                 ),
-                row=k+1,
+                row=k + 1,
                 col=j,
             )
 
-        if(k == 1):
-            fig['layout']['xaxis']['title']=f'q{qubit}/r{k-1}: Frequency (GHz)'
-            fig['layout']['yaxis']['title']='current (A)'
+        if k == 1:
+            fig["layout"]["xaxis"]["title"] = f"q{qubit}/r{k-1}: Frequency (GHz)"
+            fig["layout"]["yaxis"]["title"] = "current (A)"
             xaxis = f"xaxis{k+1}"
             yaxis = f"yaxis{k+1}"
-            fig['layout'][xaxis]['title']=f'q{qubit}/r{k-1}: Frequency (GHz)'
-            fig['layout'][yaxis]['title']='current (A)'
+            fig["layout"][xaxis]["title"] = f"q{qubit}/r{k-1}: Frequency (GHz)"
+            fig["layout"][yaxis]["title"] = "current (A)"
             xaxis = f"xaxis{k+2}"
             yaxis = f"yaxis{k+2}"
-            fig['layout'][xaxis]['title']=f'q{qubit}/r{k-1}: Frequency (GHz)'
-            fig['layout'][yaxis]['title']='current (A)'
+            fig["layout"][xaxis]["title"] = f"q{qubit}/r{k-1}: Frequency (GHz)"
+            fig["layout"][yaxis]["title"] = "current (A)"
             xaxis = f"xaxis{k+3}"
             yaxis = f"yaxis{k+3}"
-            fig['layout'][xaxis]['title']=f'q{qubit}/r{k-1}: Frequency (GHz)'
-            fig['layout'][yaxis]['title']='current (A)'
+            fig["layout"][xaxis]["title"] = f"q{qubit}/r{k-1}: Frequency (GHz)"
+            fig["layout"][yaxis]["title"] = "current (A)"
 
         else:
             xaxis = f"xaxis{2*k-1}"
             yaxis = f"yaxis{2*k-1}"
-            fig['layout'][xaxis]['title']=f'q{qubit}/r{k-1}: Frequency (GHz)'
-            fig['layout'][yaxis]['title']='current (A)'
+            fig["layout"][xaxis]["title"] = f"q{qubit}/r{k-1}: Frequency (GHz)"
+            fig["layout"][yaxis]["title"] = "current (A)"
             xaxis = f"xaxis{2*k}"
             yaxis = f"yaxis{2*k}"
-            fig['layout'][xaxis]['title']=f'q{qubit}/r{k-1}: Frequency (GHz)'
-            fig['layout'][yaxis]['title']='current (A)'
+            fig["layout"][xaxis]["title"] = f"q{qubit}/r{k-1}: Frequency (GHz)"
+            fig["layout"][yaxis]["title"] = "current (A)"
             xaxis = f"xaxis{2*k+1}"
             yaxis = f"yaxis{2*k+1}"
-            fig['layout'][xaxis]['title']=f'q{qubit}/r{k-1}: Frequency (GHz)'
-            fig['layout'][yaxis]['title']='current (A)'
+            fig["layout"][xaxis]["title"] = f"q{qubit}/r{k-1}: Frequency (GHz)"
+            fig["layout"][yaxis]["title"] = "current (A)"
             xaxis = f"xaxis{2*k+2}"
             yaxis = f"yaxis{2*k+2}"
-            fig['layout'][xaxis]['title']=f'q{qubit}/r{k-1}: Frequency (GHz)'
-            fig['layout'][yaxis]['title']='current (A)'
-      
+            fig["layout"][xaxis]["title"] = f"q{qubit}/r{k-1}: Frequency (GHz)"
+            fig["layout"][yaxis]["title"] = "current (A)"
+
         k += 2
 
     fig.update_layout(
@@ -257,6 +263,7 @@ def frequency_flux_msr_phase__matrix(folder, routine, qubit, format):
         uirevision="0",  # ``uirevision`` allows zooming while live plotting
     )
     return fig
+
 
 # Rabi pulse length and gain
 def duration_gain_msr_phase(folder, routine, qubit, format):
@@ -304,27 +311,28 @@ def duration_gain_msr_phase(folder, routine, qubit, format):
             uirevision="0",  # ``uirevision`` allows zooming while live plotting
         )
 
-        if(i == 1):
-            fig['layout']['xaxis']['title']=f'q{qubit}/r{i-1}: duration (ns)'
-            fig['layout']['yaxis']['title']='gain (dimensionless)'
+        if i == 1:
+            fig["layout"]["xaxis"]["title"] = f"q{qubit}/r{i-1}: duration (ns)"
+            fig["layout"]["yaxis"]["title"] = "gain (dimensionless)"
             xaxis = f"xaxis{i+1}"
             yaxis = f"yaxis{i+1}"
-            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: duration (ns)'
-            fig['layout'][yaxis]['title']='gain (dimensionless)'
+            fig["layout"][xaxis]["title"] = f"q{qubit}/r{i-1}: duration (ns)"
+            fig["layout"][yaxis]["title"] = "gain (dimensionless)"
 
         else:
             xaxis = f"xaxis{2*i-1}"
             yaxis = f"yaxis{2*i-1}"
-            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: duration (ns)'
-            fig['layout'][yaxis]['title']='gain (dimensionless)'
+            fig["layout"][xaxis]["title"] = f"q{qubit}/r{i-1}: duration (ns)"
+            fig["layout"][yaxis]["title"] = "gain (dimensionless)"
             xaxis = f"xaxis{2*i}"
             yaxis = f"yaxis{2*i}"
-            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: duration (ns)'
-            fig['layout'][yaxis]['title']='gain (dimensionless)'
+            fig["layout"][xaxis]["title"] = f"q{qubit}/r{i-1}: duration (ns)"
+            fig["layout"][yaxis]["title"] = "gain (dimensionless)"
 
         i += 1
 
     return fig
+
 
 # Rabi pulse length and amplitude
 def duration_amplitude_msr_phase(folder, routine, qubit, format):
@@ -373,24 +381,24 @@ def duration_amplitude_msr_phase(folder, routine, qubit, format):
             uirevision="0",  # ``uirevision`` allows zooming while live plotting
         )
 
-        if(i == 1):
-            fig['layout']['xaxis']['title']=f'q{qubit}/r{i-1}: duration (ns)'
-            fig['layout']['yaxis']['title']='A (dimensionless)'
+        if i == 1:
+            fig["layout"]["xaxis"]["title"] = f"q{qubit}/r{i-1}: duration (ns)"
+            fig["layout"]["yaxis"]["title"] = "A (dimensionless)"
             xaxis = f"xaxis{i+1}"
             yaxis = f"yaxis{i+1}"
-            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: duration (ns)'
-            fig['layout'][yaxis]['title']='A (dimensionless)'
+            fig["layout"][xaxis]["title"] = f"q{qubit}/r{i-1}: duration (ns)"
+            fig["layout"][yaxis]["title"] = "A (dimensionless)"
 
         else:
             xaxis = f"xaxis{2*i-1}"
             yaxis = f"yaxis{2*i-1}"
-            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: duration (ns)'
-            fig['layout'][yaxis]['title']='A (dimensionless)'
+            fig["layout"][xaxis]["title"] = f"q{qubit}/r{i-1}: duration (ns)"
+            fig["layout"][yaxis]["title"] = "A (dimensionless)"
             xaxis = f"xaxis{2*i}"
             yaxis = f"yaxis{2*i}"
-            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: duration (ns)'
-            fig['layout'][yaxis]['title']='A (dimensionless)'
-        
+            fig["layout"][xaxis]["title"] = f"q{qubit}/r{i-1}: duration (ns)"
+            fig["layout"][yaxis]["title"] = "A (dimensionless)"
+
         i += 1
 
     return fig

--- a/src/qibocal/plots/heatmaps.py
+++ b/src/qibocal/plots/heatmaps.py
@@ -6,95 +6,155 @@ from plotly.subplots import make_subplots
 
 from qibocal.data import DataUnits
 
+def get_data_subfolders(folder):
+    # iterate over multiple data folders
+    subfolders = []
+    for file in os.listdir(folder):
+        d = os.path.join(folder, file)
+        if os.path.isdir(d):
+            subfolders.append(os.path.basename(d))
+    return subfolders
 
+# Resonator spectroscopy flux- tested
 def frequency_flux_msr_phase(folder, routine, qubit, format):
-    data = DataUnits.load_data(folder, routine, format, f"data_q{qubit}")
+
+    # iterate over multiple data folders
+    subfolders = get_data_subfolders(folder)
+
     fig = make_subplots(
-        rows=1,
+        rows=len(subfolders),
         cols=2,
         horizontal_spacing=0.1,
-        vertical_spacing=0.1,
+        vertical_spacing=0.2,
         subplot_titles=(
             "MSR (V)",
             "phase (rad)",
         ),
     )
 
-    fig.add_trace(
-        go.Heatmap(
-            x=data.get_values("frequency", "GHz"),
-            y=data.get_values("current", "A"),
-            z=data.get_values("MSR", "V"),
-            colorbar_x=0.45,
-        ),
-        row=1,
-        col=1,
-    )
-    fig.add_trace(
-        go.Heatmap(
-            x=data.get_values("frequency", "GHz"),
-            y=data.get_values("current", "A"),
-            z=data.get_values("phase", "rad"),
-            colorbar_x=1.0,
-        ),
-        row=1,
-        col=2,
-    )
-    fig.update_layout(
-        showlegend=False,
-        uirevision="0",  # ``uirevision`` allows zooming while live plotting
-        xaxis_title="Frequency (GHz)",
-        yaxis_title="Current (A)",
-        xaxis2_title="Frequency (GHz)",
-        yaxis2_title="Current (A)",
-    )
+    i = 1
+    for subfolder in subfolders:
+ 
+        data = DataUnits.load_data(folder, subfolder, routine, format, f"data_q{qubit}")
+
+        fig.add_trace(
+            go.Heatmap(
+                x=data.get_values("frequency", "GHz"),
+                y=data.get_values("current", "A"),
+                z=data.get_values("MSR", "V"),
+                colorbar_x=0.45,
+            ),
+            row=i,
+            col=1,
+        )
+        fig.add_trace(
+            go.Heatmap(
+                x=data.get_values("frequency", "GHz"),
+                y=data.get_values("current", "A"),
+                z=data.get_values("phase", "rad"),
+                colorbar_x=1.0,
+            ),
+            row=i,
+            col=2,
+        )
+
+        fig.update_layout(
+            showlegend=False,
+            uirevision="0",  # ``uirevision`` allows zooming while live plotting
+        )
+
+        if(i == 1):
+            fig['layout']['xaxis']['title']=f'q{qubit}/r{i-1}: Frequency (GHz)'
+            fig['layout']['yaxis']['title']='Current (A)'
+            xaxis = f"xaxis{i+1}"
+            yaxis = f"yaxis{i+1}"
+            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: Frequency (GHz)'
+            fig['layout'][yaxis]['title']='Current (A)'
+
+        else:
+            xaxis = f"xaxis{i+1}"
+            yaxis = f"yaxis{i+1}"
+            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: Frequency (GHz)'
+            fig['layout'][yaxis]['title']='Current (A)'
+            xaxis = f"xaxis{i+2}"
+            yaxis = f"yaxis{i+2}"
+            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: Frequency (GHz)'
+            fig['layout'][yaxis]['title']='Current (A)'
+
+        i += 1
+
     return fig
 
-
+# Punchout - tested
 def frequency_attenuation_msr_phase(folder, routine, qubit, format):
-    data = DataUnits.load_data(folder, routine, format, f"data_q{qubit}")
+
+    # iterate over multiple data folders
+    subfolders = get_data_subfolders(folder)
+    
     fig = make_subplots(
-        rows=1,
+        rows=len(subfolders),
         cols=2,
         horizontal_spacing=0.1,
-        vertical_spacing=0.1,
+        vertical_spacing=0.2,
         subplot_titles=(
             "MSR (V)",
             "phase (rad)",
         ),
     )
 
-    fig.add_trace(
-        go.Heatmap(
-            x=data.get_values("frequency", "GHz"),
-            y=data.get_values("attenuation", "dB"),
-            z=data.get_values("MSR", "V"),
-            colorbar_x=0.45,
-        ),
-        row=1,
-        col=1,
-    )
-    fig.add_trace(
-        go.Heatmap(
-            x=data.get_values("frequency", "GHz"),
-            y=data.get_values("attenuation", "dB"),
-            z=data.get_values("phase", "rad"),
-            colorbar_x=1.0,
-        ),
-        row=1,
-        col=2,
-    )
-    fig.update_layout(
-        showlegend=False,
-        uirevision="0",  # ``uirevision`` allows zooming while live plotting
-        xaxis_title="Frequency (GHz)",
-        yaxis_title="Attenuation (dB)",
-        xaxis2_title="Frequency (GHz)",
-        yaxis2_title="Attenuation (dB)",
-    )
+    i = 1
+    for subfolder in subfolders:
+        data = DataUnits.load_data(folder, subfolder, routine, format, f"data_q{qubit}")       
+
+        fig.add_trace(
+            go.Heatmap(
+                x=data.get_values("frequency", "GHz"),
+                y=data.get_values("attenuation", "dB"),
+                z=data.get_values("MSR", "V"),
+                colorbar_x=0.45,
+            ),
+            row=i,
+            col=1,
+        )
+        fig.add_trace(
+            go.Heatmap(
+                x=data.get_values("frequency", "GHz"),
+                y=data.get_values("attenuation", "dB"),
+                z=data.get_values("phase", "rad"),
+                colorbar_x=1.0,
+            ),
+            row=i,
+            col=2,
+        )
+        
+        fig.update_layout(
+            showlegend=False,
+            uirevision="0",  # ``uirevision`` allows zooming while live plotting
+        )
+
+        if(i == 1):
+            fig['layout']['xaxis']['title']=f'q{qubit}/r{i-1}: Frequency (GHz)'
+            fig['layout']['yaxis']['title']='Attenuation (dB)'
+            xaxis = f"xaxis{i+1}"
+            yaxis = f"yaxis{i+1}"
+            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: Frequency (GHz)'
+            fig['layout'][yaxis]['title']='Attenuation (dB)'
+
+        else:
+            xaxis = f"xaxis{i+1}"
+            yaxis = f"yaxis{i+1}"
+            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: Frequency (GHz)'
+            fig['layout'][yaxis]['title']='Attenuation (dB)'
+            xaxis = f"xaxis{i+2}"
+            yaxis = f"yaxis{i+2}"
+            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: Frequency (GHz)'
+            fig['layout'][yaxis]['title']='Attenuation (dB)'
+
+        i += 1
+
     return fig
 
-
+# Resonator spectroscopy flux matrix - to be adapted
 def frequency_flux_msr_phase__matrix(folder, routine, qubit, format):
     fluxes = []
     for i in range(25):  # FIXME: 25 is hardcoded
@@ -149,90 +209,139 @@ def frequency_flux_msr_phase__matrix(folder, routine, qubit, format):
     )
     return fig
 
-
+# Rabi pulse length and gain - to be tested
 def duration_gain_msr_phase(folder, routine, qubit, format):
-    data = DataUnits.load_data(folder, routine, format, f"data_q{qubit}")
+
+    # iterate over multiple data folders
+    subfolders = get_data_subfolders(folder)
+
     fig = make_subplots(
-        rows=1,
+        rows=len(subfolders),
         cols=2,
         horizontal_spacing=0.1,
-        vertical_spacing=0.1,
+        vertical_spacing=0.2,
         subplot_titles=(
             "MSR (V)",
             "phase (rad)",
         ),
     )
+    i = 1
+    for subfolder in subfolders:
 
-    fig.add_trace(
-        go.Heatmap(
-            x=data.get_values("duration", "ns"),
-            y=data.get_values("gain", "dimensionless"),
-            z=data.get_values("MSR", "V"),
-            colorbar_x=0.45,
-        ),
-        row=1,
-        col=1,
-    )
-    fig.add_trace(
-        go.Heatmap(
-            x=data.get_values("duration", "ns"),
-            y=data.get_values("gain", "dimensionless"),
-            z=data.get_values("phase", "rad"),
-            colorbar_x=1.0,
-        ),
-        row=1,
-        col=2,
-    )
-    fig.update_layout(
-        showlegend=False,
-        uirevision="0",  # ``uirevision`` allows zooming while live plotting
-        xaxis_title="duration (ns)",
-        yaxis_title="gain (dimensionless)",
-        xaxis2_title="duration (ns)",
-        yaxis2_title="gain (dimensionless)",
-    )
+        data = DataUnits.load_data(folder, subfolder, routine, format, f"data_q{qubit}")
+
+        fig.add_trace(
+            go.Heatmap(
+                x=data.get_values("duration", "ns"),
+                y=data.get_values("gain", "dimensionless"),
+                z=data.get_values("MSR", "V"),
+                colorbar_x=0.45,
+            ),
+            row=1,
+            col=1,
+        )
+        fig.add_trace(
+            go.Heatmap(
+                x=data.get_values("duration", "ns"),
+                y=data.get_values("gain", "dimensionless"),
+                z=data.get_values("phase", "rad"),
+                colorbar_x=1.0,
+            ),
+            row=1,
+            col=2,
+        )
+
+        fig.update_layout(
+            showlegend=False,
+            uirevision="0",  # ``uirevision`` allows zooming while live plotting
+        )
+
+        if(i == 1):
+            fig['layout']['xaxis']['title']=f'q{qubit}/r{i-1}: duration (ns)'
+            fig['layout']['yaxis']['title']='gain (dimensionless)'
+            xaxis = f"xaxis{i+1}"
+            yaxis = f"yaxis{i+1}"
+            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: duration (ns)'
+            fig['layout'][yaxis]['title']='gain (dimensionless)'
+
+        else:
+            xaxis = f"xaxis{i+1}"
+            yaxis = f"yaxis{i+1}"
+            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: duration (ns)'
+            fig['layout'][yaxis]['title']='gain (dimensionless)'
+            xaxis = f"xaxis{i+2}"
+            yaxis = f"yaxis{i+2}"
+            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: duration (ns)'
+            fig['layout'][yaxis]['title']='gain (dimensionless)'
+
+        i += 1
+
     return fig
 
-
+# Rabi pulse length and amplitude - to be tested
 def duration_amplitude_msr_phase(folder, routine, qubit, format):
-    data = DataUnits.load_data(folder, routine, format, f"data_q{qubit}")
+
+    # iterate over multiple data folders
+    subfolders = get_data_subfolders(folder)
+
     fig = make_subplots(
-        rows=1,
+        rows=len(subfolders),
         cols=2,
         horizontal_spacing=0.1,
-        vertical_spacing=0.1,
+        vertical_spacing=0.2,
         subplot_titles=(
             "MSR (V)",
             "phase (rad)",
         ),
     )
 
-    fig.add_trace(
-        go.Heatmap(
-            x=data.get_values("duration", "ns"),
-            y=data.get_values("amplitude", "dimensionless"),
-            z=data.get_values("MSR", "V"),
-            colorbar_x=0.45,
-        ),
-        row=1,
-        col=1,
-    )
-    fig.add_trace(
-        go.Heatmap(
-            x=data.get_values("duration", "ns"),
-            y=data.get_values("amplitude", "dimensionless"),
-            z=data.get_values("phase", "rad"),
-            colorbar_x=1.0,
-        ),
-        row=1,
-        col=2,
-    )
-    fig.update_layout(
-        showlegend=False,
-        uirevision="0",  # ``uirevision`` allows zooming while live plotting
-        xaxis_title="duration (ns)",
-        yaxis_title="amplitude (dimensionless)",
-        xaxis2_title="duration (ns)",
-        yaxis2_title="amplitude (dimensionless)",
-    )
+    i = 1
+    for subfolder in subfolders:
+
+        data = DataUnits.load_data(folder, subfolder, routine, format, f"data_q{qubit}")
+
+        fig.add_trace(
+            go.Heatmap(
+                x=data.get_values("duration", "ns"),
+                y=data.get_values("amplitude", "dimensionless"),
+                z=data.get_values("MSR", "V"),
+                colorbar_x=0.45,
+            ),
+            row=i,
+            col=1,
+        )
+        fig.add_trace(
+            go.Heatmap(
+                x=data.get_values("duration", "ns"),
+                y=data.get_values("amplitude", "dimensionless"),
+                z=data.get_values("phase", "rad"),
+                colorbar_x=1.0,
+            ),
+            row=i,
+            col=2,
+        )
+
+        fig.update_layout(
+            showlegend=False,
+            uirevision="0",  # ``uirevision`` allows zooming while live plotting
+        )
+
+        if(i == 1):
+            fig['layout']['xaxis']['title']=f'q{qubit}/r{i-1}: duration (ns)'
+            fig['layout']['yaxis']['title']='amplitude (dimensionless)'
+            xaxis = f"xaxis{i+1}"
+            yaxis = f"yaxis{i+1}"
+            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: duration (ns)'
+            fig['layout'][yaxis]['title']='amplitude (dimensionless)'
+
+        else:
+            xaxis = f"xaxis{i+1}"
+            yaxis = f"yaxis{i+1}"
+            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: duration (ns)'
+            fig['layout'][yaxis]['title']='amplitude (dimensionless)'
+            xaxis = f"xaxis{i+2}"
+            yaxis = f"yaxis{i+2}"
+            fig['layout'][xaxis]['title']=f'q{qubit}/r{i-1}: duration (ns)'
+            fig['layout'][yaxis]['title']='amplitude (dimensionless)'
+
     return fig

--- a/src/qibocal/plots/heatmaps.py
+++ b/src/qibocal/plots/heatmaps.py
@@ -5,17 +5,7 @@ import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
 from qibocal.data import DataUnits
-
-
-def get_data_subfolders(folder):
-    # iterate over multiple data folders
-    subfolders = []
-    for file in os.listdir(folder):
-        d = os.path.join(folder, file)
-        if os.path.isdir(d):
-            subfolders.append(os.path.basename(d))
-
-    return subfolders[::-1]
+from qibocal.plots.utils import get_data_subfolders
 
 
 # Resonator spectroscopy flux

--- a/src/qibocal/plots/scatters.py
+++ b/src/qibocal/plots/scatters.py
@@ -1218,7 +1218,7 @@ def msr_beta(folder, routine, qubit, format):
             beta_param = np.linspace(
                 min(data.get_values("beta_param", "dimensionless")),
                 max(data.get_values("beta_param", "dimensionless")),
-                20,
+                2 * len(data),
             )
             params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
             fig.add_trace(

--- a/src/qibocal/plots/scatters.py
+++ b/src/qibocal/plots/scatters.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import os
+#import os
 
 import numpy as np
 import plotly.graph_objects as go
@@ -7,16 +7,7 @@ from plotly.subplots import make_subplots
 
 from qibocal.data import Data, DataUnits
 from qibocal.fitting.utils import cos, exp, flipping, lorenzian, rabi, ramsey
-
-
-def get_data_subfolders(folder):
-    # iterate over multiple data folders
-    subfolders = []
-    for file in os.listdir(folder):
-        d = os.path.join(folder, file)
-        if os.path.isdir(d):
-            subfolders.append(os.path.basename(d))
-    return subfolders[::-1]
+from qibocal.plots.utils import get_data_subfolders
 
 
 # Resonator and qubit spectroscopies

--- a/src/qibocal/plots/scatters.py
+++ b/src/qibocal/plots/scatters.py
@@ -117,9 +117,13 @@ def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
                 row=1,
                 col=1,
             )
-
+            if(data_fit.df[params[2]][0] == 0):
+                param2 = ""
+            else:
+                param2 = f"q{qubit}/r{i} {params[2]}: {data_fit.df[params[2]][0]:.1f} Hz.<br>"
+                
             fitting_report = fitting_report + (
-                f"q{qubit}/r{i} {params[2]}: {data_fit.df[params[2]][0]:.1f} Hz.<br>q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f} uV.<br>q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.0f} Hz.<br><br>"
+                f"{param2}q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f} uV.<br>q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.0f} Hz.<br><br>"
             )
 
         i += 1

--- a/src/qibocal/plots/scatters.py
+++ b/src/qibocal/plots/scatters.py
@@ -16,7 +16,7 @@ def get_data_subfolders(folder):
         d = os.path.join(folder, file)
         if os.path.isdir(d):
             subfolders.append(os.path.basename(d))
-    return subfolders
+    return subfolders[::-1]
 
 
 # Resonator and qubit spectroscopies - tested

--- a/src/qibocal/plots/scatters.py
+++ b/src/qibocal/plots/scatters.py
@@ -117,11 +117,11 @@ def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
                 row=1,
                 col=1,
             )
-            if(data_fit.df[params[2]][0] == 0):
+            if data_fit.df[params[2]][0] == 0:
                 param2 = ""
             else:
                 param2 = f"q{qubit}/r{i} {params[2]}: {data_fit.df[params[2]][0]:.1f} Hz.<br>"
-                
+
             fitting_report = fitting_report + (
                 f"{param2}q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f} uV.<br>q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.0f} Hz.<br><br>"
             )

--- a/src/qibocal/plots/scatters.py
+++ b/src/qibocal/plots/scatters.py
@@ -195,7 +195,8 @@ def time_msr_phase(folder, routine, qubit, fformat):
 
     # iterate over multiple data folders
     subfolders = get_data_subfolders(folder)
-    print(subfolders)
+    # print(subfolders)
+    i = 0
     for subfolder in subfolders:
         try:
             data = DataUnits.load_data(
@@ -225,7 +226,7 @@ def time_msr_phase(folder, routine, qubit, fformat):
             go.Scatter(
                 x=data.get_values("Time", "ns"),
                 y=data.get_values("MSR", "uV"),
-                name="Rabi Oscillations",
+                name=f"Rabi q{qubit}/r{i}",
             ),
             row=1,
             col=1,
@@ -234,7 +235,7 @@ def time_msr_phase(folder, routine, qubit, fformat):
             go.Scatter(
                 x=data.get_values("Time", "ns"),
                 y=data.get_values("phase", "rad"),
-                name="Rabi Oscillations",
+                name=f"Rabi q{qubit}/r{i}",
             ),
             row=1,
             col=2,
@@ -259,7 +260,7 @@ def time_msr_phase(folder, routine, qubit, fformat):
                         data_fit.get_values("popt3"),
                         data_fit.get_values("popt4"),
                     ),
-                    name="Fit",
+                    name=f"Fit q{qubit}/r{i}",
                     line=go.scatter.Line(dash="dot"),
                 ),
                 row=1,
@@ -269,10 +270,10 @@ def time_msr_phase(folder, routine, qubit, fformat):
             fig.add_annotation(
                 dict(
                     font=dict(color="black", size=12),
-                    x=0,
-                    y=-0.20,
+                    x=i * 0.13,
+                    y=-0.25,
                     showarrow=False,
-                    text=f"Estimated {params[1]} is {data_fit.df[params[1]][0]:.3f} ns.",
+                    text=f"q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f} ns.",
                     textangle=0,
                     xanchor="left",
                     xref="paper",
@@ -283,16 +284,17 @@ def time_msr_phase(folder, routine, qubit, fformat):
             fig.add_annotation(
                 dict(
                     font=dict(color="black", size=12),
-                    x=0,
+                    x=i * 0.13,
                     y=-0.30,
                     showarrow=False,
-                    text=f"Estimated {params[0]} is {data_fit.df[params[0]][0]:.1f} uV.",
+                    text=f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} uV.",
                     textangle=0,
                     xanchor="left",
                     xref="paper",
                     yref="paper",
                 )
             )
+        i += 1
 
     # last part
     fig.update_layout(

--- a/src/qibocal/plots/scatters.py
+++ b/src/qibocal/plots/scatters.py
@@ -127,7 +127,7 @@ def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
             fig.add_annotation(
                 dict(
                     font=dict(color="black", size=12),
-                    x=i*0.13,
+                    x=i * 0.13,
                     y=-0.25,
                     showarrow=False,
                     text=f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} Hz.",
@@ -140,7 +140,7 @@ def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
             fig.add_annotation(
                 dict(
                     font=dict(color="black", size=12),
-                    x=i*0.13,
+                    x=i * 0.13,
                     y=-0.30,
                     showarrow=False,
                     text=f"q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f} uV.",
@@ -173,16 +173,14 @@ def frequency_attenuation_msr_phase__cut(folder, routine, qubit, format):
         cols=1,
         horizontal_spacing=0.1,
         vertical_spacing=0.1,
-        subplot_titles=(
-            "MSR (V)",
-        ),
+        subplot_titles=("MSR (V)",),
     )
 
     # iterate over multiple data folders
     subfolders = get_data_subfolders(folder)
     i = 0
     for subfolder in subfolders:
-        #print(subfolder)
+        # print(subfolder)
         data = DataUnits.load_data(folder, subfolder, routine, format, f"data_q{qubit}")
         # index data on a specific attenuation value
         smalldf = data.df[

--- a/src/qibocal/plots/scatters.py
+++ b/src/qibocal/plots/scatters.py
@@ -19,7 +19,7 @@ def get_data_subfolders(folder):
     return subfolders[::-1]
 
 
-# Resonator and qubit spectroscopies - tested
+# Resonator and qubit spectroscopies
 def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
 
     fig = make_subplots(
@@ -36,6 +36,7 @@ def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
     # iterate over multiple data folders
     subfolders = get_data_subfolders(folder)
     i = 0
+    fitting_report = ""
     for subfolder in subfolders:
         try:
             data_fast = DataUnits.load_data(
@@ -126,48 +127,27 @@ def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
                 col=1,
             )
 
-            fig.add_annotation(
-                dict(
-                    font=dict(color="black", size=12),
-                    x=i * 0.13,
-                    y=-0.25,
-                    showarrow=False,
-                    text=f"q{qubit}/r{i} {params[2]}: {data_fit.df[params[2]][0]:.1f} Hz.",
-                    textangle=0,
-                    xanchor="left",
-                    xref="paper",
-                    yref="paper",
-                )
-            )
-            fig.add_annotation(
-                dict(
-                    font=dict(color="black", size=12),
-                    x=i * 0.13,
-                    y=-0.30,
-                    showarrow=False,
-                    text=f"q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f} uV.",
-                    textangle=0,
-                    xanchor="left",
-                    xref="paper",
-                    yref="paper",
-                )
-            )
-            if data_fit.df[params[0]][0] != 0:
-                fig.add_annotation(
-                    dict(
-                        font=dict(color="black", size=12),
-                        x=i * 0.13,
-                        y=-0.20,
-                        showarrow=False,
-                        text=f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.0f} Hz.",
-                        textangle=0,
-                        xanchor="left",
-                        xref="paper",
-                        yref="paper",
-                    )
-                )
-
+            fitting_report = fitting_report + (f"q{qubit}/r{i} {params[2]}: {data_fit.df[params[2]][0]:.1f} Hz.<br>q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f} uV.<br>q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.0f} Hz.<br><br>")
+        
         i += 1
+
+    fig.add_annotation(
+        dict(
+            font=dict(color="black", size=12),
+            x=0,
+            y=1.2,
+            showarrow=False,
+            text="<b>FITTING DATA</b>",
+            font_family="Arial",
+            font_size=20,
+            textangle=0,
+            xanchor="left",
+            xref="paper",
+            yref="paper",
+            font_color="#5e9af1",
+            hovertext=fitting_report,
+        )
+    )
 
     fig.update_layout(
         showlegend=True,
@@ -180,7 +160,7 @@ def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
     return fig
 
 
-# Resonator and qubit spectroscopies - tested
+# Resonator and qubit spectroscopies
 def frequency_attenuation_msr_phase__cut(folder, routine, qubit, format):
 
     plot1d_attenuation = 56  # attenuation value to use for 1D frequency vs MSR plot
@@ -226,7 +206,7 @@ def frequency_attenuation_msr_phase__cut(folder, routine, qubit, format):
     return fig
 
 
-# Rabi oscillations pulse length - tested
+# Rabi oscillations pulse length
 def time_msr_phase(folder, routine, qubit, format):
 
     fig = make_subplots(
@@ -315,40 +295,26 @@ def time_msr_phase(folder, routine, qubit, format):
             )
 
             fitting_report = fitting_report + (f"q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f} ns<br>q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} uV.<br><br>")
-
-            # fig.add_annotation(
-            #     dict(
-            #         font=dict(color="black", size=12),
-            #         x=i * 0.13,
-            #         y=-0.30,
-            #         showarrow=False,
-            #         text=f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} uV.",
-            #         textangle=0,
-            #         xanchor="left",
-            #         xref="paper",
-            #         yref="paper",
-            #     )
-            # )
+        
         i += 1
 
-        fig.add_annotation(
-            dict(
-                font=dict(color="black", size=12),
-                x=0,
-                y=1.2,
-                showarrow=False,
-                #text="<a href='https://benasque.org'>FITTING REPORT</a>",
-                text="<b>FITTING DATA</b>",
-                font_family="Arial",
-                font_size=20,
-                textangle=0,
-                xanchor="left",
-                xref="paper",
-                yref="paper",
-                font_color="#5e9af1",
-                hovertext=fitting_report,
-            )
+    fig.add_annotation(
+        dict(
+            font=dict(color="black", size=12),
+            x=0,
+            y=1.2,
+            showarrow=False,
+            text="<b>FITTING DATA</b>",
+            font_family="Arial",
+            font_size=20,
+            textangle=0,
+            xanchor="left",
+            xref="paper",
+            yref="paper",
+            font_color="#5e9af1",
+            hovertext=fitting_report,
         )
+    )
 
     # last part
     fig.update_layout(
@@ -362,7 +328,7 @@ def time_msr_phase(folder, routine, qubit, format):
     return fig
 
 
-# Rabi oscillations pulse gain - tested
+# Rabi oscillations pulse gain
 def gain_msr_phase(folder, routine, qubit, format):
 
     fig = make_subplots(
@@ -379,6 +345,7 @@ def gain_msr_phase(folder, routine, qubit, format):
     # iterate over multiple data folders
     subfolders = get_data_subfolders(folder)
     i = 0
+    fitting_report = ""
     for subfolder in subfolders:
         try:
             data = DataUnits.load_data(
@@ -449,34 +416,27 @@ def gain_msr_phase(folder, routine, qubit, format):
                 col=1,
             )
 
-            fig.add_annotation(
-                dict(
-                    font=dict(color="black", size=12),
-                    x=i * 0.15,
-                    y=-0.25,
-                    showarrow=False,
-                    text=f"q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f}",
-                    textangle=0,
-                    xanchor="left",
-                    xref="paper",
-                    yref="paper",
-                )
-            )
-
-            fig.add_annotation(
-                dict(
-                    font=dict(color="black", size=12),
-                    x=i * 0.15,
-                    y=-0.30,
-                    showarrow=False,
-                    text=f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.4f} uV",
-                    textangle=0,
-                    xanchor="left",
-                    xref="paper",
-                    yref="paper",
-                )
-            )
+            fitting_report = fitting_report + (f"q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f}<br>q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.4f} uV<br><br>")
+        
         i += 1
+
+    fig.add_annotation(
+        dict(
+            font=dict(color="black", size=12),
+            x=0,
+            y=1.2,
+            showarrow=False,
+            text="<b>FITTING DATA</b>",
+            font_family="Arial",
+            font_size=20,
+            textangle=0,
+            xanchor="left",
+            xref="paper",
+            yref="paper",
+            font_color="#5e9af1",
+            hovertext=fitting_report,
+        )
+    )
 
     fig.update_layout(
         showlegend=True,
@@ -487,7 +447,7 @@ def gain_msr_phase(folder, routine, qubit, format):
     return fig
 
 
-# Rabi oscillations pulse amplitude - tested
+# Rabi oscillations pulse amplitude
 def amplitude_msr_phase(folder, routine, qubit, format):
 
     fig = make_subplots(
@@ -504,6 +464,7 @@ def amplitude_msr_phase(folder, routine, qubit, format):
     # iterate over multiple data folders
     subfolders = get_data_subfolders(folder)
     i = 0
+    fitting_report = ""
     for subfolder in subfolders:
 
         try:
@@ -564,34 +525,27 @@ def amplitude_msr_phase(folder, routine, qubit, format):
                 col=1,
             )
 
-            fig.add_annotation(
-                dict(
-                    font=dict(color="black", size=12),
-                    x=i * 0.15,
-                    y=-0.30,
-                    showarrow=False,
-                    text=f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.3f} uV.",
-                    textangle=0,
-                    xanchor="left",
-                    xref="paper",
-                    yref="paper",
-                )
-            )
+            fitting_report = fitting_report + (f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.3f} uV.<br>q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.4f}<br><br>")
 
-            fig.add_annotation(
-                dict(
-                    font=dict(color="black", size=12),
-                    x=i * 0.15,
-                    y=-0.25,
-                    showarrow=False,
-                    text=f"q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.4f}",
-                    textangle=0,
-                    xanchor="left",
-                    xref="paper",
-                    yref="paper",
-                )
-            )
         i += 1
+
+    fig.add_annotation(
+        dict(
+            font=dict(color="black", size=12),
+            x=0,
+            y=1.2,
+            showarrow=False,
+            text="<b>FITTING DATA</b>",
+            font_family="Arial",
+            font_size=20,
+            textangle=0,
+            xanchor="left",
+            xref="paper",
+            yref="paper",
+            font_color="#5e9af1",
+            hovertext=fitting_report,
+        )
+    )
 
     fig.update_layout(
         showlegend=True,
@@ -602,7 +556,7 @@ def amplitude_msr_phase(folder, routine, qubit, format):
     return fig
 
 
-# Ramsey oscillations - tested
+# Ramsey oscillations
 def time_msr(folder, routine, qubit, format):
     fig = make_subplots(
         rows=1,
@@ -615,6 +569,7 @@ def time_msr(folder, routine, qubit, format):
     # iterate over multiple data folders
     subfolders = get_data_subfolders(folder)
     i = 0
+    fitting_report = ""
     for subfolder in subfolders:
         try:
             data = DataUnits.load_data(
@@ -667,48 +622,27 @@ def time_msr(folder, routine, qubit, format):
                 col=1,
             )
 
-            fig.add_annotation(
-                dict(
-                    font=dict(color="black", size=12),
-                    x=i * 0.18,
-                    y=-0.30,
-                    showarrow=False,
-                    text=f"q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f} Hz.",
-                    textangle=0,
-                    xanchor="left",
-                    xref="paper",
-                    yref="paper",
-                )
-            )
+            fitting_report = fitting_report + (f"q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f} Hz.<br>q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} ns<br>q{qubit}/r{i} {params[2]}: {data_fit.df[params[2]][0]:.3f} Hz<br><br>")
 
-            fig.add_annotation(
-                dict(
-                    font=dict(color="black", size=12),
-                    x=i * 0.18,
-                    y=-0.20,
-                    showarrow=False,
-                    text=f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} ns",
-                    textangle=0,
-                    xanchor="left",
-                    xref="paper",
-                    yref="paper",
-                )
-            )
-
-            fig.add_annotation(
-                dict(
-                    font=dict(color="black", size=12),
-                    x=i * 0.18,
-                    y=-0.25,
-                    showarrow=False,
-                    text=f"q{qubit}/r{i} {params[2]}: {data_fit.df[params[2]][0]:.3f} Hz",
-                    textangle=0,
-                    xanchor="left",
-                    xref="paper",
-                    yref="paper",
-                )
-            )
         i += 1
+
+    fig.add_annotation(
+        dict(
+            font=dict(color="black", size=12),
+            x=0,
+            y=1.2,
+            showarrow=False,
+            text="<b>FITTING DATA</b>",
+            font_family="Arial",
+            font_size=20,
+            textangle=0,
+            xanchor="left",
+            xref="paper",
+            yref="paper",
+            font_color="#5e9af1",
+            hovertext=fitting_report,
+        )
+    )
 
     fig.update_layout(
         showlegend=True,
@@ -719,7 +653,7 @@ def time_msr(folder, routine, qubit, format):
     return fig
 
 
-# T1 - tested
+# T1
 def t1_time_msr_phase(folder, routine, qubit, format):
 
     fig = make_subplots(
@@ -736,6 +670,7 @@ def t1_time_msr_phase(folder, routine, qubit, format):
     # iterate over multiple data folders
     subfolders = get_data_subfolders(folder)
     i = 0
+    fitting_report = ""
     for subfolder in subfolders:
         try:
             data = DataUnits.load_data(
@@ -794,21 +729,41 @@ def t1_time_msr_phase(folder, routine, qubit, format):
                 col=1,
             )
 
-            fig.add_annotation(
-                dict(
-                    font=dict(color="black", size=12),
-                    x=i * 0.07,
-                    y=-0.20,
-                    showarrow=False,
-                    text=f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} ns.",
-                    textangle=0,
-                    xanchor="left",
-                    xref="paper",
-                    yref="paper",
-                )
-            )
+            fitting_report = fitting_report + (f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} ns.<br><br>")
+
+            # fig.add_annotation(
+            #     dict(
+            #         font=dict(color="black", size=12),
+            #         x=i * 0.07,
+            #         y=-0.20,
+            #         showarrow=False,
+            #         text=f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} ns.",
+            #         textangle=0,
+            #         xanchor="left",
+            #         xref="paper",
+            #         yref="paper",
+            #     )
+            # )
         i += 1
 
+    fig.add_annotation(
+        dict(
+            font=dict(color="black", size=12),
+            x=0,
+            y=1.2,
+            showarrow=False,
+            text="<b>FITTING DATA</b>",
+            font_family="Arial",
+            font_size=20,
+            textangle=0,
+            xanchor="left",
+            xref="paper",
+            yref="paper",
+            font_color="#5e9af1",
+            hovertext=fitting_report,
+        )
+    )
+    
     # last part
     fig.update_layout(
         showlegend=True,
@@ -821,7 +776,7 @@ def t1_time_msr_phase(folder, routine, qubit, format):
     return fig
 
 
-# Flipping - tested
+# Flipping
 def flips_msr_phase(folder, routine, qubit, format):
 
     fig = make_subplots(
@@ -838,6 +793,7 @@ def flips_msr_phase(folder, routine, qubit, format):
     # iterate over multiple data folders
     subfolders = get_data_subfolders(folder)
     i = 0
+    fitting_report = ""
     for subfolder in subfolders:
         try:
             data = DataUnits.load_data(
@@ -897,33 +853,27 @@ def flips_msr_phase(folder, routine, qubit, format):
                 col=1,
             )
 
-            fig.add_annotation(
-                dict(
-                    font=dict(color="black", size=12),
-                    x=i * 0.11,
-                    y=-0.25,
-                    showarrow=False,
-                    text=f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.4f}",
-                    textangle=0,
-                    xanchor="left",
-                    xref="paper",
-                    yref="paper",
-                )
-            )
-            fig.add_annotation(
-                dict(
-                    font=dict(color="black", size=12),
-                    x=i * 0.11,
-                    y=-0.30,
-                    showarrow=False,
-                    text=f"q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f}",
-                    textangle=0,
-                    xanchor="left",
-                    xref="paper",
-                    yref="paper",
-                )
-            )
+            fitting_report = fitting_report + (f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.4f}<br>q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f}<br><br>")
+
         i += 1
+
+    fig.add_annotation(
+        dict(
+            font=dict(color="black", size=12),
+            x=0,
+            y=1.2,
+            showarrow=False,
+            text="<b>FITTING DATA</b>",
+            font_family="Arial",
+            font_size=20,
+            textangle=0,
+            xanchor="left",
+            xref="paper",
+            yref="paper",
+            font_color="#5e9af1",
+            hovertext=fitting_report,
+        )
+    )
 
     # last part
     fig.update_layout(
@@ -937,7 +887,7 @@ def flips_msr_phase(folder, routine, qubit, format):
     return fig
 
 
-# Calibrate qubit states - tested
+# Calibrate qubit states
 def exc_gnd(folder, routine, qubit, format):
 
     fig = make_subplots(
@@ -951,6 +901,7 @@ def exc_gnd(folder, routine, qubit, format):
     # iterate over multiple data folders
     subfolders = get_data_subfolders(folder)
     i = 0
+    fitting_report = ""
     for subfolder in subfolders:
         try:
             parameters = DataUnits.load_data(
@@ -1051,21 +1002,27 @@ def exc_gnd(folder, routine, qubit, format):
             col=1,
         )
 
-        title_text = f"q{qubit}/r{i}: r_angle = {rotation_angle:.3f} / thrld = {threshold:.3f}<br>q{qubit}/r{i}: fidelity = {fidelity:.3f} / ass_fidelity = {assignment_fidelity:.3f}"
-        fig.add_annotation(
-            dict(
-                font=dict(color="black", size=12),
-                x=i * 0.55,
-                y=-0.25,
-                showarrow=False,
-                text=f"{title_text}",
-                textangle=0,
-                xanchor="left",
-                xref="paper",
-                yref="paper",
-            )
-        )
+        title_text = f"q{qubit}/r{i}: r_angle = {rotation_angle:.3f} / thrld = {threshold:.3f}<br>q{qubit}/r{i}: fidelity = {fidelity:.3f} / ass_fidelity = {assignment_fidelity:.3f}<br><br>"
+        fitting_report = fitting_report + title_text
         i += 1
+
+    fig.add_annotation(
+        dict(
+            font=dict(color="black", size=12),
+            x=0,
+            y=1.2,
+            showarrow=False,
+            text="<b>FITTING DATA</b>",
+            font_family="Arial",
+            font_size=13,
+            textangle=0,
+            xanchor="left",
+            xref="paper",
+            yref="paper",
+            font_color="#5e9af1",
+            hovertext=fitting_report,
+        )
+    )
 
     # fig.update_xaxes(title_text=title_text, row=1, col=1)
     fig.update_layout(
@@ -1078,7 +1035,7 @@ def exc_gnd(folder, routine, qubit, format):
     return fig
 
 
-# allXY - tested
+# allXY - tested 
 def prob_gate(folder, routine, qubit, format):
 
     fig = make_subplots(
@@ -1126,7 +1083,7 @@ def prob_gate(folder, routine, qubit, format):
     return fig
 
 
-# allXY iteration - tested
+# allXY iteration
 def prob_gate_iteration(folder, routine, qubit, format):
 
     import numpy as np
@@ -1194,7 +1151,7 @@ def prob_gate_iteration(folder, routine, qubit, format):
     return fig
 
 
-# Beta param tuning - tested
+# Beta param tuning
 def msr_beta(folder, routine, qubit, format):
 
     fig = make_subplots(
@@ -1208,6 +1165,7 @@ def msr_beta(folder, routine, qubit, format):
     # iterate over multiple data folders
     subfolders = get_data_subfolders(folder)
     i = 0
+    fitting_report = ""
     for subfolder in subfolders:
         try:
             data = DataUnits.load_data(
@@ -1261,20 +1219,27 @@ def msr_beta(folder, routine, qubit, format):
                 col=1,
             )
 
-            fig.add_annotation(
-                dict(
-                    font=dict(color="black", size=12),
-                    x=0,
-                    y=-0.13 + (-i * 0.05),
-                    showarrow=False,
-                    text=f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.4f}",
-                    textangle=0,
-                    xanchor="left",
-                    xref="paper",
-                    yref="paper",
-                )
-            )
+            fitting_report = fitting_report + (f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.4f}<br><br>")
+
             i += 1
+
+    fig.add_annotation(
+        dict(
+            font=dict(color="black", size=12),
+            x=0,
+            y=1.2,
+            showarrow=False,
+            text="<b>FITTING DATA</b>",
+            font_family="Arial",
+            font_size=20,
+            textangle=0,
+            xanchor="left",
+            xref="paper",
+            yref="paper",
+            font_color="#5e9af1",
+            hovertext=fitting_report,
+        )
+    )
 
     fig.update_layout(
         showlegend=True,
@@ -1285,7 +1250,7 @@ def msr_beta(folder, routine, qubit, format):
     return fig
 
 
-# Dispersive shift - tested
+# Dispersive shift
 def dispersive_frequency_msr_phase(folder, routine, qubit, formato):
 
     fig = make_subplots(
@@ -1302,6 +1267,7 @@ def dispersive_frequency_msr_phase(folder, routine, qubit, formato):
     # iterate over multiple data folders
     subfolders = get_data_subfolders(folder)
     i = 0
+    fitting_report = ""
     for subfolder in subfolders:
         try:
             data_spec = DataUnits.load_data(
@@ -1416,20 +1382,9 @@ def dispersive_frequency_msr_phase(folder, routine, qubit, formato):
                 row=1,
                 col=1,
             )
-            fig.add_annotation(
-                dict(
-                    font=dict(color="black", size=12),
-                    x=i * 0.15,
-                    y=-0.25,
-                    showarrow=False,
-                    text=f"q{qubit}/r{i} {params[2]}: {data_fit.df[params[2]][0]:.1f} Hz.",
-                    textangle=0,
-                    xanchor="left",
-                    xref="paper",
-                    yref="paper",
-                )
-            )
 
+            fitting_report = fitting_report + (f"q{qubit}/r{i} {params[2]}: {data_fit.df[params[2]][0]:.1f} Hz.<br>")
+ 
         # fitting shifted  traces
         if len(data_shifted) > 0 and len(data_fit_shifted) > 0:
             freqrange = np.linspace(
@@ -1454,20 +1409,28 @@ def dispersive_frequency_msr_phase(folder, routine, qubit, formato):
                 row=1,
                 col=1,
             )
-            fig.add_annotation(
-                dict(
-                    font=dict(color="black", size=12),
-                    x=i * 0.15,
-                    y=-0.30,
-                    showarrow=False,
-                    text=f"q{qubit}/r{i} shifted {params[2]}: {data_fit_shifted.df[params[2]][0]:.1f} Hz.",
-                    textangle=0,
-                    xanchor="left",
-                    xref="paper",
-                    yref="paper",
-                )
-            )
+
+            fitting_report = fitting_report + (f"q{qubit}/r{i} shifted {params[2]}: {data_fit_shifted.df[params[2]][0]:.1f} Hz.<br><br>")
+
         i += 1
+
+    fig.add_annotation(
+        dict(
+            font=dict(color="black", size=12),
+            x=0,
+            y=1.2,
+            showarrow=False,
+            text="<b>FITTING DATA</b>",
+            font_family="Arial",
+            font_size=20,
+            textangle=0,
+            xanchor="left",
+            xref="paper",
+            yref="paper",
+            font_color="#5e9af1",
+            hovertext=fitting_report,
+        )
+    )
 
     fig.update_layout(
         showlegend=True,

--- a/src/qibocal/plots/scatters.py
+++ b/src/qibocal/plots/scatters.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#import os
+# import os
 
 import numpy as np
 import plotly.graph_objects as go

--- a/src/qibocal/plots/scatters.py
+++ b/src/qibocal/plots/scatters.py
@@ -127,8 +127,10 @@ def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
                 col=1,
             )
 
-            fitting_report = fitting_report + (f"q{qubit}/r{i} {params[2]}: {data_fit.df[params[2]][0]:.1f} Hz.<br>q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f} uV.<br>q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.0f} Hz.<br><br>")
-        
+            fitting_report = fitting_report + (
+                f"q{qubit}/r{i} {params[2]}: {data_fit.df[params[2]][0]:.1f} Hz.<br>q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f} uV.<br>q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.0f} Hz.<br><br>"
+            )
+
         i += 1
 
     fig.add_annotation(
@@ -294,8 +296,10 @@ def time_msr_phase(folder, routine, qubit, format):
                 col=1,
             )
 
-            fitting_report = fitting_report + (f"q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f} ns<br>q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} uV.<br><br>")
-        
+            fitting_report = fitting_report + (
+                f"q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f} ns<br>q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} uV.<br><br>"
+            )
+
         i += 1
 
     fig.add_annotation(
@@ -416,8 +420,10 @@ def gain_msr_phase(folder, routine, qubit, format):
                 col=1,
             )
 
-            fitting_report = fitting_report + (f"q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f}<br>q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.4f} uV<br><br>")
-        
+            fitting_report = fitting_report + (
+                f"q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f}<br>q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.4f} uV<br><br>"
+            )
+
         i += 1
 
     fig.add_annotation(
@@ -525,7 +531,9 @@ def amplitude_msr_phase(folder, routine, qubit, format):
                 col=1,
             )
 
-            fitting_report = fitting_report + (f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.3f} uV.<br>q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.4f}<br><br>")
+            fitting_report = fitting_report + (
+                f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.3f} uV.<br>q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.4f}<br><br>"
+            )
 
         i += 1
 
@@ -622,7 +630,9 @@ def time_msr(folder, routine, qubit, format):
                 col=1,
             )
 
-            fitting_report = fitting_report + (f"q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f} Hz.<br>q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} ns<br>q{qubit}/r{i} {params[2]}: {data_fit.df[params[2]][0]:.3f} Hz<br><br>")
+            fitting_report = fitting_report + (
+                f"q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f} Hz.<br>q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} ns<br>q{qubit}/r{i} {params[2]}: {data_fit.df[params[2]][0]:.3f} Hz<br><br>"
+            )
 
         i += 1
 
@@ -729,7 +739,9 @@ def t1_time_msr_phase(folder, routine, qubit, format):
                 col=1,
             )
 
-            fitting_report = fitting_report + (f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} ns.<br><br>")
+            fitting_report = fitting_report + (
+                f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} ns.<br><br>"
+            )
 
             # fig.add_annotation(
             #     dict(
@@ -763,7 +775,7 @@ def t1_time_msr_phase(folder, routine, qubit, format):
             hovertext=fitting_report,
         )
     )
-    
+
     # last part
     fig.update_layout(
         showlegend=True,
@@ -853,7 +865,9 @@ def flips_msr_phase(folder, routine, qubit, format):
                 col=1,
             )
 
-            fitting_report = fitting_report + (f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.4f}<br>q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f}<br><br>")
+            fitting_report = fitting_report + (
+                f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.4f}<br>q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f}<br><br>"
+            )
 
         i += 1
 
@@ -1035,7 +1049,7 @@ def exc_gnd(folder, routine, qubit, format):
     return fig
 
 
-# allXY - tested 
+# allXY - tested
 def prob_gate(folder, routine, qubit, format):
 
     fig = make_subplots(
@@ -1219,7 +1233,9 @@ def msr_beta(folder, routine, qubit, format):
                 col=1,
             )
 
-            fitting_report = fitting_report + (f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.4f}<br><br>")
+            fitting_report = fitting_report + (
+                f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.4f}<br><br>"
+            )
 
             i += 1
 
@@ -1383,8 +1399,10 @@ def dispersive_frequency_msr_phase(folder, routine, qubit, formato):
                 col=1,
             )
 
-            fitting_report = fitting_report + (f"q{qubit}/r{i} {params[2]}: {data_fit.df[params[2]][0]:.1f} Hz.<br>")
- 
+            fitting_report = fitting_report + (
+                f"q{qubit}/r{i} {params[2]}: {data_fit.df[params[2]][0]:.1f} Hz.<br>"
+            )
+
         # fitting shifted  traces
         if len(data_shifted) > 0 and len(data_fit_shifted) > 0:
             freqrange = np.linspace(
@@ -1410,7 +1428,9 @@ def dispersive_frequency_msr_phase(folder, routine, qubit, formato):
                 col=1,
             )
 
-            fitting_report = fitting_report + (f"q{qubit}/r{i} shifted {params[2]}: {data_fit_shifted.df[params[2]][0]:.1f} Hz.<br><br>")
+            fitting_report = fitting_report + (
+                f"q{qubit}/r{i} shifted {params[2]}: {data_fit_shifted.df[params[2]][0]:.1f} Hz.<br><br>"
+            )
 
         i += 1
 

--- a/src/qibocal/plots/scatters.py
+++ b/src/qibocal/plots/scatters.py
@@ -269,7 +269,6 @@ def time_msr_phase(folder, routine, qubit, format):
             row=1,
             col=2,
         )
-
         # add fitting trace
         if len(data) > 0 and len(data_fit) > 0:
             timerange = np.linspace(

--- a/src/qibocal/plots/scatters.py
+++ b/src/qibocal/plots/scatters.py
@@ -19,7 +19,7 @@ def get_data_subfolders(folder):
     return subfolders
 
 
-# Resonator and qubit spectroscopies - TO BE tested
+# Resonator and qubit spectroscopies - tested
 def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
 
     fig = make_subplots(
@@ -127,7 +127,7 @@ def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
             fig.add_annotation(
                 dict(
                     font=dict(color="black", size=12),
-                    x=0,
+                    x=i*0.13,
                     y=-0.25,
                     showarrow=False,
                     text=f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} Hz.",
@@ -140,7 +140,7 @@ def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
             fig.add_annotation(
                 dict(
                     font=dict(color="black", size=12),
-                    x=0,
+                    x=i*0.13,
                     y=-0.30,
                     showarrow=False,
                     text=f"q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f} uV.",
@@ -1093,7 +1093,7 @@ def prob_gate(folder, routine, qubit, format):
     return fig
 
 
-# allXY - TO BE tested
+# allXY iteration - TO BE tested
 def prob_gate_iteration(folder, routine, qubit, format):
 
     import numpy as np

--- a/src/qibocal/plots/scatters.py
+++ b/src/qibocal/plots/scatters.py
@@ -163,16 +163,26 @@ def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
     return fig
 
 
-# Resonator and qubit spectroscopies - TO BE tested
+# Resonator and qubit spectroscopies - tested
 def frequency_attenuation_msr_phase__cut(folder, routine, qubit, format):
 
-    fig = go.Figure()
-    plot1d_attenuation = 30  # attenuation value to use for 1D frequency vs MSR plot
+    plot1d_attenuation = 56  # attenuation value to use for 1D frequency vs MSR plot
+
+    fig = make_subplots(
+        rows=1,
+        cols=1,
+        horizontal_spacing=0.1,
+        vertical_spacing=0.1,
+        subplot_titles=(
+            "MSR (V)",
+        ),
+    )
 
     # iterate over multiple data folders
     subfolders = get_data_subfolders(folder)
     i = 0
     for subfolder in subfolders:
+        #print(subfolder)
         data = DataUnits.load_data(folder, subfolder, routine, format, f"data_q{qubit}")
         # index data on a specific attenuation value
         smalldf = data.df[
@@ -193,7 +203,7 @@ def frequency_attenuation_msr_phase__cut(folder, routine, qubit, format):
         i += 1
 
     fig.update_layout(
-        showlegend=False,
+        showlegend=True,
         uirevision="0",  # ``uirevision`` allows zooming while live plotting,
         xaxis_title="Frequency (GHz)",
         yaxis_title="MSR (V)",
@@ -686,7 +696,7 @@ def time_msr(folder, routine, qubit, format):
     return fig
 
 
-# T1 - TO BE tested
+# T1 - tested
 def t1_time_msr_phase(folder, routine, qubit, format):
 
     fig = make_subplots(
@@ -764,7 +774,7 @@ def t1_time_msr_phase(folder, routine, qubit, format):
             fig.add_annotation(
                 dict(
                     font=dict(color="black", size=12),
-                    x=i * 0.12,
+                    x=i * 0.07,
                     y=-0.20,
                     showarrow=False,
                     text=f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} ns.",
@@ -788,7 +798,7 @@ def t1_time_msr_phase(folder, routine, qubit, format):
     return fig
 
 
-# Flipping - TO BE tested
+# Flipping - tested
 def flips_msr_phase(folder, routine, qubit, format):
 
     fig = make_subplots(
@@ -867,7 +877,7 @@ def flips_msr_phase(folder, routine, qubit, format):
             fig.add_annotation(
                 dict(
                     font=dict(color="black", size=12),
-                    x=0,
+                    x=i * 0.11,
                     y=-0.25,
                     showarrow=False,
                     text=f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.4f}",
@@ -880,7 +890,7 @@ def flips_msr_phase(folder, routine, qubit, format):
             fig.add_annotation(
                 dict(
                     font=dict(color="black", size=12),
-                    x=0,
+                    x=i * 0.11,
                     y=-0.30,
                     showarrow=False,
                     text=f"q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f}",
@@ -890,7 +900,7 @@ def flips_msr_phase(folder, routine, qubit, format):
                     yref="paper",
                 )
             )
-        i = +1
+        i += 1
 
     # last part
     fig.update_layout(
@@ -1093,7 +1103,7 @@ def prob_gate(folder, routine, qubit, format):
     return fig
 
 
-# allXY iteration - TO BE tested
+# allXY iteration - tested
 def prob_gate_iteration(folder, routine, qubit, format):
 
     import numpy as np
@@ -1252,7 +1262,7 @@ def msr_beta(folder, routine, qubit, format):
     return fig
 
 
-# Dispersive shift - TO BE tested
+# Dispersive shift - tested
 def dispersive_frequency_msr_phase(folder, routine, qubit, formato):
 
     fig = make_subplots(
@@ -1384,7 +1394,7 @@ def dispersive_frequency_msr_phase(folder, routine, qubit, formato):
             fig.add_annotation(
                 dict(
                     font=dict(color="black", size=12),
-                    x=0,
+                    x=i * 0.15,
                     y=-0.25,
                     showarrow=False,
                     text=f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} Hz.",
@@ -1422,7 +1432,7 @@ def dispersive_frequency_msr_phase(folder, routine, qubit, formato):
             fig.add_annotation(
                 dict(
                     font=dict(color="black", size=12),
-                    x=0,
+                    x=i * 0.15,
                     y=-0.30,
                     showarrow=False,
                     text=f"q{qubit}/r{i} shifted {params[0]}: {data_fit_shifted.df[params[0]][0]:.1f} Hz.",

--- a/src/qibocal/plots/scatters.py
+++ b/src/qibocal/plots/scatters.py
@@ -743,19 +743,6 @@ def t1_time_msr_phase(folder, routine, qubit, format):
                 f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} ns.<br><br>"
             )
 
-            # fig.add_annotation(
-            #     dict(
-            #         font=dict(color="black", size=12),
-            #         x=i * 0.07,
-            #         y=-0.20,
-            #         showarrow=False,
-            #         text=f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} ns.",
-            #         textangle=0,
-            #         xanchor="left",
-            #         xref="paper",
-            #         yref="paper",
-            #     )
-            # )
         i += 1
 
     fig.add_annotation(

--- a/src/qibocal/plots/scatters.py
+++ b/src/qibocal/plots/scatters.py
@@ -63,7 +63,6 @@ def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
                     "label1",
                     "label2",
                     "label3",
-
                 ]
             )
 
@@ -153,7 +152,7 @@ def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
                     yref="paper",
                 )
             )
-            if (data_fit.df[params[0]][0] != 0):
+            if data_fit.df[params[0]][0] != 0:
                 fig.add_annotation(
                     dict(
                         font=dict(color="black", size=12),

--- a/src/qibocal/plots/scatters.py
+++ b/src/qibocal/plots/scatters.py
@@ -62,6 +62,8 @@ def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
                     "popt3",
                     "label1",
                     "label2",
+                    "label3",
+
                 ]
             )
 
@@ -124,13 +126,14 @@ def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
                 row=1,
                 col=1,
             )
+
             fig.add_annotation(
                 dict(
                     font=dict(color="black", size=12),
                     x=i * 0.13,
                     y=-0.25,
                     showarrow=False,
-                    text=f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} Hz.",
+                    text=f"q{qubit}/r{i} {params[2]}: {data_fit.df[params[2]][0]:.1f} Hz.",
                     textangle=0,
                     xanchor="left",
                     xref="paper",
@@ -150,6 +153,21 @@ def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
                     yref="paper",
                 )
             )
+            if (data_fit.df[params[0]][0] != 0):
+                fig.add_annotation(
+                    dict(
+                        font=dict(color="black", size=12),
+                        x=i * 0.13,
+                        y=-0.20,
+                        showarrow=False,
+                        text=f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.0f} Hz.",
+                        textangle=0,
+                        xanchor="left",
+                        xref="paper",
+                        yref="paper",
+                    )
+                )
+
         i += 1
 
     fig.update_layout(
@@ -1307,6 +1325,7 @@ def dispersive_frequency_msr_phase(folder, routine, qubit, formato):
                     "popt3",
                     "label1",
                     "label2",
+                    "label3",
                 ]
             )
 
@@ -1323,6 +1342,7 @@ def dispersive_frequency_msr_phase(folder, routine, qubit, formato):
                     "popt3",
                     "label1",
                     "label2",
+                    "label3",
                 ]
             )
 
@@ -1395,7 +1415,7 @@ def dispersive_frequency_msr_phase(folder, routine, qubit, formato):
                     x=i * 0.15,
                     y=-0.25,
                     showarrow=False,
-                    text=f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} Hz.",
+                    text=f"q{qubit}/r{i} {params[2]}: {data_fit.df[params[2]][0]:.1f} Hz.",
                     textangle=0,
                     xanchor="left",
                     xref="paper",
@@ -1433,7 +1453,7 @@ def dispersive_frequency_msr_phase(folder, routine, qubit, formato):
                     x=i * 0.15,
                     y=-0.30,
                     showarrow=False,
-                    text=f"q{qubit}/r{i} shifted {params[0]}: {data_fit_shifted.df[params[0]][0]:.1f} Hz.",
+                    text=f"q{qubit}/r{i} shifted {params[2]}: {data_fit_shifted.df[params[2]][0]:.1f} Hz.",
                     textangle=0,
                     xanchor="left",
                     xref="paper",

--- a/src/qibocal/plots/scatters.py
+++ b/src/qibocal/plots/scatters.py
@@ -243,6 +243,7 @@ def time_msr_phase(folder, routine, qubit, format):
     # iterate over multiple data folders
     subfolders = get_data_subfolders(folder)
     i = 0
+    fitting_report = ""
     for subfolder in subfolders:
         try:
             data = DataUnits.load_data(
@@ -313,34 +314,41 @@ def time_msr_phase(folder, routine, qubit, format):
                 col=1,
             )
 
-            fig.add_annotation(
-                dict(
-                    font=dict(color="black", size=12),
-                    x=i * 0.13,
-                    y=-0.25,
-                    showarrow=False,
-                    text=f"q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f} ns.",
-                    textangle=0,
-                    xanchor="left",
-                    xref="paper",
-                    yref="paper",
-                )
-            )
+            fitting_report = fitting_report + (f"q{qubit}/r{i} {params[1]}: {data_fit.df[params[1]][0]:.3f} ns<br>q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} uV.<br><br>")
 
-            fig.add_annotation(
-                dict(
-                    font=dict(color="black", size=12),
-                    x=i * 0.13,
-                    y=-0.30,
-                    showarrow=False,
-                    text=f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} uV.",
-                    textangle=0,
-                    xanchor="left",
-                    xref="paper",
-                    yref="paper",
-                )
-            )
+            # fig.add_annotation(
+            #     dict(
+            #         font=dict(color="black", size=12),
+            #         x=i * 0.13,
+            #         y=-0.30,
+            #         showarrow=False,
+            #         text=f"q{qubit}/r{i} {params[0]}: {data_fit.df[params[0]][0]:.1f} uV.",
+            #         textangle=0,
+            #         xanchor="left",
+            #         xref="paper",
+            #         yref="paper",
+            #     )
+            # )
         i += 1
+
+        fig.add_annotation(
+            dict(
+                font=dict(color="black", size=12),
+                x=0,
+                y=1.2,
+                showarrow=False,
+                #text="<a href='https://benasque.org'>FITTING REPORT</a>",
+                text="<b>FITTING DATA</b>",
+                font_family="Arial",
+                font_size=20,
+                textangle=0,
+                xanchor="left",
+                xref="paper",
+                yref="paper",
+                font_color="#5e9af1",
+                hovertext=fitting_report,
+            )
+        )
 
     # last part
     fig.update_layout(

--- a/src/qibocal/plots/scatters.py
+++ b/src/qibocal/plots/scatters.py
@@ -1035,7 +1035,7 @@ def exc_gnd(folder, routine, qubit, format):
     return fig
 
 
-# allXY - tested
+# allXY
 def prob_gate(folder, routine, qubit, format):
 
     fig = make_subplots(
@@ -1176,7 +1176,7 @@ def msr_beta(folder, routine, qubit, format):
                 name=f"data_q{qubit}", quantities={"beta_param": "dimensionless"}
             )
         try:
-            data_fit = Data.load_data(
+            data_fit = DataUnits.load_data(
                 folder, subfolder, routine, format, f"fit_q{qubit}"
             )
         except:
@@ -1444,6 +1444,126 @@ def dispersive_frequency_msr_phase(folder, routine, qubit, formato):
         xaxis_title="Frequency (GHz)",
         yaxis_title="MSR (uV)",
         xaxis2_title="Frequency (GHz)",
+        yaxis2_title="Phase (rad)",
+    )
+    return fig
+
+
+# Spin echos
+def spin_echo_time_msr_phase(folder, routine, qubit, format):
+
+    """Spin echo plotting routine:
+    The routine plots the results of a modified Ramsey sequence with an additional Rx(pi) pulse placed symmetrically between the two Rx(pi/2) pulses.
+    An exponential fit to this data gives a spin echo decay time T2.
+
+    Args:
+        folder (string): Folder name where the data and fitted data is located
+        routine (string): Name of the calibration routine that calls this plotting method
+        qubit (int): Target qubit to characterize
+        format (string): Data file format. Supported formats are .csv and .pkl
+    """
+
+    fig = make_subplots(
+        rows=1,
+        cols=2,
+        horizontal_spacing=0.1,
+        vertical_spacing=0.1,
+        subplot_titles=(
+            "MSR (V)",
+            "phase (rad)",
+        ),
+    )
+
+    # iterate over multiple data folders
+    subfolders = get_data_subfolders(folder)
+    i = 0
+    for subfolder in subfolders:
+        try:
+            data = DataUnits.load_data(
+                folder, subfolder, routine, format, f"data_q{qubit}"
+            )
+        except:
+            data = DataUnits(quantities={"Time": "ns"})
+
+        try:
+            data_fit = Data.load_data(
+                folder, subfolder, routine, format, f"fit_q{qubit}"
+            )
+        except:
+            data_fit = Data(
+                quantities=[
+                    "popt0",
+                    "popt1",
+                    "popt2",
+                    "label1",
+                ]
+            )
+
+        fig.add_trace(
+            go.Scatter(
+                x=data.get_values("Time", "ns"),
+                y=data.get_values("MSR", "uV"),
+                name=f"q{qubit}/r{i}: spin echo",
+            ),
+            row=1,
+            col=1,
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=data.get_values("Time", "ns"),
+                y=data.get_values("phase", "rad"),
+                name=f"q{qubit}/r{i}: spin echo",
+            ),
+            row=1,
+            col=2,
+        )
+
+        # add fitting trace
+        if len(data) > 0 and len(data_fit) > 0:
+            timerange = np.linspace(
+                min(data.get_values("Time", "ns")),
+                max(data.get_values("Time", "ns")),
+                2 * len(data),
+            )
+            params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
+            fig.add_trace(
+                go.Scatter(
+                    x=timerange,
+                    y=exp(
+                        timerange,
+                        data_fit.df["popt0"][0],
+                        data_fit.df["popt1"][0],
+                        data_fit.df["popt2"][0],
+                    ),
+                    name=f"Fit q{qubit}/r{i}:",
+                    line=go.scatter.Line(dash="dot"),
+                ),
+                row=1,
+                col=1,
+            )
+
+            fig.add_annotation(
+                dict(
+                    font=dict(color="black", size=12),
+                    x=i * 0.09,
+                    y=-0.25,
+                    showarrow=False,
+                    text=f"q{qubit}/r{i}: {params[0]}: {data_fit.df[params[0]][0]:.1f} ns.",
+                    textangle=0,
+                    xanchor="left",
+                    xref="paper",
+                    yref="paper",
+                )
+            )
+        i += 1
+
+    # last part
+    fig.update_layout(
+        showlegend=True,
+        uirevision="0",  # ``uirevision`` allows zooming while live plotting
+        xaxis_title="Time (ns)",
+        yaxis_title="MSR (uV)",
+        xaxis2_title="Time (ns)",
         yaxis2_title="Phase (rad)",
     )
     return fig

--- a/src/qibocal/plots/scatters.py
+++ b/src/qibocal/plots/scatters.py
@@ -1,10 +1,22 @@
 # -*- coding: utf-8 -*-
+import os
+
 import numpy as np
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
 from qibocal.data import Data, DataUnits
 from qibocal.fitting.utils import cos, exp, flipping, lorenzian, rabi, ramsey
+
+
+def get_data_subfolders(folder):
+    # iterate over multiple data folders
+    subfolders = []
+    for file in os.listdir(folder):
+        d = os.path.join(folder, file)
+        if os.path.isdir(d):
+            subfolders.append(os.path.basename(d))
+    return subfolders
 
 
 def frequency_msr_phase__fast_precision(folder, routine, qubit, format):
@@ -168,26 +180,7 @@ def frequency_attenuation_msr_phase__cut(folder, routine, qubit, format):
 
 
 # For Rabi oscillations
-def time_msr_phase(folder, routine, qubit, format):
-    try:
-        data = DataUnits.load_data(folder, routine, format, f"data_q{qubit}")
-    except:
-        data = DataUnits(quantities={"Time": "ns"})
-
-    try:
-        data_fit = Data.load_data(folder, routine, format, f"fit_q{qubit}")
-    except:
-        data_fit = Data(
-            quantities=[
-                "popt0",
-                "popt1",
-                "popt2",
-                "popt3",
-                "popt4",
-                "label1",
-                "label2",
-            ]
-        )
+def time_msr_phase(folder, routine, qubit, fformat):
 
     fig = make_subplots(
         rows=1,
@@ -200,78 +193,106 @@ def time_msr_phase(folder, routine, qubit, format):
         ),
     )
 
-    fig.add_trace(
-        go.Scatter(
-            x=data.get_values("Time", "ns"),
-            y=data.get_values("MSR", "uV"),
-            name="Rabi Oscillations",
-        ),
-        row=1,
-        col=1,
-    )
-    fig.add_trace(
-        go.Scatter(
-            x=data.get_values("Time", "ns"),
-            y=data.get_values("phase", "rad"),
-            name="Rabi Oscillations",
-        ),
-        row=1,
-        col=2,
-    )
+    # iterate over multiple data folders
+    subfolders = get_data_subfolders(folder)
+    print(subfolders)
+    for subfolder in subfolders:
+        try:
+            data = DataUnits.load_data(
+                folder, subfolder, routine, fformat, f"data_q{qubit}"
+            )
+        except:
+            data = DataUnits(quantities={"Time": "ns"})
 
-    # add fitting trace
-    if len(data) > 0 and len(data_fit) > 0:
-        timerange = np.linspace(
-            min(data.get_values("Time", "ns")),
-            max(data.get_values("Time", "ns")),
-            2 * len(data),
-        )
-        params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
+        try:
+            data_fit = Data.load_data(
+                folder, subfolder, routine, fformat, f"fit_q{qubit}"
+            )
+        except:
+            data_fit = Data(
+                quantities=[
+                    "popt0",
+                    "popt1",
+                    "popt2",
+                    "popt3",
+                    "popt4",
+                    "label1",
+                    "label2",
+                ]
+            )
+
         fig.add_trace(
             go.Scatter(
-                x=timerange,
-                y=rabi(
-                    timerange,
-                    data_fit.get_values("popt0"),
-                    data_fit.get_values("popt1"),
-                    data_fit.get_values("popt2"),
-                    data_fit.get_values("popt3"),
-                    data_fit.get_values("popt4"),
-                ),
-                name="Fit",
-                line=go.scatter.Line(dash="dot"),
+                x=data.get_values("Time", "ns"),
+                y=data.get_values("MSR", "uV"),
+                name="Rabi Oscillations",
             ),
             row=1,
             col=1,
         )
-
-        fig.add_annotation(
-            dict(
-                font=dict(color="black", size=12),
-                x=0,
-                y=-0.20,
-                showarrow=False,
-                text=f"Estimated {params[1]} is {data_fit.df[params[1]][0]:.3f} ns.",
-                textangle=0,
-                xanchor="left",
-                xref="paper",
-                yref="paper",
-            )
+        fig.add_trace(
+            go.Scatter(
+                x=data.get_values("Time", "ns"),
+                y=data.get_values("phase", "rad"),
+                name="Rabi Oscillations",
+            ),
+            row=1,
+            col=2,
         )
 
-        fig.add_annotation(
-            dict(
-                font=dict(color="black", size=12),
-                x=0,
-                y=-0.30,
-                showarrow=False,
-                text=f"Estimated {params[0]} is {data_fit.df[params[0]][0]:.1f} uV.",
-                textangle=0,
-                xanchor="left",
-                xref="paper",
-                yref="paper",
+        # add fitting trace
+        if len(data) > 0 and len(data_fit) > 0:
+            timerange = np.linspace(
+                min(data.get_values("Time", "ns")),
+                max(data.get_values("Time", "ns")),
+                2 * len(data),
             )
-        )
+            params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
+            fig.add_trace(
+                go.Scatter(
+                    x=timerange,
+                    y=rabi(
+                        timerange,
+                        data_fit.get_values("popt0"),
+                        data_fit.get_values("popt1"),
+                        data_fit.get_values("popt2"),
+                        data_fit.get_values("popt3"),
+                        data_fit.get_values("popt4"),
+                    ),
+                    name="Fit",
+                    line=go.scatter.Line(dash="dot"),
+                ),
+                row=1,
+                col=1,
+            )
+
+            fig.add_annotation(
+                dict(
+                    font=dict(color="black", size=12),
+                    x=0,
+                    y=-0.20,
+                    showarrow=False,
+                    text=f"Estimated {params[1]} is {data_fit.df[params[1]][0]:.3f} ns.",
+                    textangle=0,
+                    xanchor="left",
+                    xref="paper",
+                    yref="paper",
+                )
+            )
+
+            fig.add_annotation(
+                dict(
+                    font=dict(color="black", size=12),
+                    x=0,
+                    y=-0.30,
+                    showarrow=False,
+                    text=f"Estimated {params[0]} is {data_fit.df[params[0]][0]:.1f} uV.",
+                    textangle=0,
+                    xanchor="left",
+                    xref="paper",
+                    yref="paper",
+                )
+            )
 
     # last part
     fig.update_layout(

--- a/src/qibocal/plots/utils.py
+++ b/src/qibocal/plots/utils.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+import os.path
+
+def get_data_subfolders(folder):
+    # iterate over multiple data folders
+    subfolders = []
+    for file in os.listdir(folder):
+        d = os.path.join(folder, file)
+        if os.path.isdir(d):
+            subfolders.append(os.path.basename(d))
+
+    return subfolders[::-1]

--- a/src/qibocal/plots/utils.py
+++ b/src/qibocal/plots/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os.path
 
+
 def get_data_subfolders(folder):
     # iterate over multiple data folders
     subfolders = []

--- a/src/qibocal/web/app.py
+++ b/src/qibocal/web/app.py
@@ -23,7 +23,7 @@ app.layout = html.Div(
         dcc.Interval(
             id="interval",
             # TODO: Perhaps the user should be allowed to change the refresh rate
-            interval=1000,
+            interval=2000,
             n_intervals=0,
             disabled=False,
         ),

--- a/src/qibocal/web/server.py
+++ b/src/qibocal/web/server.py
@@ -2,8 +2,9 @@
 import os
 import pathlib
 import subprocess
+
 import yaml
-from flask import Flask, request, render_template, redirect
+from flask import Flask, redirect, render_template, request
 
 from qibocal import __version__
 from qibocal.cli.builders import ReportBuilder
@@ -34,21 +35,22 @@ def page(path=None):
         report=report,
     )
 
-@server.route("/", methods =["GET", "POST"])
+
+@server.route("/", methods=["GET", "POST"])
 def qq_compare():
     if request.method == "POST":
-        list_of_folders="" 
-        success=""
-        selected_folders = request.form.getlist('list_of_folders')    
+        list_of_folders = ""
+        success = ""
+        selected_folders = request.form.getlist("list_of_folders")
         for folder in selected_folders:
-            list_of_folders = list_of_folders + folder +" "
+            list_of_folders = list_of_folders + folder + " "
 
-        #execute shell command qq-compare
+        # execute shell command qq-compare
         command = "qq-compare " + list_of_folders
         try:
             command_output = subprocess.check_output([command], shell=True)
-            
+
         except subprocess.CalledProcessError as e:
             return "An error occurred while trying to generate qq-report.<br>Please check folder compatility."
-        
+
         return redirect("/data/qq-compare", code=302)

--- a/src/qibocal/web/server.py
+++ b/src/qibocal/web/server.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import os
 import pathlib
-
+import subprocess
 import yaml
-from flask import Flask, render_template
+from flask import Flask, request, render_template, redirect
 
 from qibocal import __version__
 from qibocal.cli.builders import ReportBuilder
@@ -33,3 +33,22 @@ def page(path=None):
         folders=folders,
         report=report,
     )
+
+@server.route("/", methods =["GET", "POST"])
+def qq_compare():
+    if request.method == "POST":
+        list_of_folders="" 
+        success=""
+        selected_folders = request.form.getlist('list_of_folders')    
+        for folder in selected_folders:
+            list_of_folders = list_of_folders + folder +" "
+
+        #execute shell command qq-compare
+        command = "qq-compare " + list_of_folders
+        try:
+            command_output = subprocess.check_output([command], shell=True)
+            
+        except subprocess.CalledProcessError as e:
+            return "An error occurred while trying to generate qq-report.<br>Please check folder compatility."
+        
+        return redirect("/data/qq-compare", code=302)

--- a/src/qibocal/web/templates/template.html
+++ b/src/qibocal/web/templates/template.html
@@ -87,11 +87,17 @@
             </button>
             <div class="collapse show list-group" id="saved-reports">
               <ul class="btn-toggle-nav list-unstyled fw-normal pb-1 small">
-                {% for folder in folders %}
-                <li><a id="reports" href="{{ url_for('page', path=folder) }}"
-                    class="link-dark d-inline-flex text-decoration-none rounded list-group-item {{ 'active' if folder == report.path else '' }}">{{ folder }}</a></li>
-                {% endfor %}
-              </ul>
+                <form action="/" method="post">
+                  {% for folder in folders %}
+                  <li>
+                    <input type="checkbox" name="list_of_folders" value="{{ folder }}">
+                    <a id="reports" href="{{ url_for('page', path=folder) }}" class="link-dark d-inline-flex text-decoration-none rounded list-group-item {{ 'active' if folder == report.path else '' }}">{{ folder }}</a>
+                  </li>
+                  {% endfor %}
+                </ul>
+                <br><br>
+                <button style="background:#6400FF;color:white;" type="submit" title="Select saved reports to compare" >qq-compare report</button>
+              </form>
             </div>
           </li>
           {% endif %}


### PR DESCRIPTION
This PR implements qq-compare command in qibocal. The command will check if the folders are comparable between them, so the folders have contain data obtained from the same type of actions using qibocal module.

The use of the command is the following:

1. Execute qq-compare folder_1 folder_2 folder_N (where the arguments are the folders to be compared)
2. Comparision results are stores under "qq-compare" folder located in the users folder
3. Previous comparisons are moved and stored in "qq-compare_{date_time}" folders
4. Open qq-live and click "qq-compare" folder to see the results

All the data regarding same qubits are compare under the same plot. The legends are automatically named with the nomenclature "qm/rn" that should be interpreted as the execution N over qubit M of the given action that is being compared.

All qq-live plotting methods has been adapted (and tested) to the needs of qq-compare without affecting the single execution of any action avoiding the duplication of code.

This PR has been tested with qibolab branch alvaro/binning_pr (the more advanced one qibolab driver, pending to be merged into main)

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [ ] Coverage does not decrease.
- [x] Documentation is updated.
