### PR TITLE
replace ro_pulses[qubit].frequency with ro_pulse.frequency

### DIFF
--- a/src/qibocal/calibrations/characterization/resonator_spectroscopy.py
+++ b/src/qibocal/calibrations/characterization/resonator_spectroscopy.py
@@ -599,7 +599,7 @@ def dispersive_shift(
                     # store the results
                     r.update(
                         {
-                            "frequency[Hz]": ro_pulses[qubit].frequency,
+                            "frequency[Hz]": ro_pulse.frequency,
                             "qubit": ro_pulse.qubit,
                             "iteration": iteration,
                         }


### PR DESCRIPTION
This PR fixes a bug in the `dispersive_shift()` routine, that manifested when performing multiplexed scans.
With the bug, the would wrongly save the frequency of the last qubit for all qubits.


Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
