### PR TITLE
New docs font and version display

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -75,12 +75,17 @@ exclude_patterns = []
 #
 html_theme = "furo"
 
+# custom title
+html_title = "Version " + release
 
+# custom html theme options (colors and font)
 html_theme_options = {
     "light_css_variables": {
         "color-brand-primary": "#6400FF",
         "color-brand-secondary": "#6400FF",
         "color-brand-content": "#6400FF",
+        "font-stack": "Ubuntu",
+        "font-stack--monospace": "Courier, monospace",
     }
 }
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -13,7 +13,6 @@ Qibocal key features:
 * Declarative inputs using runcard.
 * Generation of a report.
 
-This documentation refers to qibocal |release|.
 
 Contents
 ========


### PR DESCRIPTION
In this PR:

- the text font is changed into "Ubuntu";
- the software's version is shown in the side-bar now.