### PR TITLE
add poetry-extras input in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,4 +34,5 @@ jobs:
       package-manager: "poetry"
       dependency-path: "**/poetry.lock"
       trigger-label: "${{needs.evaluate-label.outputs.label}}"
+      poetry-extras: --with docs
       project: qibocal


### PR DESCRIPTION
This PR fixes the failure of the [publish workflow ](https://github.com/qiboteam/qibocal/actions/runs/4424960162/jobs/7759427273#step:6:147).
Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
