### PR TITLE
Refactor qubit biassing port

### DIFF
--- a/src/qibocal/calibrations/characterization/qubit_spectroscopy.py
+++ b/src/qibocal/calibrations/characterization/qubit_spectroscopy.py
@@ -368,7 +368,7 @@ def qubit_spectroscopy_flux(
         for fluxline in fluxlines:
             for current in current_ranges[fluxline]:
                 # set new flux current
-                platform.qf_port[fluxline].current = current
+                platform.qb_port[fluxline].current = current
 
                 # TODO: adjust resonator frequency if coefs available in the runcard
                 # coefs should be determined in resonator_spectroscopy_flux

--- a/src/qibocal/calibrations/characterization/resonator_spectroscopy.py
+++ b/src/qibocal/calibrations/characterization/resonator_spectroscopy.py
@@ -516,7 +516,7 @@ def resonator_spectroscopy_flux(
         for fluxline in fluxlines:
             for current in current_ranges[fluxline]:
                 # set new flux current
-                platform.qf_port[fluxline].current = current
+                platform.qb_port[fluxline].current = current
                 for delta_freq in delta_frequency_range:
                     # save data as often as defined by points
                     if count % points == 0:


### PR DESCRIPTION
Hi,
This PR modifies the names of the qubit biassing ports (from `qf_port` to `qb_port`), so that it works with the minor refactor introduced in qibolab PR#242 Adding the offsets to platforms.
As you may see it only affects the flux spectroscopies.
Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
