### PR TITLE
Readout optimization for TWPA

### DIFF
--- a/src/qibocal/calibrations/characterization/ro_optimization.py
+++ b/src/qibocal/calibrations/characterization/ro_optimization.py
@@ -169,7 +169,7 @@ def ro_frequency(
 
     # finally, save the remaining data and the fits
     yield data
-    yield ro_optimization_fit(data, "delta_frequency")
+    yield ro_optimization_fit(data, "state", "qubit", "iteration", "delta_frequency")
 
 
 @plot("Qubit States", plots.ro_amplitude)
@@ -329,4 +329,248 @@ def ro_amplitude(
 
     # finally, save the remaining data and the fits
     yield data
-    yield ro_optimization_fit(data, "delta_amplitude")
+    yield ro_optimization_fit(data, "state", "qubit", "iteration", "delta_amplitude")
+
+
+@plot("TWPA frequency", plots.ro_frequency)
+def twpa_frequency(
+    platform: AbstractPlatform,
+    qubits: list,
+    frequency_width: float,
+    frequency_step: float,
+    nshots,
+):
+    """
+    Method which optimizes the Read-out fidelity by varying the frequency of the TWPA.
+    Two analogous tests are performed for calibrate the ground state and the excited state of the oscillator.
+    The subscripts `exc` and `gnd` will represent the excited state |1> and the ground state |0>.
+    Their distinctiveness is then associated to the fidelity.
+
+    Args:
+        platform (:class:`qibolab.platforms.abstract.AbstractPlatform`): custom abstract platform on which we perform the calibration.
+        qubits (list): List of target qubits to perform the action
+        frequency_width (float): Frequency range to sweep in Hz
+        frequency_step (float): Frequency step to sweep in Hz
+        nshots (int): number of times the pulse sequence will be repeated.
+    Returns:
+        A DataUnits object with the raw data obtained for the fast and precision sweeps with the following keys
+
+            - **MSR[V]**: Resonator signal voltage mesurement in volts
+            - **i[V]**: Resonator signal voltage mesurement for the component I in volts
+            - **q[V]**: Resonator signal voltage mesurement for the component Q in volts
+            - **phase[rad]**: Resonator signal phase mesurement in radians
+            - **iteration[dimensionless]**: Execution number
+            - **qubit**: The qubit being tested
+            - **iteration**: The iteration number of the many determined by software_averages
+
+    """
+
+    # reload instrument settings from runcard
+    platform.reload_settings()
+
+    # create two sequences of pulses:
+    # state0_sequence: I  - MZ
+    # state1_sequence: RX - MZ
+
+    # taking advantage of multiplexing, apply the same set of gates to all qubits in parallel
+    state0_sequence = PulseSequence()
+    state1_sequence = PulseSequence()
+
+    RX_pulses = {}
+    ro_pulses = {}
+    initial_frequency = {}
+    for qubit in qubits:
+        RX_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
+        ro_pulses[qubit] = platform.create_qubit_readout_pulse(
+            qubit, start=RX_pulses[qubit].finish
+        )
+        initial_frequency[qubit] = platform.get_lo_twpa_frequency(qubit)
+
+        state0_sequence.add(ro_pulses[qubit])
+        state1_sequence.add(RX_pulses[qubit])
+        state1_sequence.add(ro_pulses[qubit])
+
+    # create a DataUnits object to store the results
+    data = DataUnits(
+        name="data",
+        quantities={"frequency": "Hz", "delta_frequency": "Hz"},
+        options=["qubit", "iteration", "state"],
+    )
+    data_fit = Data(
+        name="fit",
+        quantities=[
+            "frequency",
+            "delta_frequency",
+            "rotation_angle",
+            "threshold",
+            "fidelity",
+            "assignment_fidelity",
+            "average_state0",
+            "average_state1",
+            "qubit",
+        ],
+    )
+
+    # iterate over the frequency range
+    delta_frequency_range = np.arange(
+        -frequency_width / 2, frequency_width / 2, frequency_step
+    ).astype(int)
+
+    # retrieve and store the results for every qubit
+    for frequency in delta_frequency_range:
+        for qubit in qubits:
+            platform.set_lo_twpa_frequency(qubit, initial_frequency[qubit] + frequency)
+
+        state0_results = platform.execute_pulse_sequence(state0_sequence, nshots=nshots)
+        for qubit in qubits:
+            r = state0_results[ro_pulses[qubit].serial].raw
+            r.update(
+                {
+                    "frequency[Hz]": [platform.get_lo_twpa_frequency(qubit)] * nshots,
+                    "delta_frequency[Hz]": [frequency] * nshots,
+                    "qubit": [qubit] * nshots,
+                    "iteration": np.arange(nshots),
+                    "state": [0] * nshots,
+                }
+            )
+            data.add_data_from_dict(r)
+
+        state1_results = platform.execute_pulse_sequence(state1_sequence, nshots=nshots)
+        for qubit in qubits:
+            r = state1_results[ro_pulses[qubit].serial].raw
+            r.update(
+                {
+                    "frequency[Hz]": [platform.get_lo_twpa_frequency(qubit)] * nshots,
+                    "delta_frequency[Hz]": [frequency] * nshots,
+                    "qubit": [qubit] * nshots,
+                    "iteration": np.arange(nshots),
+                    "state": [1] * nshots,
+                }
+            )
+            data.add_data_from_dict(r)
+
+        # finally, save the remaining data and the fits
+        yield data
+        yield ro_optimization_fit(
+            data, "delta_frequency", "state", "qubit", "iteration"
+        )
+
+
+@plot("TWPA power", plots.ro_power)
+def twpa_power(
+    platform: AbstractPlatform,
+    qubits: list,
+    power_width: float,
+    power_step: float,
+    nshots,
+):
+    """
+    Method which optimizes the Read-out fidelity by varying the power of the TWPA.
+    Two analogous tests are performed for calibrate the ground state and the excited state of the oscillator.
+    The subscripts `exc` and `gnd` will represent the excited state |1> and the ground state |0>.
+    Their distinctiveness is then associated to the fidelity.
+
+    Args:
+        platform (:class:`qibolab.platforms.abstract.AbstractPlatform`): custom abstract platform on which we perform the calibration.
+        qubits (list): List of target qubits to perform the action
+        power_width (float): width of the power range to be scanned in dBm
+        power_step (float): step of the power range to be scanned in dBm
+        nshots (int): number of times the pulse sequence will be repeated.
+    Returns:
+        A DataUnits object with the raw data obtained for the fast and precision sweeps with the following keys
+
+            - **MSR[V]**: Resonator signal voltage mesurement in volts
+            - **i[V]**: Resonator signal voltage mesurement for the component I in volts
+            - **q[V]**: Resonator signal voltage mesurement for the component Q in volts
+            - **phase[rad]**: Resonator signal phase mesurement in radians
+            - **iteration[dimensionless]**: Execution number
+            - **qubit**: The qubit being tested
+            - **iteration**: The iteration number of the many determined by software_averages
+
+    """
+
+    # reload instrument settings from runcard
+    platform.reload_settings()
+
+    # create two sequences of pulses:
+    # state0_sequence: I  - MZ
+    # state1_sequence: RX - MZ
+
+    # taking advantage of multiplexing, apply the same set of gates to all qubits in parallel
+    state0_sequence = PulseSequence()
+    state1_sequence = PulseSequence()
+
+    RX_pulses = {}
+    ro_pulses = {}
+    initial_power = {}
+    for qubit in qubits:
+        RX_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
+        ro_pulses[qubit] = platform.create_qubit_readout_pulse(
+            qubit, start=RX_pulses[qubit].finish
+        )
+        initial_power[qubit] = platform.get_lo_twpa_power(qubit)
+
+        state0_sequence.add(ro_pulses[qubit])
+        state1_sequence.add(RX_pulses[qubit])
+        state1_sequence.add(ro_pulses[qubit])
+
+    # create a DataUnits object to store the results
+    data = DataUnits(
+        name="data",
+        quantities={"power": "dBm", "delta_power": "dBm"},
+        options=["qubit", "iteration", "state"],
+    )
+    data_fit = Data(
+        name="fit",
+        quantities=[
+            "power",
+            "delta_power",
+            "rotation_angle",
+            "threshold",
+            "fidelity",
+            "assignment_fidelity",
+            "average_state0",
+            "average_state1",
+            "qubit",
+        ],
+    )
+
+    # iterate over the power range
+    delta_power_range = np.arange(-power_width / 2, power_width / 2, power_step)
+
+    # retrieve and store the results for every qubit
+    for power in delta_power_range:
+        for qubit in qubits:
+            platform.set_lo_twpa_power(qubit, initial_power[qubit] + power)
+
+        state0_results = platform.execute_pulse_sequence(state0_sequence, nshots=nshots)
+        for qubit in qubits:
+            r = state0_results[ro_pulses[qubit].serial].raw
+            r.update(
+                {
+                    "power[dBm]": [platform.get_lo_twpa_power(qubit)] * nshots,
+                    "delta_power[dBm]": [power] * nshots,
+                    "qubit": [qubit] * nshots,
+                    "iteration": np.arange(nshots),
+                    "state": [0] * nshots,
+                }
+            )
+            data.add_data_from_dict(r)
+
+        state1_results = platform.execute_pulse_sequence(state1_sequence, nshots=nshots)
+        for qubit in qubits:
+            r = state1_results[ro_pulses[qubit].serial].raw
+            r.update(
+                {
+                    "power[dBm]": [platform.get_lo_twpa_power(qubit)] * nshots,
+                    "delta_power[dBm]": [power] * nshots,
+                    "qubit": [qubit] * nshots,
+                    "iteration": np.arange(nshots),
+                    "state": [1] * nshots,
+                }
+            )
+            data.add_data_from_dict(r)
+
+        # finally, save the remaining data and the fits
+        yield data
+        yield ro_optimization_fit(data, "delta_power", "state", "qubit", "iteration")

--- a/src/qibocal/plots/ro_optimization.py
+++ b/src/qibocal/plots/ro_optimization.py
@@ -171,7 +171,8 @@ def ro_frequency(folder, routine, qubit, format):
     title_text += f"q{qubit}/r{report_n} | average state 1: ({complex(fit_data['average_state1'].to_numpy()[0]):.6f})<br>"
     title_text += f"q{qubit}/r{report_n} | rotation angle: {float(fit_data['rotation_angle'].to_numpy()[0]):.3f} | threshold = {float(fit_data['threshold'].to_numpy()[0]):.6f}<br>"
     title_text += f"q{qubit}/r{report_n} | fidelity: {float(fit_data['fidelity'].to_numpy()[0]):.3f}<br>"
-    title_text += f"q{qubit}/r{report_n} | assignment fidelity: {float(fit_data['assignment_fidelity'].to_numpy()[0]):.3f}<br><br>"
+    title_text += f"q{qubit}/r{report_n} | assignment fidelity: {float(fit_data['assignment_fidelity'].to_numpy()[0]):.3f}<br>"
+    title_text += f"q{qubit}/r{report_n} | optimal frequency: {float(fit_data['frequency'].to_numpy()[0]):.3f} Hz<br><br>"
     fitting_report = fitting_report + title_text
     return [fig, fig_fidelity], fitting_report
 
@@ -192,8 +193,8 @@ def ro_amplitude(folder, routine, qubit, format):
         data = DataUnits(
             name="data",
             quantities={
-                "amplitude": "dBm",
-                "delta_amplitude": "dBm",
+                "amplitude": "dimensionless",
+                "delta_amplitude": "dimensionless",
             },
             options=["iteration", "state"],
         )
@@ -334,7 +335,7 @@ def ro_amplitude(folder, routine, qubit, format):
     fig_fidelity.update_layout(
         showlegend=True,
         uirevision="0",  # ``uirevision`` allows zooming while live plotting
-        xaxis_title="delta amplitude (dBm)",
+        xaxis_title="delta amplitude (dimensionless)",
         yaxis_title="fidelity (ratio)",
         title=f"q{qubit}",
     )
@@ -344,7 +345,8 @@ def ro_amplitude(folder, routine, qubit, format):
     title_text += f"q{qubit}/r{report_n} | average state 1: ({complex(fit_data['average_state1'].to_numpy()[0]):.6f})<br>"
     title_text += f"q{qubit}/r{report_n} | rotation angle: {float(fit_data['rotation_angle'].to_numpy()[0]):.3f} | threshold = {float(fit_data['threshold'].to_numpy()[0]):.6f}<br>"
     title_text += f"q{qubit}/r{report_n} | fidelity: {float(fit_data['fidelity'].to_numpy()[0]):.3f}<br>"
-    title_text += f"q{qubit}/r{report_n} | assignment fidelity: {float(fit_data['assignment_fidelity'].to_numpy()[0]):.3f}<br><br>"
+    title_text += f"q{qubit}/r{report_n} | assignment fidelity: {float(fit_data['assignment_fidelity'].to_numpy()[0]):.3f}<br>"
+    title_text += f"q{qubit}/r{report_n} | optimal amplitude: {float(fit_data['amplitude'].to_numpy()[0]):.3f}<br><br>"
     fitting_report = fitting_report + title_text
     return [fig, fig_fidelity], fitting_report
 
@@ -518,6 +520,7 @@ def ro_power(folder, routine, qubit, format):
     title_text += f"q{qubit}/r{report_n} | average state 1: ({complex(fit_data['average_state1'].to_numpy()[0]):.6f})<br>"
     title_text += f"q{qubit}/r{report_n} | rotation angle: {float(fit_data['rotation_angle'].to_numpy()[0]):.3f} | threshold = {float(fit_data['threshold'].to_numpy()[0]):.6f}<br>"
     title_text += f"q{qubit}/r{report_n} | fidelity: {float(fit_data['fidelity'].to_numpy()[0]):.3f}<br>"
-    title_text += f"q{qubit}/r{report_n} | assignment fidelity: {float(fit_data['assignment_fidelity'].to_numpy()[0]):.3f}<br><br>"
+    title_text += f"q{qubit}/r{report_n} | assignment fidelity: {float(fit_data['assignment_fidelity'].to_numpy()[0]):.3f}<br>"
+    title_text += f"q{qubit}/r{report_n} | optimal power: {float(fit_data['power'].to_numpy()[0]):.3f} dBm<br><br>"
     fitting_report = fitting_report + title_text
     return [fig, fig_fidelity], fitting_report

--- a/src/qibocal/plots/ro_optimization.py
+++ b/src/qibocal/plots/ro_optimization.py
@@ -201,8 +201,8 @@ def ro_amplitude(folder, routine, qubit, format):
             data = DataUnits(
                 name="data",
                 quantities={
-                    "amplitude": "dimensionless",
-                    "delta_amplitude": "dimensionless",
+                    "amplitude": "dBm",
+                    "delta_amplitude": "dBm",
                 },
                 options=["iteration", "state"],
             )
@@ -348,7 +348,185 @@ def ro_amplitude(folder, routine, qubit, format):
     fig_fidelity.update_layout(
         showlegend=True,
         uirevision="0",  # ``uirevision`` allows zooming while live plotting
-        xaxis_title="delta amplitude (dimensionless)",
+        xaxis_title="delta amplitude (dBm)",
+        yaxis_title="fidelity (ratio)",
+        title=f"q{qubit}",
+    )
+    # Add fitting report for the best fidelity
+    fit_data = data_fit.df[data_fit.df["fidelity"] == data_fit.df["fidelity"].max()]
+    title_text = f"q{qubit}/r{report_n} | average state 0: ({complex(fit_data['average_state0'].to_numpy()[0]):.6f})<br>"
+    title_text += f"q{qubit}/r{report_n} | average state 1: ({complex(fit_data['average_state1'].to_numpy()[0]):.6f})<br>"
+    title_text += f"q{qubit}/r{report_n} | rotation angle: {float(fit_data['rotation_angle'].to_numpy()[0]):.3f} | threshold = {float(fit_data['threshold'].to_numpy()[0]):.6f}<br>"
+    title_text += f"q{qubit}/r{report_n} | fidelity: {float(fit_data['fidelity'].to_numpy()[0]):.3f}<br>"
+    title_text += f"q{qubit}/r{report_n} | assignment fidelity: {float(fit_data['assignment_fidelity'].to_numpy()[0]):.3f}<br><br>"
+    fitting_report = fitting_report + title_text
+    return [fig, fig_fidelity], fitting_report
+
+
+# Plot RO optimization with power
+# Plot RO optimization with amplitude
+def ro_power(folder, routine, qubit, format):
+    fig = go.Figure()
+
+    # iterate over multiple data folders
+    subfolders = get_data_subfolders(folder)
+    report_n = 0
+    fitting_report = ""
+
+    for subfolder in subfolders:
+        try:
+            data = DataUnits.load_data(folder, subfolder, routine, format, "data")
+            data.df = data.df[data.df["qubit"] == qubit]
+        except:
+            data = DataUnits(
+                name="data",
+                quantities={
+                    "power": "dBm",
+                    "delta_power": "dBm",
+                },
+                options=["iteration", "state"],
+            )
+
+        try:
+            data_fit = Data.load_data(folder, subfolder, routine, format, "fit")
+            data_fit.df = data_fit.df[data_fit.df["qubit"] == qubit]
+
+        except:
+            data_fit = Data(
+                name="fit",
+                quantities=[
+                    "power",
+                    "delta_power",
+                    "rotation_angle",
+                    "threshold",
+                    "fidelity",
+                    "assignment_fidelity",
+                    "average_state0",
+                    "average_state1",
+                ],
+            )
+
+        # Plot raw results with sliders
+        for power in data.df["delta_power"].unique():
+            state0_data = data.df[
+                (data.df["delta_power"] == power) & (data.df["state"] == 0)
+            ]
+            state1_data = data.df[
+                (data.df["delta_power"] == power) & (data.df["state"] == 1)
+            ]
+            fit_data = data_fit.df[data_fit.df["delta_power"] == power.magnitude]
+            fit_data["average_state0"] = data_fit.df["average_state0"].apply(
+                lambda x: complex(x)
+            )
+            fit_data["average_state1"] = data_fit.df["average_state1"].apply(
+                lambda x: complex(x)
+            )
+
+            # print(fit_data)
+            fig.add_trace(
+                go.Scatter(
+                    x=state0_data["i"].pint.to("V").pint.magnitude,
+                    y=state0_data["q"].pint.to("V").pint.magnitude,
+                    name=f"q{qubit}/r{report_n}: state 0",
+                    # legendgroup=f"q{qubit}/r{report_n}",
+                    mode="markers",
+                    showlegend=True,
+                    opacity=0.7,
+                    marker=dict(size=3, color=get_color_state0(report_n)),
+                    visible=False,
+                ),
+            )
+
+            fig.add_trace(
+                go.Scatter(
+                    x=state1_data["i"].pint.to("V").pint.magnitude,
+                    y=state1_data["q"].pint.to("V").pint.magnitude,
+                    name=f"q{qubit}/r{report_n}: state 1",
+                    # legendgroup=f"q{qubit}/r{report_n}",
+                    mode="markers",
+                    showlegend=True,
+                    opacity=0.7,
+                    marker=dict(size=3, color=get_color_state1(report_n)),
+                    visible=False,
+                ),
+            )
+            fig.add_trace(
+                go.Scatter(
+                    x=fit_data["average_state0"].apply(lambda x: np.real(x)).to_numpy(),
+                    y=fit_data["average_state0"].apply(lambda x: np.imag(x)).to_numpy(),
+                    name=f"q{qubit}/r{report_n}: mean state 0",
+                    # legendgroup=f"q{qubit}/r{report_n}",
+                    showlegend=True,
+                    visible=False,
+                    mode="markers",
+                    marker=dict(size=10, color=get_color_state0(report_n)),
+                ),
+            )
+
+            fig.add_trace(
+                go.Scatter(
+                    x=fit_data["average_state1"].apply(lambda x: np.real(x)).to_numpy(),
+                    y=fit_data["average_state1"].apply(lambda x: np.imag(x)).to_numpy(),
+                    name=f"avg q{qubit}/r{report_n}: mean state 1",
+                    # legendgroup=f"q{qubit}/r{report_n}",
+                    showlegend=True,
+                    visible=False,
+                    mode="markers",
+                    marker=dict(size=10, color=get_color_state1(report_n)),
+                ),
+            )
+
+        report_n += 1
+    # Show data for the first power
+    fig.data[0].visible = True
+    fig.data[1].visible = True
+    fig.data[2].visible = True
+    fig.data[3].visible = True
+
+    # Add slider
+    steps = []
+    for i, amp in enumerate(data.df["power"].unique()):
+        step = dict(
+            method="update",
+            args=[
+                {"visible": [False] * len(fig.data)},
+            ],
+            label=f"{amp.magnitude:.4f}",
+        )
+        for j in range(4):
+            step["args"][0]["visible"][i * 4 + j] = True
+        steps.append(step)
+
+    sliders = [
+        dict(
+            currentvalue={"prefix": "power: "},
+            steps=steps,
+        )
+    ]
+
+    fig.update_layout(
+        showlegend=True,
+        uirevision="0",  # ``uirevision`` allows zooming while live plotting
+        xaxis_title="i (V)",
+        yaxis_title="q (V)",
+        sliders=sliders,
+        title=f"q{qubit}",
+    )
+    fig.update_yaxes(
+        scaleanchor="x",
+        scaleratio=1,
+    )
+
+    # Plot the fidelity as a function of power
+    fig_fidelity = go.Figure()
+
+    fig_fidelity.add_trace(
+        go.Scatter(x=data_fit.df["power"], y=data_fit.df["fidelity"])
+    )
+    fig_fidelity.update_layout(
+        showlegend=True,
+        uirevision="0",  # ``uirevision`` allows zooming while live plotting
+        xaxis_title="delta power (dBm)",
         yaxis_title="fidelity (ratio)",
         title=f"q{qubit}",
     )


### PR DESCRIPTION
Readout optimization for the TWPA parameters. 

It is tested with a merged of `qibolab` : 
1. https://github.com/qiboteam/qibolab/pull/386 
2. https://github.com/qiboteam/qibolab/tree/alvaro/qblox9_sweepers

But it should work with any sweeper branch as soon as 1. is merged in Qibolab. 

It can be tested:
```yml
platform: qblox
runcard: /home/users/maxime.hantute/qibolab/src/qibolab/runcards/qw5q_gold_qblox.yml

# Instructions: Uncomment whatever you would like to run!

qubits: [0,1,2,3,4]


format: csv

actions:

  ro_frequency:
    frequency_width: 2.e+6
    frequency_step: .1e+6
    nshots: 2000

  ro_amplitude:
    amplitude_factor_min: 0.8
    amplitude_factor_max: 1.1
    amplitude_factor_step: 0.1
    nshots: 2000

  twpa_frequency:
    frequency_width: 50.e+6
    frequency_step: 10.e+6
    nshots: 2000

  twpa_power:
    power_width: 1
    power_step: 0.1
    nshots: 2000
```


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
