### PR TITLE
Detach attenuation from resonator spectroscopy

### DIFF
--- a/src/qibocal/protocols/characterization/__init__.py
+++ b/src/qibocal/protocols/characterization/__init__.py
@@ -18,10 +18,12 @@ from .ramsey import ramsey
 from .resonator_punchout import resonator_punchout
 from .resonator_punchout_attenuation import resonator_punchout_attenuation
 from .resonator_spectroscopy import resonator_spectroscopy
+from .resonator_spectroscopy_attenuation import resonator_spectroscopy_attenuation
 
 
 class Operation(Enum):
     resonator_spectroscopy = resonator_spectroscopy
+    resonator_spectroscopy_attenuation = resonator_spectroscopy_attenuation
     resonator_punchout = resonator_punchout
     resonator_punchout_attenuation = resonator_punchout_attenuation
     resonator_flux = resonator_flux

--- a/src/qibocal/protocols/characterization/qubit_spectroscopy.py
+++ b/src/qibocal/protocols/characterization/qubit_spectroscopy.py
@@ -42,11 +42,6 @@ class QubitSpectroscopyResults(Results):
     """Input drive amplitude. Same for all qubits."""
     fitted_parameters: Dict[Union[str, int], Dict[str, float]]
     """Raw fitting output."""
-    # FIXME: Is attenuation needed for qubit spectroscopy?
-    attenuation: Optional[Dict[Union[str, int], int]] = field(
-        default_factory=dict,
-    )
-    """Input attenuation [dB] for each qubit (optional)."""
 
 
 class QubitSpectroscopyData(ResonatorSpectroscopyData):
@@ -118,21 +113,18 @@ def _fit(data: QubitSpectroscopyData) -> QubitSpectroscopyResults:
     """Post-processing function for QubitSpectroscopy."""
     qubits = data.df["qubit"].unique()
     amplitudes = {}
-    attenuations = {}
     frequency = {}
     fitted_parameters = {}
     for qubit in qubits:
         freq, fitted_params = lorentzian_fit(data, qubit)
         frequency[qubit] = freq
         amplitudes[qubit] = data.amplitude
-        attenuations[qubit] = data.attenuation
         fitted_parameters[qubit] = fitted_params
 
     return QubitSpectroscopyResults(
         frequency=frequency,
         fitted_parameters=fitted_parameters,
         amplitude=amplitudes,
-        attenuation=attenuations,
     )
 
 

--- a/src/qibocal/protocols/characterization/resonator_spectroscopy.py
+++ b/src/qibocal/protocols/characterization/resonator_spectroscopy.py
@@ -101,7 +101,6 @@ def _acquisition(
     sequence = PulseSequence()
     ro_pulses = {}
     amplitudes = {}
-    attenuations = {}
 
     for qubit in qubits:
         ro_pulses[qubit] = platform.create_qubit_readout_pulse(qubit, start=0)

--- a/src/qibocal/protocols/characterization/resonator_spectroscopy_attenuation.py
+++ b/src/qibocal/protocols/characterization/resonator_spectroscopy_attenuation.py
@@ -1,0 +1,217 @@
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Union
+
+import numpy as np
+from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.pulses import PulseSequence
+from qibolab.sweeper import Parameter, Sweeper
+
+from qibocal.auto.operation import Parameters, Qubits, Results, Routine
+from qibocal.data import DataUnits
+
+from .utils import PowerLevel, lorentzian_fit, spectroscopy_plot
+
+
+@dataclass
+class ResonatorSpectroscopyAttenuationParameters(Parameters):
+    """ResonatorSpectroscopy runcard inputs."""
+
+    freq_width: int
+    """Width for frequency sweep relative  to the readout frequency (Hz)."""
+    freq_step: int
+    """Frequency step for sweep [Hz]."""
+    nshots: int
+    """Number of shots."""
+    power_level: PowerLevel
+    """Power regime (low or high). If low the readout frequency will be updated.
+    If high both the readout frequency and the bare resonator frequency will be updated."""
+    relaxation_time: int
+    """Relaxation time (ns)."""
+    amplitude: Optional[float] = None
+    """Readout amplitude (optional). If defined, same amplitude will be used in all qubits.
+    Otherwise the default amplitude defined on the platform runcard will be used"""
+    attenuation: Optional[int] = None
+    """Readout attenuation (optional). If defined, same attenuation will be used in all qubits.
+    Otherwise the default attenuation defined on the platform runcard will be used"""
+
+    def __post_init__(self):
+        # TODO: ask Alessandro if there is a proper way to pass Enum to class
+        self.power_level = PowerLevel(self.power_level)
+
+
+@dataclass
+class ResonatorSpectroscopyAttenuationResults(Results):
+    """ResonatorSpectroscopy outputs."""
+
+    frequency: Dict[Union[str, int], float] = field(
+        metadata=dict(update="readout_frequency")
+    )
+    """Readout frequency [GHz] for each qubit."""
+    fitted_parameters: Dict[Union[str, int], Dict[str, float]]
+    """Raw fitted parameters."""
+    bare_frequency: Optional[Dict[Union[str, int], float]] = field(
+        default_factory=dict, metadata=dict(update="bare_resonator_frequency")
+    )
+    """Bare resonator frequency [GHz] for each qubit."""
+    amplitude: Optional[Dict[Union[str, int], float]] = field(
+        default_factory=dict, metadata=dict(update="readout_amplitude")
+    )
+    """Readout amplitude for each qubit."""
+    attenuation: Optional[Dict[Union[str, int], int]] = field(
+        default_factory=dict, metadata=dict(update="readout_attenuation")
+    )
+    """Readout attenuation [dB] for each qubit."""
+
+
+class ResonatorSpectroscopyAttenuationData(DataUnits):
+    """ResonatorSpectroscopy acquisition outputs."""
+
+    def __init__(
+        self, resonator_type, power_level=None, amplitude=None, attenuation=None
+    ):
+        super().__init__(
+            "data",
+            {"frequency": "Hz"},
+            options=["qubit"],
+        )
+        self._resonator_type = resonator_type
+        self._power_level = power_level
+        self._amplitude = amplitude
+        self._attenuation = attenuation
+
+    @property
+    def resonator_type(self):
+        """Type of resonator"""
+        return self._resonator_type
+
+    @property
+    def power_level(self):
+        """Resonator spectroscopy power level"""
+        return self._power_level
+
+    @property
+    def amplitude(self):
+        """Readout pulse amplitude common for all qubits"""
+        return self._amplitude
+
+    @property
+    def attenuation(self):
+        """Attenuation value common for all qubits"""
+        return self._attenuation
+
+
+def _acquisition(
+    params: ResonatorSpectroscopyAttenuationParameters,
+    platform: AbstractPlatform,
+    qubits: Qubits,
+) -> ResonatorSpectroscopyAttenuationData:
+    """Data acquisition for resonator spectroscopy attenuation."""
+    # create a sequence of pulses for the experiment:
+    # MZ
+
+    # taking advantage of multiplexing, apply the same set of gates to all qubits in parallel
+    sequence = PulseSequence()
+    ro_pulses = {}
+    amplitudes = {}
+    attenuations = {}
+
+    for qubit in qubits:
+        ro_pulses[qubit] = platform.create_qubit_readout_pulse(qubit, start=0)
+        if params.amplitude is not None:
+            ro_pulses[qubit].amplitude = params.amplitude
+
+        amplitudes[qubit] = ro_pulses[qubit].amplitude
+
+        if params.attenuation is not None:
+            platform.set_attenuation(qubit, params.attenuation)
+
+        attenuations[qubit] = platform.get_attenuation(qubit)
+
+        sequence.add(ro_pulses[qubit])
+
+    # define the parameter to sweep and its range:
+    delta_frequency_range = np.arange(
+        -params.freq_width // 2, params.freq_width // 2, params.freq_step
+    )
+    sweeper = Sweeper(
+        Parameter.frequency,
+        delta_frequency_range,
+        pulses=[ro_pulses[qubit] for qubit in qubits],
+    )
+    data = ResonatorSpectroscopyAttenuationData(
+        platform.resonator_type,
+        params.power_level,
+        amplitudes,
+        attenuations,
+    )
+    results = platform.sweep(
+        sequence,
+        sweeper,
+        nshots=params.nshots,
+        relaxation_time=params.relaxation_time,
+    )
+
+    # retrieve the results for every qubit
+    for qubit in qubits:
+        # average msr, phase, i and q over the number of shots defined in the runcard
+        result = results[ro_pulses[qubit].serial]
+        # store the results
+        r = result.raw
+        r.update(
+            {
+                "frequency[Hz]": delta_frequency_range + ro_pulses[qubit].frequency,
+                "qubit": len(delta_frequency_range) * [qubit],
+            }
+        )
+        data.add_data_from_dict(r)
+    # finally, save the remaining data
+    return data
+
+
+def _fit(
+    data: ResonatorSpectroscopyAttenuationData,
+) -> ResonatorSpectroscopyAttenuationResults:
+    """Post-processing function for ResonatorSpectroscopy."""
+    qubits = data.df["qubit"].unique()
+    bare_frequency = {}
+    amplitudes = {}
+    attenuations = {}
+    frequency = {}
+    fitted_parameters = {}
+    for qubit in qubits:
+        freq, fitted_params = lorentzian_fit(data, qubit)
+        if data.power_level is PowerLevel.high:
+            bare_frequency[qubit] = freq
+
+        frequency[qubit] = freq
+        amplitudes[qubit] = data.amplitude[qubit]
+        attenuations[qubit] = data.attenuation[qubit]
+        fitted_parameters[qubit] = fitted_params
+    if data.power_level is PowerLevel.high:
+        return ResonatorSpectroscopyAttenuationResults(
+            frequency=frequency,
+            fitted_parameters=fitted_parameters,
+            bare_frequency=bare_frequency,
+            amplitude=amplitudes,
+            attenuation=attenuations,
+        )
+    else:
+        return ResonatorSpectroscopyAttenuationResults(
+            frequency=frequency,
+            fitted_parameters=fitted_parameters,
+            amplitude=amplitudes,
+            attenuation=attenuations,
+        )
+
+
+def _plot(
+    data: ResonatorSpectroscopyAttenuationData,
+    fit: ResonatorSpectroscopyAttenuationResults,
+    qubit,
+):
+    """Plotting function for ResonatorSpectroscopyAttenuation."""
+    return spectroscopy_plot(data, fit, qubit)
+
+
+resonator_spectroscopy_attenuation = Routine(_acquisition, _fit, _plot)
+"""ResonatorSpectroscopyAttenuation Routine object."""

--- a/src/qibocal/protocols/characterization/resonator_spectroscopy_attenuation.py
+++ b/src/qibocal/protocols/characterization/resonator_spectroscopy_attenuation.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from typing import Dict, Optional, Union
 
 import numpy as np
+from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
 from qibolab.platforms.abstract import AbstractPlatform
 from qibolab.pulses import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper
@@ -20,12 +21,12 @@ class ResonatorSpectroscopyAttenuationParameters(Parameters):
     """Width for frequency sweep relative  to the readout frequency (Hz)."""
     freq_step: int
     """Frequency step for sweep [Hz]."""
-    nshots: int
-    """Number of shots."""
     power_level: PowerLevel
     """Power regime (low or high). If low the readout frequency will be updated.
     If high both the readout frequency and the bare resonator frequency will be updated."""
-    relaxation_time: int
+    nshots: Optional[int] = None
+    """Number of shots."""
+    relaxation_time: Optional[int] = None
     """Relaxation time (ns)."""
     amplitude: Optional[float] = None
     """Readout amplitude (optional). If defined, same amplitude will be used in all qubits.
@@ -144,11 +145,16 @@ def _acquisition(
         amplitudes,
         attenuations,
     )
+
     results = platform.sweep(
         sequence,
+        ExecutionParameters(
+            nshots=params.nshots,
+            relaxation_time=params.relaxation_time,
+            acquisition_type=AcquisitionType.INTEGRATION,
+            averaging_mode=AveragingMode.CYCLIC,
+        ),
         sweeper,
-        nshots=params.nshots,
-        relaxation_time=params.relaxation_time,
     )
 
     # retrieve the results for every qubit
@@ -156,7 +162,7 @@ def _acquisition(
         # average msr, phase, i and q over the number of shots defined in the runcard
         result = results[ro_pulses[qubit].serial]
         # store the results
-        r = result.raw
+        r = result.serialize
         r.update(
             {
                 "frequency[Hz]": delta_frequency_range + ro_pulses[qubit].frequency,

--- a/src/qibocal/protocols/characterization/utils.py
+++ b/src/qibocal/protocols/characterization/utils.py
@@ -154,8 +154,9 @@ def spectroscopy_plot(data, fit: Results, qubit):
     if fit.amplitude[qubit] is not None:
         fitting_report += f"{qubit} | amplitude: {fit.amplitude[qubit]} <br>"
 
-    if fit.attenuation[qubit] is not None and fit.attenuation[qubit] != 0:
-        fitting_report += f"{qubit} | attenuation: {fit.attenuation[qubit]} <br>"
+    if data.__class__.__name__ == "ResonatorSpectroscopyAttenuationData":
+        if fit.attenuation[qubit] is not None and fit.attenuation[qubit] != 0:
+            fitting_report += f"{qubit} | attenuation: {fit.attenuation[qubit]} <br>"
 
     fig.update_layout(
         showlegend=True,

--- a/tests/runcards/single_routines.yml
+++ b/tests/runcards/single_routines.yml
@@ -19,7 +19,7 @@ actions:
 
   - id: resonator high power low attenuation
     priority: 0
-    operation: resonator_spectroscopy
+    operation: resonator_spectroscopy_attenuation
     parameters:
       freq_width: 10_000_000 # 20_000_000
       freq_step: 100_000 # 500_00
@@ -30,7 +30,7 @@ actions:
 
   - id: resonator low power high attenuation
     priority: 0
-    operation: resonator_spectroscopy
+    operation: resonator_spectroscopy_attenuation
     parameters:
       freq_width: 10_000_000 # 20_000_000
       freq_step: 100_000 # 500_00

--- a/tests/runcards/test_autocalibration.yml
+++ b/tests/runcards/test_autocalibration.yml
@@ -9,11 +9,23 @@ actions:
   - id: resonator high power high amplitude
     priority: 0
     operation: resonator_spectroscopy
-    next: resonator punchout
+    next: resonator high power low attenuation
     parameters:
       freq_width: 10_000_000
       freq_step: 100_000
-      amplitude: 0.4
+      amplitude: 0.9
+      power_level: high
+      nshots: 1024
+      relaxation_time: 0
+
+  - id: resonator high power low attenuation
+    priority: 0
+    operation: resonator_spectroscopy_attenuation
+    next: resonator punchout
+    parameters:
+      freq_width: 10_000_000 # 20_000_000
+      freq_step: 100_000 # 500_00
+      attenuation: 15
       power_level: high
       nshots: 1024
       relaxation_time: 0
@@ -45,16 +57,28 @@ actions:
       nshots: 1000
       relaxation_time: 0
 
-
   - id: resonator spectroscopy low power
     priority: 0
     operation: resonator_spectroscopy
-    next: resonator flux dependence
+    next: resonator low power high attenuation
     parameters:
       freq_width: 10_000_000
       freq_step: 50_000
       amplitude: 0.022
       power_level: low
+      nshots: 1024
+      relaxation_time: 0
+
+  - id: resonator low power high attenuation
+    priority: 0
+    operation: resonator_spectroscopy_attenuation
+    next: resonator flux dependence
+    parameters:
+      freq_width: 10_000_000
+      freq_step: 100_000
+      attenuation: 50
+      amplitude: 0.4
+      power_level: high
       nshots: 1024
       relaxation_time: 0
 

--- a/tests/runcards/test_autocalibration.yml
+++ b/tests/runcards/test_autocalibration.yml
@@ -78,7 +78,7 @@ actions:
       freq_step: 100_000
       attenuation: 50
       amplitude: 0.4
-      power_level: high
+      power_level: low
       nshots: 1024
       relaxation_time: 0
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -16,4 +16,5 @@ platform = Platform("dummy")
 def test_data_acquisition(action):
     """Test data acquisition for all routines using dummy"""
     task = Task(action)
+    print(task.id)
     task.operation.acquisition(task.parameters, platform, platform.qubits)


### PR DESCRIPTION
Closes #360.

I've added a different routine to set the attenuation in the resonator spectroscopy called `ResonatorSpectroscopyAttenuation`. This is just a quick fix.
Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
