### PR TITLE
Fix Chevron

### DIFF
--- a/src/qibocal/calibrations/characterization/chevron.py
+++ b/src/qibocal/calibrations/characterization/chevron.py
@@ -66,10 +66,10 @@ def tune_transition(
         (highfreq, lowfreq), start=initialize_1.finish
     )
     measure_lowfreq = platform.create_qubit_readout_pulse(
-        lowfreq, start=flux_sequence.finish
+        lowfreq, start=flux_sequence.qf_pulses[-1].se_finish
     )
     measure_highfreq = platform.create_qubit_readout_pulse(
-        highfreq, start=flux_sequence.finish
+        highfreq, start=flux_sequence.qf_pulses[-1].se_finish
     )
 
     data = DataUnits(


### PR DESCRIPTION
@igres26 spotted a bug in the current implementation of the chevron routine. The start of the readout pulses was not shifting as the duration of the flux pulse was being swept.
This PR fixes it by making use of the flux pulse symbolic expression attribute `se_finish`:
```python
    measure_lowfreq = platform.create_qubit_readout_pulse(
        lowfreq, start=flux_sequence.qf_pulses[-1].se_finish
    )
    measure_highfreq = platform.create_qubit_readout_pulse(
        highfreq, start=flux_sequence.qf_pulses[-1].se_finish
    )
```

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
