### PR TITLE
Cumulative

### DIFF
--- a/src/qibocal/fitting/methods.py
+++ b/src/qibocal/fitting/methods.py
@@ -9,6 +9,7 @@ from qibocal.config import log
 from qibocal.data import Data
 from qibocal.fitting.utils import (
     cos,
+    cumulative,
     exp,
     flipping,
     freq_q_mathieu,
@@ -1040,18 +1041,9 @@ def calibrate_qubit_states_fit(data, x, y, nshots, qubits, degree=True):
         real_values_combined = np.concatenate((real_values_state1, real_values_state0))
         real_values_combined.sort()
 
-        cum_distribution_state1 = [
-            sum(map(lambda x: x.real >= real_value, real_values_state1))
-            for real_value in real_values_combined
-        ]
-        cum_distribution_state0 = [
-            sum(map(lambda x: x.real >= real_value, real_values_state0))
-            for real_value in real_values_combined
-        ]
+        cum_distribution_state0 = cumulative(real_values_combined, real_values_state0)
+        cum_distribution_diff = cumulative(real_values_combined, real_values_state1)
 
-        cum_distribution_diff = np.abs(
-            np.array(cum_distribution_state1) - np.array(cum_distribution_state0)
-        )
         argmax = np.argmax(cum_distribution_diff)
         threshold = real_values_combined[argmax]
         errors_state1 = nshots - cum_distribution_state1[argmax]

--- a/src/qibocal/fitting/methods.py
+++ b/src/qibocal/fitting/methods.py
@@ -1041,9 +1041,12 @@ def calibrate_qubit_states_fit(data, x, y, nshots, qubits, degree=True):
         real_values_combined = np.concatenate((real_values_state1, real_values_state0))
         real_values_combined.sort()
 
+        cum_distribution_state1 = cumulative(real_values_combined, real_values_state1)
         cum_distribution_state0 = cumulative(real_values_combined, real_values_state0)
-        cum_distribution_diff = cumulative(real_values_combined, real_values_state1)
 
+        cum_distribution_diff = np.abs(
+            np.array(cum_distribution_state1) - np.array(cum_distribution_state0)
+        )
         argmax = np.argmax(cum_distribution_diff)
         threshold = real_values_combined[argmax]
         errors_state1 = nshots - cum_distribution_state1[argmax]

--- a/src/qibocal/fitting/utils.py
+++ b/src/qibocal/fitting/utils.py
@@ -128,3 +128,20 @@ def freq_r_mathieu(x, p0, p1, p2, p3, p4, p5, p6, p7=0.499):
     f_q = freq_q_mathieu(x, p2, p3, p4, p5, p6, p7)
     f_r = p0 + p1**2 * np.sqrt(G) / (p0 - f_q)
     return f_r
+
+
+def cumulative(input_data, points):
+    r"""Evaluates in `input_data` the cumulative distribution
+    function of `points`.
+    WARNING: `input_data` and `points` should be sorted data.
+    """
+    input_data_sort = np.sort(input_data)
+    points_sort = np.sort(points)
+
+    prob = []
+    app = 0
+    for val in input_data_sort:
+        app += np.max(np.searchsorted(points_sort[app::], val), 0)
+        prob.append(app)
+
+    return np.array(prob)

--- a/tests/test_fitting_methods.py
+++ b/tests/test_fitting_methods.py
@@ -18,6 +18,7 @@ from qibocal.fitting.methods import (
 )
 from qibocal.fitting.utils import (
     cos,
+    cumulative,
     exp,
     flipping,
     freq_r_mathieu,
@@ -535,3 +536,9 @@ def test_drag_tunning_fit(label, caplog):
         data, "beta_param[dimensionless]", "MSR[V]", [0], labels=label
     )
     assert "drag_tuning_fit: the fitting was not succesful" in caplog.text
+
+
+def test_cumulative():
+    points = x = np.linspace(0, 9, 10)
+    cum = cumulative(x, points)
+    assert np.array_equal(cum, points)


### PR DESCRIPTION
This PR implements and benchmarks a new function to evaluate the cumulative distribution.
To compare the old method (`method1`) with the new one (`method2`), you can use the following code
```python
import time

import numpy as np
import matplotlib.pyplot as plt

REPETITIONS = 100

def cum_method1(real_values_combined, real_values_state0):
    return  [
            sum(map(lambda x: x.real >= real_value, real_values_state0))
            for real_value in real_values_combined
        ]

def cum_method2(input_data, points):
    # data and points sorted
    input_data = np.sort(input_data)
    points = np.sort(points)
 
    prob = []
    app = 0
    for val in input_data:
        app += np.max(np.searchsorted(points[app::], val), 0)
        prob.append(app)

    return np.array(prob)

def time_compare(method, input1, input2):
    start = time.time()
    for _ in range(REPETITIONS):
       cum =  method(input1, input2)
    end = time.time()
    return (end-start)/REPETITIONS, cum

state0_center = [0.0, 0.0]
state1_center = [2.0, 2.0]
cov = 0.1 * np.eye(2)
size = 100  # print(points, input_data)

data_0 = np.random.multivariate_normal(state0_center, cov, size=size)
data_1 = np.random.multivariate_normal(state1_center, cov, size=size)

all_data = np.concatenate((data_0, data_1), axis = 0)

#method1
time1, cum1 = time_compare(cum_method1,all_data[:,0],data_0[:,0])
print("Method 1: ", time1)

#method2
time2, cum2 = time_compare(cum_method2,all_data[:,0],data_0[:,0])
print("Method 2: ", time2)

#Plots
plt.figure(figsize=(14, 7), dpi=80)
plt.subplot(1,2,1)
plt.scatter(data_0[:, 0], data_0[:, 1], label = "0")
plt.scatter(data_1[:, 0], data_1[:, 1], label = "1")

plt.subplot(1,2,2)
plt.scatter(all_data[:,0],cum1, label = f"method1 ({round(time1, 4)})")
plt.scatter(np.sort(all_data[:, 0]), cum2, label = f"method2 ({round(time2,4)})")
plt.legend()
plt.show()
```
From the outputs we can see: 

1. the new method is four time faster
2. the old method has a bug ( we have to change the condition `x.real >= real_value` in `x.real <= real_value`)
```
Method 1:  0.0026085638999938966
Method 2:  0.0008060479164123535
```
![image](https://user-images.githubusercontent.com/62623482/234499858-bc319cf2-5475-485f-b5da-ca1285a019e7.png)
With the change proposed in point 2 this is the result
![image](https://user-images.githubusercontent.com/62623482/234502066-5930c4e3-14b3-4bb6-963d-8250ff73b315.png)

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
