### PR TITLE
Fix Classification Parameters closes #305

### DIFF
--- a/src/qibocal/fitting/methods.py
+++ b/src/qibocal/fitting/methods.py
@@ -1027,9 +1027,7 @@ def calibrate_qubit_states_fit(data, x, y, nshots, qubits, degree=True):
         iq_mean_state0 = np.mean(iq_state0)
         origin = iq_mean_state0
 
-        iq_state0_translated = iq_state0 - origin
-        iq_state1_translated = iq_state1 - origin
-        rotation_angle = np.angle(np.mean(iq_state1_translated))
+        rotation_angle = np.angle(np.mean(iq_state1 - origin))
 
         iq_state1_rotated = iq_state1 * np.exp(-1j * rotation_angle)
         iq_state0_rotated = iq_state0 * np.exp(-1j * rotation_angle)

--- a/src/qibocal/fitting/methods.py
+++ b/src/qibocal/fitting/methods.py
@@ -1025,9 +1025,8 @@ def calibrate_qubit_states_fit(data, x, y, nshots, qubits, degree=True):
 
         iq_mean_state1 = np.mean(iq_state1)
         iq_mean_state0 = np.mean(iq_state0)
-        origin = iq_mean_state0
 
-        rotation_angle = np.angle(np.mean(iq_state1 - origin))
+        rotation_angle = np.angle(iq_mean_state1 - iq_mean_state0)
 
         iq_state1_rotated = iq_state1 * np.exp(-1j * rotation_angle)
         iq_state0_rotated = iq_state0 * np.exp(-1j * rotation_angle)

--- a/src/qibocal/fitting/methods.py
+++ b/src/qibocal/fitting/methods.py
@@ -1031,8 +1031,8 @@ def calibrate_qubit_states_fit(data, x, y, nshots, qubits, degree=True):
         iq_state1_translated = iq_state1 - origin
         rotation_angle = np.angle(np.mean(iq_state1_translated))
 
-        iq_state1_rotated = iq_state1_translated * np.exp(-1j * rotation_angle)
-        iq_state0_rotated = iq_state0_translated * np.exp(-1j * rotation_angle)
+        iq_state1_rotated = iq_state1 * np.exp(-1j * rotation_angle)
+        iq_state0_rotated = iq_state0 * np.exp(-1j * rotation_angle)
 
         real_values_state1 = iq_state1_rotated.real
         real_values_state0 = iq_state0_rotated.real
@@ -1060,7 +1060,7 @@ def calibrate_qubit_states_fit(data, x, y, nshots, qubits, degree=True):
         assignment_fidelity = 1 - (errors_state1 + errors_state0) / nshots / 2
         # assignment_fidelity = 1/2 + (cum_distribution_state1[argmax] - cum_distribution_state0[argmax])/nshots/2
         if degree:
-            rotation_angle = (rotation_angle * 360 / (2 * np.pi)) % 360
+            rotation_angle = (-rotation_angle * 360 / (2 * np.pi)) % 360
 
         results = {
             "rotation_angle": rotation_angle,


### PR DESCRIPTION
The PR fixes the bug introduced in the calculation of the rotation angle and threshold of the `calibrate_qubit_states_fit` function.
With this fix, AllXYs work again.

Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
