### PR TITLE
Chevron with duration sweeper

### DIFF
--- a/src/qibocal/calibrations/characterization/chevron.py
+++ b/src/qibocal/calibrations/characterization/chevron.py
@@ -50,17 +50,16 @@ def tune_transition(
         raise NotImplementedError
 
     qubit = list(qubits.keys())[0]
+    highfreq = "A3"
+    lowfreq = qubit
+    # if qubit > 2:
+    #    highfreq = qubit
+    #    lowfreq = 2
 
     platform.reload_settings()
 
-    initialize_1 = platform.create_RX_pulse(qubit, start=0, relative_phase=0)
-    initialize_2 = platform.create_RX_pulse(2, start=0, relative_phase=0)
-
-    highfreq = 2
-    lowfreq = qubit
-    if qubit > 2:
-        highfreq = qubit
-        lowfreq = 2
+    initialize_1 = platform.create_RX_pulse(lowfreq, start=0, relative_phase=0)
+    initialize_2 = platform.create_RX_pulse(highfreq, start=0, relative_phase=0)
 
     flux_sequence, _ = platform.create_CZ_pulse_sequence(
         (highfreq, lowfreq), start=initialize_1.finish
@@ -107,7 +106,7 @@ def tune_transition(
     amplitude_sweeper = Sweeper(Parameter.amplitude, amplitudes, pulses=[flux_pulse])
 
     results = platform.sweep(
-        sequence, duration_sweeper, amplitude_sweeper, nshots=1, relaxation_time=0
+        sequence, amplitude_sweeper, duration_sweeper, nshots=1, relaxation_time=0
     )
 
     res_temp = results[measure_lowfreq.serial].to_dict(average=False)

--- a/src/qibocal/plots/chevron.py
+++ b/src/qibocal/plots/chevron.py
@@ -10,11 +10,11 @@ from qibocal.plots.utils import get_data_subfolders
 
 def landscape_2q_gate(folder, routine, qubit, format):
     fitting_report = "No fitting data"
-    highfreq = 2
+    highfreq = "A3"
     lowfreq = qubit
-    if qubit > 2:
-        highfreq = qubit
-        lowfreq = 2
+    # if qubit > 2:
+    #    highfreq = qubit
+    #    lowfreq = 2
 
     subfolder = get_data_subfolders(folder)[0]
     data = DataUnits.load_data(
@@ -97,11 +97,11 @@ def landscape_2q_gate(folder, routine, qubit, format):
 
 def duration_amplitude_msr_flux_pulse(folder, routine, qubit, format):
     fitting_report = "No fitting data"
-    highfreq = 2
+    highfreq = "A3"
     lowfreq = qubit
-    if qubit > 2:
-        highfreq = qubit
-        lowfreq = 2
+    # if qubit > 2:
+    #    highfreq = qubit
+    #    lowfreq = 2
 
     subfolder = get_data_subfolders(folder)[0]
     data = DataUnits.load_data(
@@ -160,11 +160,11 @@ def duration_amplitude_msr_flux_pulse(folder, routine, qubit, format):
 
 def duration_amplitude_I_flux_pulse(folder, routine, qubit, format):
     fitting_report = "No fitting data"
-    highfreq = 2
+    highfreq = "A3"
     lowfreq = qubit
-    if qubit > 2:
-        highfreq = qubit
-        lowfreq = 2
+    # if qubit > 2:
+    #    highfreq = qubit
+    #    lowfreq = 2
 
     subfolder = get_data_subfolders(folder)[0]
     data = DataUnits.load_data(
@@ -223,11 +223,11 @@ def duration_amplitude_I_flux_pulse(folder, routine, qubit, format):
 
 def duration_amplitude_Q_flux_pulse(folder, routine, qubit, format):
     fitting_report = "No fitting data"
-    highfreq = 2
+    highfreq = "A3"
     lowfreq = qubit
-    if qubit > 2:
-        highfreq = qubit
-        lowfreq = 2
+    # if qubit > 2:
+    #    highfreq = qubit
+    #    lowfreq = 2
 
     subfolder = get_data_subfolders(folder)[0]
     data = DataUnits.load_data(


### PR DESCRIPTION
Updates the Chevron routine to use the duration sweeper implemented in qiboteam/qibolab#371. I have not tested this on hardware because it requires some modifications in order to execute on qw25q (new runcard / crossing points / qubit names). It seems to work as expected on the simulator.

@igres26 @maxhant give a try if you want. I am not sure how much performance will improve compared to not using sweeper for duration, as we do now.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
