### PR TITLE
Add platform runcard in qq runcard

### DIFF
--- a/runcards/actions_qq_1q.yml
+++ b/runcards/actions_qq_1q.yml
@@ -1,19 +1,21 @@
-platform: tii1q
+platform: tii1q_b1
+
+runcard: tii1q_b1.yml
 
 qubits: [0]
 
 format: csv
 
 actions:
-  # resonator_spectroscopy:
-  #   lowres_width: 5_000_000
-  #   lowres_step: 2_000_000
-  #   highres_width: 1_500_000
-  #   highres_step: 200_000
-  #   precision_width: 1_500_000
-  #   precision_step: 100_000
-  #   software_averages: 1
-  #   points: 5
+  resonator_spectroscopy:
+    lowres_width: 5_000_000
+    lowres_step: 2_000_000
+    highres_width: 1_500_000
+    highres_step: 200_000
+    precision_width: 1_500_000
+    precision_step: 100_000
+    software_averages: 2
+    points: 5
 
   # resonator_punchout:
   #   freq_width: 10_000_000
@@ -95,6 +97,10 @@ actions:
   #   nshots: 1024
   #   points: 1
 
+  # calibrate_qubit_states_binning:
+  #   niter: 1024
+  #   points: 10
+
   # dispersive_shift:
   #   freq_width: 5_000_000
   #   freq_step: 200_000
@@ -152,9 +158,9 @@ actions:
   #   software_averages: 1
   #   points: 5
 
-  spin_echo_3pulses:
-    delay_between_pulses_start: 4
-    delay_between_pulses_end: 20000
-    delay_between_pulses_step: 20
-    software_averages: 1
-    points: 5
+  # spin_echo_3pulses:
+  #   delay_between_pulses_start: 4
+  #   delay_between_pulses_end: 20000
+  #   delay_between_pulses_step: 20
+  #   software_averages: 1
+  #   points: 5

--- a/src/qibocal/cli/_base.py
+++ b/src/qibocal/cli/_base.py
@@ -33,6 +33,12 @@ TARGET_COMPARE_DIR = "qq-compare/"
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.argument("runcard", metavar="RUNCARD", type=click.Path(exists=True))
+@click.argument(
+    "platform_runcard",
+    metavar="PLATFORM_RUNCARD",
+    type=click.Path(exists=True),
+    required=False,
+)
 @click.option(
     "folder",
     "-o",
@@ -45,16 +51,18 @@ TARGET_COMPARE_DIR = "qq-compare/"
     is_flag=True,
     help="Use --force option to overwrite the output folder.",
 )
-def command(runcard, folder, force=None):
+def command(runcard, folder, force=None, platform_runcard=None):
 
     """qibocal: Quantum Calibration Verification and Validation using Qibo.
 
     Arguments:
 
      - RUNCARD: runcard with declarative inputs.
+
+     - PLATFORM_RUNCARD: Qibolab's platform runcard. If not provided Qibocal will use the runcard available in Qibolab for the platform chosen.
     """
 
-    builder = ActionBuilder(runcard, folder, force)
+    builder = ActionBuilder(runcard, folder, force, platform_runcard)
     builder.execute()
     builder.dump_report()
 

--- a/src/qibocal/cli/_base.py
+++ b/src/qibocal/cli/_base.py
@@ -33,12 +33,6 @@ TARGET_COMPARE_DIR = "qq-compare/"
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.argument("runcard", metavar="RUNCARD", type=click.Path(exists=True))
-@click.argument(
-    "platform_runcard",
-    metavar="PLATFORM_RUNCARD",
-    type=click.Path(exists=True),
-    required=False,
-)
 @click.option(
     "folder",
     "-o",
@@ -51,7 +45,7 @@ TARGET_COMPARE_DIR = "qq-compare/"
     is_flag=True,
     help="Use --force option to overwrite the output folder.",
 )
-def command(runcard, folder, force=None, platform_runcard=None):
+def command(runcard, folder, force=None):
 
     """qibocal: Quantum Calibration Verification and Validation using Qibo.
 
@@ -62,7 +56,7 @@ def command(runcard, folder, force=None, platform_runcard=None):
      - PLATFORM_RUNCARD: Qibolab's platform runcard. If not provided Qibocal will use the runcard available in Qibolab for the platform chosen.
     """
 
-    builder = ActionBuilder(runcard, folder, force, platform_runcard)
+    builder = ActionBuilder(runcard, folder, force)
     builder.execute()
     builder.dump_report()
 

--- a/src/qibocal/cli/builders.py
+++ b/src/qibocal/cli/builders.py
@@ -25,12 +25,13 @@ class ActionBuilder:
         force (bool): option to overwrite the output folder if it exists already.
     """
 
-    def __init__(self, runcard, folder=None, force=False, platform_runcard=None):
+    def __init__(self, runcard, folder=None, force=False):
         path, self.folder = self._generate_output_folder(folder, force)
         self.runcard = load_yaml(runcard)
         # Qibolab default backend if not provided in runcard.
         backend_name = self.runcard.get("backend", "qibolab")
         platform_name = self.runcard.get("platform", "dummy")
+        platform_runcard = self.runcard.get("runcard", None)
         self.backend, self.platform = self._allocate_backend(
             backend_name, platform_name, path, platform_runcard
         )


### PR DESCRIPTION
This PR closes #181.
Now it will be possible to specify the platform runcard path in the qq runcard:

```yaml
platform: tii1q_b1

runcard: <path_to_runcard>

qubits: [0]

format: csv

actions:
  resonator_spectroscopy:
    lowres_width: 5_000_000
    lowres_step: 2_000_000
    highres_width: 1_500_000
    highres_step: 200_000
    precision_width: 1_500_000
    precision_step: 100_000
    software_averages: 2
    points: 5
```

`qq` will correctly modify the parameters of the platform runcard provided (I've performed a quick test using the `tii1q_b1` platform using qiboteam/qibolab#255).
We will need to update the documentation. I prefer to do this directly in #121.


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [ ] Documentation is updated. ( This will be done in #121)
