### PR TITLE
Fix pulse sequence creation in Rabi routines

### DIFF
--- a/src/qibocal/calibrations/characterization/rabi.py
+++ b/src/qibocal/calibrations/characterization/rabi.py
@@ -192,8 +192,10 @@ def rabi_pulse_gain(
     qd_pulses = {}
     ro_pulses = {}
     for qubit in qubits:
-        qd_pulses[qubit] = platform.create_qubit_drive_pulse(qubit, start=0, duration=4)
-        ro_pulses[qubit] = platform.create_qubit_readout_pulse(qubit, start=4)
+        qd_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
+        ro_pulses[qubit] = platform.create_qubit_readout_pulse(
+            qubit, start=qd_pulses[qubit].finish
+        )
         sequence.add(qd_pulses[qubit])
         sequence.add(ro_pulses[qubit])
 
@@ -320,8 +322,10 @@ def rabi_pulse_amplitude(
     qd_pulses = {}
     ro_pulses = {}
     for qubit in qubits:
-        qd_pulses[qubit] = platform.create_qubit_drive_pulse(qubit, start=0, duration=4)
-        ro_pulses[qubit] = platform.create_qubit_readout_pulse(qubit, start=4)
+        qd_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
+        ro_pulses[qubit] = platform.create_qubit_readout_pulse(
+            qubit, start=qd_pulses[qubit].finish
+        )
         sequence.add(qd_pulses[qubit])
         sequence.add(ro_pulses[qubit])
 
@@ -445,8 +449,10 @@ def rabi_pulse_length_and_gain(
     qd_pulses = {}
     ro_pulses = {}
     for qubit in qubits:
-        qd_pulses[qubit] = platform.create_qubit_drive_pulse(qubit, start=0, duration=4)
-        ro_pulses[qubit] = platform.create_qubit_readout_pulse(qubit, start=4)
+        qd_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
+        ro_pulses[qubit] = platform.create_qubit_readout_pulse(
+            qubit, start=qd_pulses[qubit].finish
+        )
         sequence.add(qd_pulses[qubit])
         sequence.add(ro_pulses[qubit])
 
@@ -553,8 +559,10 @@ def rabi_pulse_length_and_amplitude(
     qd_pulses = {}
     ro_pulses = {}
     for qubit in qubits:
-        qd_pulses[qubit] = platform.create_qubit_drive_pulse(qubit, start=0, duration=4)
-        ro_pulses[qubit] = platform.create_qubit_readout_pulse(qubit, start=4)
+        qd_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
+        ro_pulses[qubit] = platform.create_qubit_readout_pulse(
+            qubit, start=qd_pulses[qubit].finish
+        )
         sequence.add(qd_pulses[qubit])
         sequence.add(ro_pulses[qubit])
 


### PR DESCRIPTION
Hi, 
This PR fixes a bug in the creation of the pulse sequences in some Rabi experiments that was introduced in PR #155.
Thanks @maxhant 
Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
