### PR TITLE
Fix ramsey plotting bug

### DIFF
--- a/src/qibocal/plots/ramsey.py
+++ b/src/qibocal/plots/ramsey.py
@@ -40,14 +40,14 @@ def time_msr(folder, routine, qubit, format):
         except:
             data_fit = Data(
                 quantities=[
+                    "T2",
+                    "drive_frequency",
+                    "delta_frequency",                 
                     "popt0",
                     "popt1",
                     "popt2",
                     "popt3",
                     "popt4",
-                    "label1",
-                    "label2",
-                    "label3",
                     "qubit",
                 ]
             )
@@ -121,16 +121,16 @@ def time_msr(folder, routine, qubit, format):
                 row=1,
                 col=1,
             )
-
+            corrected_qubit_frequency = params['delta_frequency'] + params['drive_frequency']
             fitting_report = (
                 fitting_report
                 + (
                     f"q{qubit}/r{report_n} | delta_frequency: {params['delta_frequency']:,.0f} Hz<br>"
                 )
                 + (
-                    f"q{qubit}/r{report_n} | corrected_qubit_frequency: {params['corrected_qubit_frequency']:,.0f} Hz<br>"
+                    f"q{qubit}/r{report_n} | corrected_qubit_frequency: {corrected_qubit_frequency:,.0f} Hz<br>"
                 )
-                + (f"q{qubit}/r{report_n} | t2: {params['t2']:,.0f} ns.<br><br>")
+                + (f"q{qubit}/r{report_n} | t2: {params['T2']:,.0f} ns.<br><br>")
             )
         report_n += 1
 

--- a/src/qibocal/plots/ramsey.py
+++ b/src/qibocal/plots/ramsey.py
@@ -42,7 +42,7 @@ def time_msr(folder, routine, qubit, format):
                 quantities=[
                     "T2",
                     "drive_frequency",
-                    "delta_frequency",                 
+                    "delta_frequency",
                     "popt0",
                     "popt1",
                     "popt2",
@@ -121,7 +121,9 @@ def time_msr(folder, routine, qubit, format):
                 row=1,
                 col=1,
             )
-            corrected_qubit_frequency = params['delta_frequency'] + params['drive_frequency']
+            corrected_qubit_frequency = (
+                params["delta_frequency"] + params["drive_frequency"]
+            )
             fitting_report = (
                 fitting_report
                 + (

--- a/src/qibocal/plots/ramsey.py
+++ b/src/qibocal/plots/ramsey.py
@@ -121,16 +121,14 @@ def time_msr(folder, routine, qubit, format):
                 row=1,
                 col=1,
             )
-            corrected_qubit_frequency = (
-                params["delta_frequency"] + params["drive_frequency"]
-            )
+
             fitting_report = (
                 fitting_report
                 + (
                     f"q{qubit}/r{report_n} | delta_frequency: {params['delta_frequency']:,.0f} Hz<br>"
                 )
                 + (
-                    f"q{qubit}/r{report_n} | corrected_qubit_frequency: {corrected_qubit_frequency:,.0f} Hz<br>"
+                    f"q{qubit}/r{report_n} | drive_frequency: {params['drive_frequency']:,.0f} Hz<br>"
                 )
                 + (f"q{qubit}/r{report_n} | t2: {params['T2']:,.0f} ns.<br><br>")
             )


### PR DESCRIPTION
Fix a plotting bug probably due to some change. Here is the error message:
```
raceback (most recent call last):
  File "/home/users/maxime.hantute/.conda/envs/test/bin/qq", line 6, in <module>
    sys.exit(command())
  File "/home/users/maxime.hantute/.conda/envs/test/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/users/maxime.hantute/.conda/envs/test/lib/python3.9/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/users/maxime.hantute/.conda/envs/test/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/users/maxime.hantute/.conda/envs/test/lib/python3.9/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/nfs/users/maxime.hantute/qibocal/src/qibocal/cli/_base.py", line 59, in command
    builder.execute()
  File "/nfs/users/maxime.hantute/qibocal/src/qibocal/cli/builders.py", line 264, in execute
    self.dump_report(actions)
  File "/nfs/users/maxime.hantute/qibocal/src/qibocal/cli/builders.py", line 301, in dump_report
    create_report(self.folder, actions)
  File "/nfs/users/maxime.hantute/qibocal/src/qibocal/web/report.py", line 20, in create_report
    html = template.render(
  File "/home/users/maxime.hantute/.conda/envs/test/lib/python3.9/site-packages/jinja2/environment.py", line 1301, in render
    self.environment.handle_exception()
  File "/home/users/maxime.hantute/.conda/envs/test/lib/python3.9/site-packages/jinja2/environment.py", line 936, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/nfs/users/maxime.hantute/qibocal/src/qibocal/web/templates/template.html", line 189, in top-level template code
    {{ report.get_figure(routine, method, qubit) }}
  File "/nfs/users/maxime.hantute/qibocal/src/qibocal/cli/builders.py", line 359, in get_figure
    figures, _ = method(self.path, routine.__name__, qubit, self.format)
  File "/nfs/users/maxime.hantute/qibocal/src/qibocal/plots/ramsey.py", line 132, in time_msr
    f"q{qubit}/r{report_n} | corrected_qubit_frequency: {params['corrected_qubit_frequency']:,.0f} Hz<br>"
KeyError: 'corrected_qubit_frequency'
```

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
