### PR TITLE
Fix `update_platform_runcard` method

### DIFF
--- a/runcards/actions_qq_1q.yml
+++ b/runcards/actions_qq_1q.yml
@@ -1,8 +1,8 @@
-platform: qblox
+platform: tii1q_b1
 
 # runcard: tii1q_b1.yml
 
-qubits: [q0]
+qubits: [0]
 
 format: csv
 
@@ -61,13 +61,13 @@ actions:
   #   software_averages: 1
   #   points: 5
 
-  # qubit_spectroscopy: # narrow
-  #   fast_width: 5_000_000
-  #   fast_step: 500_000
-  #   precision_width: 400_000
-  #   precision_step: 20_000
-  #   software_averages: 2
-  #   points: 5
+  qubit_spectroscopy: # narrow
+    fast_width: 5_000_000
+    fast_step: 500_000
+    precision_width: 400_000
+    precision_step: 20_000
+    software_averages: 2
+    points: 5
 
   # qubit_spectroscopy_flux: # precission
   #   freq_width: 5_000_000

--- a/src/qibocal/calibrations/characterization/qubit_spectroscopy.py
+++ b/src/qibocal/calibrations/characterization/qubit_spectroscopy.py
@@ -204,7 +204,7 @@ def qubit_spectroscopy(
                     y="MSR[uV]",
                     qubits=qubits,
                     resonator_type=platform.resonator_type,
-                    labels=["resonator_freq", "peak_voltage", "intermediate_freq"],
+                    labels=["qubit_freq", "peak_voltage", "intermediate_freq"],
                 )
             # reconfigure the instrument based on the new resonator frequency
             # in this case setting the local oscillators
@@ -243,7 +243,7 @@ def qubit_spectroscopy(
         y="MSR[uV]",
         qubits=qubits,
         resonator_type=platform.resonator_type,
-        labels=["resonator_freq", "peak_voltage", "intermediate_freq"],
+        labels=["qubit_freq", "peak_voltage", "intermediate_freq"],
     )
 
 

--- a/src/qibocal/cli/builders.py
+++ b/src/qibocal/cli/builders.py
@@ -127,12 +127,8 @@ class ActionBuilder:
         for param in list(sig.parameters)[2:-1]:
             if param not in params:
                 raise_error(AttributeError, f"Missing parameter {param} in runcard.")
-        if f.__annotations__["qubits"] == int:
-            single_qubit_action = True
-        else:
-            single_qubit_action = False
 
-        return f, params, path, single_qubit_action
+        return f, params, path
 
     def execute(self):
         """Method to execute sequentially all the actions in the runcard."""
@@ -142,41 +138,31 @@ class ActionBuilder:
             self.platform.start()
 
         for action in self.runcard["actions"]:
-            routine, args, path, single_qubit_action = self._build_single_action(action)
-            self._execute_single_action(routine, args, path, single_qubit_action)
+            routine, args, path = self._build_single_action(action)
+            self._execute_single_action(routine, args, path)
 
         if self.platform is not None:
             self.platform.stop()
             self.platform.disconnect()
 
-    def _execute_single_action(self, routine, arguments, path, single_qubit):
+    def _execute_single_action(self, routine, arguments, path):
         """Method to execute a single action and retrieving the results."""
         if self.format is None:
             raise_error(ValueError, f"Cannot store data using {self.format} format.")
-        if single_qubit:
-            for qubit in self.qubits:
-                results = routine(self.platform, qubit, **arguments)
 
-                for data in results:
-                    getattr(data, f"to_{self.format}")(path)
+        results = routine(self.platform, qubit, **arguments)
 
-                if self.platform is not None:
-                    self.update_platform_runcard(qubit, routine.__name__)
-        else:
-            results = routine(self.platform, self.qubits, **arguments)
+        for data in results:
+            getattr(data, f"to_{self.format}")(path)
 
-            for data in results:
-                getattr(data, f"to_{self.format}")(path)
-
-            # if self.platform is not None:
-            #     self.update_platform_runcard(qubit, routine.__name__)
+        for qubit in self.qubits:
+            if self.platform is not None:
+                self.update_platform_runcard(qubit, routine.__name__)
 
     def update_platform_runcard(self, qubit, routine):
-
         try:
-            data_fit = Data.load_data(
-                self.folder, "data", routine, self.format, f"fit_q{qubit}"
-            )
+            data_fit = Data.load_data(self.folder, "data", routine, self.format, "fits")
+            data_fit.df = data_fit.df[data_fit.df["qubit"] == qubit]
         except:
             data_fit = Data()
 

--- a/src/qibocal/cli/builders.py
+++ b/src/qibocal/cli/builders.py
@@ -140,6 +140,10 @@ class ActionBuilder:
         for action in self.runcard["actions"]:
             routine, args, path = self._build_single_action(action)
             self._execute_single_action(routine, args, path)
+            for qubit in self.qubits:
+                if self.platform is not None:
+                    print(action)
+                    self.update_platform_runcard(qubit, action)
 
         if self.platform is not None:
             self.platform.stop()
@@ -155,10 +159,6 @@ class ActionBuilder:
         for data in results:
             getattr(data, f"to_{self.format}")(path)
 
-        for qubit in self.qubits:
-            if self.platform is not None:
-                self.update_platform_runcard(qubit, routine.__name__)
-
     def update_platform_runcard(self, qubit, routine):
         try:
             data_fit = Data.load_data(self.folder, "data", routine, self.format, "fits")
@@ -166,7 +166,9 @@ class ActionBuilder:
         except:
             data_fit = Data()
 
-        params = [i for i in list(data_fit.df.keys()) if "popt" not in i]
+        params = [
+            i for i in list(data_fit.df.keys()) if "popt" not in i and i != "qubit"
+        ]
         settings = load_yaml(f"{self.folder}/new_platform.yml")
 
         for param in params:

--- a/src/qibocal/cli/builders.py
+++ b/src/qibocal/cli/builders.py
@@ -142,7 +142,6 @@ class ActionBuilder:
             self._execute_single_action(routine, args, path)
             for qubit in self.qubits:
                 if self.platform is not None:
-                    print(action)
                     self.update_platform_runcard(qubit, action)
 
         if self.platform is not None:

--- a/src/qibocal/cli/builders.py
+++ b/src/qibocal/cli/builders.py
@@ -150,7 +150,7 @@ class ActionBuilder:
         if self.format is None:
             raise_error(ValueError, f"Cannot store data using {self.format} format.")
 
-        results = routine(self.platform, qubit, **arguments)
+        results = routine(self.platform, self.qubits, **arguments)
 
         for data in results:
             getattr(data, f"to_{self.format}")(path)


### PR DESCRIPTION
Fixes the behavior of the method `update_platform_runcard` of the `ActionBuilder` that was broken after merging PR #155. After executing all the calibration routines the user will find in the output folder a file `new_platform.yml` with an updated platform runcard. All the parameters in the runcard are updated sequentially.

I've fixed in a typo in the routine `qubit_spectroscopy`.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
