### PR TITLE
Fix allXY plot label and plot

### DIFF
--- a/src/qibocal/calibrations/characterization/allXY.py
+++ b/src/qibocal/calibrations/characterization/allXY.py
@@ -100,15 +100,15 @@ def allXY(
 
             # retrieve the results for every qubit
             for ro_pulse in ro_pulses.values():
-                r = results[ro_pulse.serial].to_dict_probability(state=0)
+                z_proj = 2 * results[ro_pulse.serial].ground_state_probability - 1
                 # store the results
-                r.update(
-                    {
-                        "gateNumber": gateNumber,
-                        "qubit": ro_pulse.qubit,
-                        "iteration": iteration,
-                    }
-                )
+                r = {
+                    "probability": z_proj,
+                    "gateNumber": gateNumber,
+                    "beta_param": beta_param,
+                    "qubit": ro_pulse.qubit,
+                    "iteration": iteration,
+                }
                 data.add(r)
             count += 1
             gateNumber += 1
@@ -193,16 +193,15 @@ def allXY_drag_pulse_tuning(
 
                 # retrieve the results for every qubit
                 for ro_pulse in ro_pulses.values():
-                    r = results[ro_pulse.serial].to_dict_probability(state=0)
+                    z_proj = 2 * results[ro_pulse.serial].ground_state_probability - 1
                     # store the results
-                    r.update(
-                        {
-                            "gateNumber": gateNumber,
-                            "beta_param": beta_param,
-                            "qubit": ro_pulse.qubit,
-                            "iteration": iteration,
-                        }
-                    )
+                    r = {
+                        "probability": z_proj,
+                        "gateNumber": gateNumber,
+                        "beta_param": beta_param,
+                        "qubit": ro_pulse.qubit,
+                        "iteration": iteration,
+                    }
                     data.add(r)
                 count += 1
                 gateNumber += 1

--- a/src/qibocal/plots/allXY.py
+++ b/src/qibocal/plots/allXY.py
@@ -110,11 +110,20 @@ def allXY(folder, routine, qubit, format):
         col=1,
     )
 
+    fig.add_hline(
+        y=-1,
+        line_width=2,
+        line_dash="dash",
+        line_color="grey",
+        row=1,
+        col=1,
+    )
+
     fig.update_layout(
         showlegend=True,
         uirevision="0",  # ``uirevision`` allows zooming while live plotting
         xaxis_title="Gate sequence number",
-        yaxis_title="Z projection probability of qubit state |o>",
+        yaxis_title="Expectation value of Z",
     )
     return fig
 
@@ -194,11 +203,20 @@ def allXY_drag_pulse_tuning(folder, routine, qubit, format):
         col=1,
     )
 
+    fig.add_hline(
+        y=-1,
+        line_width=2,
+        line_dash="dash",
+        line_color="grey",
+        row=1,
+        col=1,
+    )
+
     fig.update_layout(
         showlegend=True,
         uirevision="0",  # ``uirevision`` allows zooming while live plotting
         xaxis_title="Gate sequence number",
-        yaxis_title="Z projection probability of qubit state |o>",
+        yaxis_title="Expectation value of Z",
     )
     return fig
 


### PR DESCRIPTION
After merging #189 I changed the allXY routines because I thought that in the y axis we were supposed to plot the probability of the ground state (I got confused by the label in the plot). This PR fixes this issue.
Moreover, I changed the y label of the plot to "Expectation value of Z" to avoid future misunderstandings.

![image](https://user-images.githubusercontent.com/49183315/214577398-3dce8193-03ed-4cf0-a136-5c5c87a60940.png)


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [ ] Coverage does not decrease.
- [x] Documentation is updated.
