### PR TITLE
Refactor routines in order to work `AbstractPlatform` methods

### DIFF
--- a/runcards/actions_qq_1q.yml
+++ b/runcards/actions_qq_1q.yml
@@ -1,28 +1,28 @@
-platform: tii1q
+platform: tii1q_b1
 
 qubits: [0]
 
 format: csv
 
 actions:
-  # resonator_spectroscopy:
-  #   lowres_width: 5_000_000
-  #   lowres_step: 2_000_000
-  #   highres_width: 1_500_000
-  #   highres_step: 200_000
-  #   precision_width: 1_500_000
-  #   precision_step: 100_000
-  #   software_averages: 1
-  #   points: 5
+  resonator_spectroscopy:
+    lowres_width: 5_000_000
+    lowres_step: 2_000_000
+    highres_width: 1_500_000
+    highres_step: 200_000
+    precision_width: 1_500_000
+    precision_step: 100_000
+    software_averages: 1
+    points: 5
 
-  # resonator_punchout:
-  #   freq_width: 10_000_000
-  #   freq_step: 200_000
-  #   min_att: 0
-  #   max_att: 60
-  #   step_att: 2 # attenuation must be a multiple of 2
-  #   software_averages: 1
-  #   points: 10
+  resonator_punchout:
+    freq_width: 10_000_000
+    freq_step: 200_000
+    min_att: 0
+    max_att: 60
+    step_att: 2 # attenuation must be a multiple of 2
+    software_averages: 1
+    points: 1
 
   # qubit_spectroscopy:
   #   fast_start: -5_000_000
@@ -152,9 +152,9 @@ actions:
   #   software_averages: 1
   #   points: 5
 
-  spin_echo_3pulses:
-    delay_between_pulses_start: 4
-    delay_between_pulses_end: 20000
-    delay_between_pulses_step: 20
-    software_averages: 1
-    points: 5
+  # spin_echo_3pulses:
+  #   delay_between_pulses_start: 4
+  #   delay_between_pulses_end: 20000
+  #   delay_between_pulses_step: 20
+  #   software_averages: 1
+  #   points: 5

--- a/runcards/dummy.yml
+++ b/runcards/dummy.yml
@@ -1,5 +1,3 @@
-#TODO: dummy platform not working!
-
 platform: dummy
 
 qubits: [0]
@@ -16,3 +14,147 @@ actions:
     precision_step: 100_000
     software_averages: 1
     points: 5
+
+  resonator_punchout:
+    freq_width: 10_000_000
+    freq_step: 200_000
+    min_att: 0
+    max_att: 60
+    step_att: 2 # attenuation must be a multiple of 2
+    software_averages: 1
+    points: 1
+
+  # qubit_spectroscopy:
+  #   fast_start: -5_000_000
+  #   fast_end: 5_000_000
+  #   fast_step: 200_000
+  #   precision_start: -500_000
+  #   precision_end: 500_000
+  #   precision_step: 20_000
+  #   software_averages: 1
+  #   points: 10
+
+  # rabi_pulse_amplitude:
+  #   pulse_amplitude_start: 0 # 0<=a<=1
+  #   pulse_amplitude_end: 1
+  #   pulse_amplitude_step: 0.02
+  #   software_averages: 1
+  #   points: 10
+
+  # rabi_pulse_gain:
+  #   pulse_gain_start: 0 # -1.0<=g<=1.0
+  #   pulse_gain_end: 1
+  #   pulse_gain_step: 0.02
+  #   software_averages: 1
+  #   points: 10
+
+  # rabi_pulse_length_and_amplitude:
+  #   pulse_duration_start: 4 # minimum 4ns
+  #   pulse_duration_end: 200
+  #   pulse_duration_step: 4
+  #   pulse_amplitude_start: 0 # -1.0<= amplitude <=1.0
+  #   pulse_amplitude_end: 1
+  #   pulse_amplitude_step: 0.02
+  #   software_averages: 1
+  #   points: 10
+
+  # rabi_pulse_length_and_gain:
+  #   pulse_duration_start: 4 # minimum 4ns
+  #   pulse_duration_end: 200
+  #   pulse_duration_step: 4
+  #   pulse_gain_start: 0 # -1.0<=g<=1.0
+  #   pulse_gain_end: 1
+  #   pulse_gain_step: 0.02
+  #   software_averages: 1
+  #   points: 10
+
+  # rabi_pulse_length:
+  #   pulse_duration_start: 4 # minimum 4ns
+  #   pulse_duration_end: 200
+  #   pulse_duration_step: 4
+  #   software_averages: 1
+  #   points: 10
+
+  # allXY_iteration:
+  #   beta_start: -1
+  #   beta_end: 1
+  #   beta_step: 0.2
+  #   software_averages: 1
+  #   points: 1
+
+  # allXY:
+  #   beta_param: Null
+  #   software_averages: 1
+  #   points: 1
+
+  # calibrate_qubit_states:
+  #   nshots: 1024
+  #   points: 1
+
+  # calibrate_qubit_states_binning:
+  #   nshots: 1024
+  #   points: 1
+
+  # dispersive_shift:
+  #   freq_width: 5_000_000
+  #   freq_step: 200_000
+  #   software_averages: 1
+  #   points: 5
+
+  # flipping:
+  #   niter: 10
+  #   step: 2
+  #   points: 1
+
+  # ramsey_frequency_detuned:
+  #   t_start: 4
+  #   t_end: [2000] #t_end (optimal) = 3.5 * T2 (limited by HW to 8000ns)
+  #   t_step: 16
+  #   n_osc: 4
+  #   software_averages: 1
+  #   points: 1
+
+  # ramsey:
+  #   delay_between_pulses_start: 0 # must be a multiple of 4 incl 0
+  #   delay_between_pulses_end: 4000
+  #   delay_between_pulses_step: 16 # must be a multiple of 4
+  #   software_averages: 1
+  #   points: 1
+
+  # RO_matrix:
+  #   niter: 10 # set niter = 1024 to collect good statistics
+
+  # ro_pulse_phase:
+  #   pulse_phase_start: 0
+  #   pulse_phase_end: 6.28318
+  #   pulse_phase_step: 0.1
+  #   software_averages: 1
+  #   points: 10
+
+  # t1:
+  #   delay_before_readout_start: 4
+  #   delay_before_readout_end: 50_000
+  #   delay_before_readout_step: 500
+  #   software_averages: 1
+  #   points: 5
+
+  # spin_echo:
+  #   delay_between_pulses_start: 4
+  #   delay_between_pulses_end: 4000
+  #   delay_between_pulses_step: 20
+  #   software_averages: 1
+  #   points: 5
+
+  # spin_echo_3pulses:
+  #   delay_between_pulses_start: 4
+  #   delay_between_pulses_end: 30000
+  #   delay_between_pulses_step: 20
+  #   software_averages: 1
+  #   points: 5
+
+  # spin_echo_3pulses:
+  #   delay_between_pulses_start: 4
+  #   delay_between_pulses_end: 20000
+  #   delay_between_pulses_step: 20
+  #   software_averages: 1
+  #   points: 5

--- a/src/qibocal/calibrations/characterization/resonator_spectroscopy.py
+++ b/src/qibocal/calibrations/characterization/resonator_spectroscopy.py
@@ -59,7 +59,6 @@ def resonator_spectroscopy(
                 )
 
             platform.set_lo_frequency(qubit, freq - ro_pulse.frequency)
-            log.debug(platform.execute_pulse_sequence(sequence))
             msr, phase, i, q = platform.execute_pulse_sequence(sequence)[
                 ro_pulse.serial
             ]
@@ -245,14 +244,7 @@ def resonator_spectroscopy_flux(
                 results = {
                     "MSR[V]": msr,
                     "i[V]": i,
-                    "q[V]": q,  # resonator_punchout:
-                    #   freq_width: 10_000_000
-                    #   freq_step: 200_000
-                    #   min_att: 0
-                    #   max_att: 60
-                    #   step_att: 2 # attenuation must be a multiple of 2
-                    #   software_averages: 1
-                    #   points: 1
+                    "q[V]": q,
                     "phase[rad]": phase,
                     "frequency[Hz]": freq,
                     "current[A]": curr,

--- a/src/qibocal/calibrations/characterization/resonator_spectroscopy.py
+++ b/src/qibocal/calibrations/characterization/resonator_spectroscopy.py
@@ -29,10 +29,9 @@ def resonator_spectroscopy(
     ro_pulse = platform.create_qubit_readout_pulse(qubit, start=0)
     sequence.add(ro_pulse)
 
-    resonator_frequency = platform.characterization["single_qubit"][qubit][
-        "resonator_freq"
-    ]
+    resonator_frequency = platform.get_resonator_frequency(qubit)
 
+    # TODO: is this parameter necessary
     qrm_LO = platform.qrm[qubit].ports["o1"].lo_frequency
 
     frequency_range = (
@@ -59,7 +58,7 @@ def resonator_spectroscopy(
                     qrm_lo=qrm_LO,
                 )
 
-            platform.ro_port[qubit].lo_frequency = freq - ro_pulse.frequency
+            platform.set_lo_frequency(qubit, freq - ro_pulse.frequency)
             msr, phase, i, q = platform.execute_pulse_sequence(sequence)[
                 ro_pulse.serial
             ]
@@ -118,7 +117,8 @@ def resonator_spectroscopy(
                     qrm_lo=qrm_LO,
                 )
 
-            platform.ro_port[qubit].lo_frequency = freq - ro_pulse.frequency
+            # platform.ro_port[qubit].lo_frequency = freq - ro_pulse.frequency
+            platform.set_lo_frequency(qubit, freq - ro_pulse.frequency)
             msr, phase, i, q = platform.execute_pulse_sequence(sequence)[
                 ro_pulse.serial
             ]


### PR DESCRIPTION
This PR is closely related to qiboteam/qibolab#262.
The following routines have been updated and they currently work with `tii1q_b1` and with the `dummy` platform in qibolab.

- [x] resonator_spectroscopy
- [x] resonator_punchout

If we like this approach I will continue to modify the other calibration routines.
Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
