### PR TITLE
Testing documentation examples in workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,7 @@ jobs:
           poe test
       - name: Test documentation examples
         run: |
+          source $VENV
           make -C doc doctest
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,9 @@ jobs:
         run: |
           source $VENV
           poe test
+      - name: Test documentation examples
+        run: |
+          make -C doc doctest
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ lint = "pylint src/**/*.py -E"
 lint-warnings = "pylint src/**/*.py --exit-zero"
 docs = "make -C doc html"
 docs-clean = "make -C doc clean"
+test-docs = "make -C doc doctest"
 
 [tool.pytest.ini_options]
 testpaths = ['src/qibocal/tests/']


### PR DESCRIPTION
As already stated in #130 with this PR we add the possibility to test the documentation examples directly in the workflow using the `doctest` ext available in sphinx. This is exactly the same approach that we use in Qibo.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
