### PR TITLE
Sync with qiboteam/qibolab#438

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.9, "3.10"]
     uses: qiboteam/workflows/.github/workflows/deploy-pip-poetry.yml@main
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.9, "3.10"]
     uses: qiboteam/workflows/.github/workflows/rules-poetry.yml@main
     with:
       os: ${{ matrix.os }}

--- a/poetry.lock
+++ b/poetry.lock
@@ -118,9 +118,6 @@ files = [
     {file = "Babel-2.12.1.tar.gz", hash = "sha256:cc2d99999cd01d44420ae725a21c9e3711b3aadc7976d6147f622d8581963455"},
 ]
 
-[package.dependencies]
-pytz = {version = ">=2015.7", markers = "python_version < \"3.9\""}
-
 [[package]]
 name = "backcall"
 version = "0.2.0"
@@ -153,27 +150,15 @@ html5lib = ["html5lib"]
 lxml = ["lxml"]
 
 [[package]]
-name = "blinker"
-version = "1.6.2"
-description = "Fast, simple object-to-object and broadcast signaling"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "blinker-1.6.2-py3-none-any.whl", hash = "sha256:c3d739772abb7bc2860abf5f2ec284223d9ad5c76da018234f6f50d6f31ab1f0"},
-    {file = "blinker-1.6.2.tar.gz", hash = "sha256:4afd3de66ef3a9f8067559fb7a1cbe555c17dcbe15971b05d1b625c3e7abe213"},
-]
-
-[[package]]
 name = "cachetools"
-version = "5.3.0"
+version = "5.3.1"
 description = "Extensible memoizing collections and decorators"
 category = "main"
 optional = true
-python-versions = "~=3.7"
+python-versions = ">=3.7"
 files = [
-    {file = "cachetools-5.3.0-py3-none-any.whl", hash = "sha256:429e1a1e845c008ea6c85aa35d4b98b65d6a9763eeef3e37e92728a12d1de9d4"},
-    {file = "cachetools-5.3.0.tar.gz", hash = "sha256:13dfddc7b8df938c21a940dfa6557ce6e94a2f1cdfa58eb90c805721d58f2c14"},
+    {file = "cachetools-5.3.1-py3-none-any.whl", hash = "sha256:95ef631eeaea14ba2e36f06437f36463aac3a096799e876ee55e5cdccb102590"},
+    {file = "cachetools-5.3.1.tar.gz", hash = "sha256:dce83f2d9b4e1f732a8cd44af8e8fab2dbe46201467fc98b3ef8f269092bf62b"},
 ]
 
 [[package]]
@@ -508,22 +493,23 @@ files = [
 
 [[package]]
 name = "dash"
-version = "2.9.3"
+version = "2.10.0"
 description = "A Python framework for building reactive web-apps. Developed by Plotly."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "dash-2.9.3-py3-none-any.whl", hash = "sha256:a749ae1ea9de3fe7b785353a818ec9b629d39c6b7e02462954203bd1e296fd0e"},
-    {file = "dash-2.9.3.tar.gz", hash = "sha256:47392f8d6455dc989a697407eb5941f3bad80604df985ab1ac9d4244568ffb34"},
+    {file = "dash-2.10.0-py3-none-any.whl", hash = "sha256:2a010cd593f952041ab1737ea8af574b19be54584f52665f269eb0bcfef765fa"},
+    {file = "dash-2.10.0.tar.gz", hash = "sha256:33abd550733a609247b792d29d5b8fc9663e5161409a3179ec24551f4b74f2a6"},
 ]
 
 [package.dependencies]
 dash-core-components = "2.0.0"
 dash-html-components = "2.0.0"
 dash-table = "5.0.0"
-Flask = ">=1.0.4"
+Flask = ">=1.0.4,<=2.2.3"
 plotly = ">=5.0.0"
+Werkzeug = "<=2.2.3"
 
 [package.extras]
 celery = ["celery[redis] (>=5.1.2)", "importlib-metadata (<5)", "redis (>=3.5.3)"]
@@ -676,23 +662,22 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.2.3)", "diff-cover (>=7.5)", "p
 
 [[package]]
 name = "flask"
-version = "2.3.2"
+version = "2.2.3"
 description = "A simple framework for building complex web applications."
 category = "main"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.7"
 files = [
-    {file = "Flask-2.3.2-py3-none-any.whl", hash = "sha256:77fd4e1249d8c9923de34907236b747ced06e5467ecac1a7bb7115ae0e9670b0"},
-    {file = "Flask-2.3.2.tar.gz", hash = "sha256:8c2f9abd47a9e8df7f0c3f091ce9497d011dc3b31effcf4c85a6e2b50f4114ef"},
+    {file = "Flask-2.2.3-py3-none-any.whl", hash = "sha256:c0bec9477df1cb867e5a67c9e1ab758de9cb4a3e52dd70681f59fa40a62b3f2d"},
+    {file = "Flask-2.2.3.tar.gz", hash = "sha256:7eb373984bf1c770023fce9db164ed0c3353cd0b53f130f4693da0ca756a2e6d"},
 ]
 
 [package.dependencies]
-blinker = ">=1.6.2"
-click = ">=8.1.3"
+click = ">=8.0"
 importlib-metadata = {version = ">=3.6.0", markers = "python_version < \"3.10\""}
-itsdangerous = ">=2.1.2"
-Jinja2 = ">=3.1.2"
-Werkzeug = ">=2.3.3"
+itsdangerous = ">=2.0"
+Jinja2 = ">=3.0"
+Werkzeug = ">=2.2.2"
 
 [package.extras]
 async = ["asgiref (>=3.2)"]
@@ -700,14 +685,14 @@ dotenv = ["python-dotenv"]
 
 [[package]]
 name = "flatbuffers"
-version = "23.5.9"
+version = "23.5.26"
 description = "The FlatBuffers serialization format for Python"
 category = "main"
 optional = true
 python-versions = "*"
 files = [
-    {file = "flatbuffers-23.5.9-py2.py3-none-any.whl", hash = "sha256:a02eb8c2d61cba153cd211937de8f8f7764b6a7510971b2c4684ed8b02e6e571"},
-    {file = "flatbuffers-23.5.9.tar.gz", hash = "sha256:93a506b6ab771c79ce816e7b35a93ed08ec5b4c9edb811101a22c44a4152f018"},
+    {file = "flatbuffers-23.5.26-py2.py3-none-any.whl", hash = "sha256:c0ff356da363087b915fde4b8b45bdda73432fc17cddb3c8157472eab1422ad1"},
+    {file = "flatbuffers-23.5.26.tar.gz", hash = "sha256:9ea1144cac05ce5d86e2859f431c6cd5e66cd9c78c558317c7955fb8d4c78d89"},
 ]
 
 [[package]]
@@ -815,20 +800,20 @@ files = [
 
 [[package]]
 name = "google-auth"
-version = "2.18.1"
+version = "2.19.0"
 description = "Google Authentication Library"
 category = "main"
 optional = true
-python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
+python-versions = ">=3.6"
 files = [
-    {file = "google-auth-2.18.1.tar.gz", hash = "sha256:d7a3249027e7f464fbbfd7ee8319a08ad09d2eea51578575c4bd360ffa049ccb"},
-    {file = "google_auth-2.18.1-py2.py3-none-any.whl", hash = "sha256:55a395cdfd3f3dd3f649131d41f97c17b4ed8a2aac1be3502090c716314e8a37"},
+    {file = "google-auth-2.19.0.tar.gz", hash = "sha256:f39d528077ac540793dd3c22a8706178f157642a67d874db25c640b7fead277e"},
+    {file = "google_auth-2.19.0-py2.py3-none-any.whl", hash = "sha256:be617bfaf77774008e9d177573f782e109188c8a64ae6e744285df5cea3e7df6"},
 ]
 
 [package.dependencies]
 cachetools = ">=2.0.0,<6.0"
 pyasn1-modules = ">=0.2.1"
-rsa = {version = ">=3.1.4,<5", markers = "python_version >= \"3.6\""}
+rsa = ">=3.1.4,<5"
 six = ">=1.9.0"
 urllib3 = "<2.0"
 
@@ -1094,14 +1079,14 @@ files = [
 
 [[package]]
 name = "ipython"
-version = "8.12.2"
+version = "8.13.2"
 description = "IPython: Productive Interactive Computing"
 category = "main"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "ipython-8.12.2-py3-none-any.whl", hash = "sha256:ea8801f15dfe4ffb76dea1b09b847430ffd70d827b41735c64a0638a04103bfc"},
-    {file = "ipython-8.12.2.tar.gz", hash = "sha256:c7b80eb7f5a855a88efc971fda506ff7a91c280b42cdae26643e0f601ea281ea"},
+    {file = "ipython-8.13.2-py3-none-any.whl", hash = "sha256:ffca270240fbd21b06b2974e14a86494d6d29290184e788275f55e0b55914926"},
+    {file = "ipython-8.13.2.tar.gz", hash = "sha256:7dff3fad32b97f6488e02f87b970f309d082f758d7b7fc252e3b19ee0e432dbb"},
 ]
 
 [package.dependencies]
@@ -2218,25 +2203,25 @@ wcwidth = "*"
 
 [[package]]
 name = "protobuf"
-version = "4.23.1"
+version = "4.23.2"
 description = ""
 category = "main"
 optional = true
 python-versions = ">=3.7"
 files = [
-    {file = "protobuf-4.23.1-cp310-abi3-win32.whl", hash = "sha256:410bcc0a5b279f634d3e16082ce221dfef7c3392fac723500e2e64d1806dd2be"},
-    {file = "protobuf-4.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:32e78beda26d7a101fecf15d7a4a792278a0d26a31bc327ff05564a9d68ab8ee"},
-    {file = "protobuf-4.23.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:f9510cac91e764e86acd74e2b7f7bc5e6127a7f3fb646d7c8033cfb84fd1176a"},
-    {file = "protobuf-4.23.1-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:346990f634272caac1f09efbcfbbacb23098b1f606d172534c6fa2d9758bb436"},
-    {file = "protobuf-4.23.1-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:3ce113b3f3362493bddc9069c2163a38f240a9ed685ff83e7bcb756b05e1deb0"},
-    {file = "protobuf-4.23.1-cp37-cp37m-win32.whl", hash = "sha256:2036a3a1e7fc27f973fa0a7888dce712393af644f4695385f117886abc792e39"},
-    {file = "protobuf-4.23.1-cp37-cp37m-win_amd64.whl", hash = "sha256:3b8905eafe4439076e1f58e9d1fa327025fd2777cf90f14083092ae47f77b0aa"},
-    {file = "protobuf-4.23.1-cp38-cp38-win32.whl", hash = "sha256:5b9cd6097e6acae48a68cb29b56bc79339be84eca65b486910bb1e7a30e2b7c1"},
-    {file = "protobuf-4.23.1-cp38-cp38-win_amd64.whl", hash = "sha256:decf119d54e820f298ee6d89c72d6b289ea240c32c521f00433f9dc420595f38"},
-    {file = "protobuf-4.23.1-cp39-cp39-win32.whl", hash = "sha256:91fac0753c3c4951fbb98a93271c43cc7cf3b93cf67747b3e600bb1e5cc14d61"},
-    {file = "protobuf-4.23.1-cp39-cp39-win_amd64.whl", hash = "sha256:ac50be82491369a9ec3710565777e4da87c6d2e20404e0abb1f3a8f10ffd20f0"},
-    {file = "protobuf-4.23.1-py3-none-any.whl", hash = "sha256:65f0ac96ef67d7dd09b19a46aad81a851b6f85f89725577f16de38f2d68ad477"},
-    {file = "protobuf-4.23.1.tar.gz", hash = "sha256:95789b569418a3e32a53f43d7763be3d490a831e9c08042539462b6d972c2d7e"},
+    {file = "protobuf-4.23.2-cp310-abi3-win32.whl", hash = "sha256:384dd44cb4c43f2ccddd3645389a23ae61aeb8cfa15ca3a0f60e7c3ea09b28b3"},
+    {file = "protobuf-4.23.2-cp310-abi3-win_amd64.whl", hash = "sha256:09310bce43353b46d73ba7e3bca78273b9bc50349509b9698e64d288c6372c2a"},
+    {file = "protobuf-4.23.2-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:b2cfab63a230b39ae603834718db74ac11e52bccaaf19bf20f5cce1a84cf76df"},
+    {file = "protobuf-4.23.2-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:c52cfcbfba8eb791255edd675c1fe6056f723bf832fa67f0442218f8817c076e"},
+    {file = "protobuf-4.23.2-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:86df87016d290143c7ce3be3ad52d055714ebaebb57cc659c387e76cfacd81aa"},
+    {file = "protobuf-4.23.2-cp37-cp37m-win32.whl", hash = "sha256:281342ea5eb631c86697e1e048cb7e73b8a4e85f3299a128c116f05f5c668f8f"},
+    {file = "protobuf-4.23.2-cp37-cp37m-win_amd64.whl", hash = "sha256:ce744938406de1e64b91410f473736e815f28c3b71201302612a68bf01517fea"},
+    {file = "protobuf-4.23.2-cp38-cp38-win32.whl", hash = "sha256:6c081863c379bb1741be8f8193e893511312b1d7329b4a75445d1ea9955be69e"},
+    {file = "protobuf-4.23.2-cp38-cp38-win_amd64.whl", hash = "sha256:25e3370eda26469b58b602e29dff069cfaae8eaa0ef4550039cc5ef8dc004511"},
+    {file = "protobuf-4.23.2-cp39-cp39-win32.whl", hash = "sha256:efabbbbac1ab519a514579ba9ec52f006c28ae19d97915951f69fa70da2c9e91"},
+    {file = "protobuf-4.23.2-cp39-cp39-win_amd64.whl", hash = "sha256:54a533b971288af3b9926e53850c7eb186886c0c84e61daa8444385a4720297f"},
+    {file = "protobuf-4.23.2-py3-none-any.whl", hash = "sha256:8da6070310d634c99c0db7df48f10da495cc283fd9e9234877f0cd182d43ab7f"},
+    {file = "protobuf-4.23.2.tar.gz", hash = "sha256:20874e7ca4436f683b64ebdbee2129a5a2c301579a67d1a7dda2cdf62fb7f5f7"},
 ]
 
 [[package]]
@@ -2651,11 +2636,11 @@ tabulate = ">=0.9.0,<0.10.0"
 
 [[package]]
 name = "qibolab"
-version = "0.0.4"
+version = "0.0.5"
 description = "Quantum hardware module and drivers for Qibo"
 category = "main"
 optional = false
-python-versions = ">=3.8,<3.12"
+python-versions = ">=3.9,<3.12"
 files = []
 develop = false
 
@@ -2668,12 +2653,13 @@ qibo = "^0.1.12"
 [package.extras]
 qblox = ["pyvisa-py (==0.5.3)", "qblox-instruments (==0.9.0)", "qcodes (>=0.37.0,<0.38.0)", "qcodes_contrib_drivers (==0.18.0)"]
 qm = ["qm-qua (==1.1.1)", "qualang-tools (==0.14.0)"]
+zh = ["laboneq (==2.5.0)"]
 
 [package.source]
 type = "git"
 url = "https://github.com/qiboteam/qibolab.git"
 reference = "main"
-resolved_reference = "1a00c69090654dbc0b7d34e691732ea0081d80dd"
+resolved_reference = "7a5b331498fe788620ac9ec3071fff71dcd745bc"
 
 [[package]]
 name = "recommonmark"
@@ -3413,14 +3399,14 @@ test = ["argcomplete (>=2.0)", "pre-commit", "pytest", "pytest-mock"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.6.1"
+version = "4.6.2"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typing_extensions-4.6.1-py3-none-any.whl", hash = "sha256:6bac751f4789b135c43228e72de18637e9a6c29d12777023a703fd1a6858469f"},
-    {file = "typing_extensions-4.6.1.tar.gz", hash = "sha256:558bc0c4145f01e6405f4a5fdbd82050bd221b119f4bf72a961a1cfd471349d6"},
+    {file = "typing_extensions-4.6.2-py3-none-any.whl", hash = "sha256:3a8b36f13dd5fdc5d1b16fe317f5668545de77fa0b8e02006381fd49d731ab98"},
+    {file = "typing_extensions-4.6.2.tar.gz", hash = "sha256:06006244c70ac8ee83fa8282cb188f697b8db25bc8b4df07be1873c43897060c"},
 ]
 
 [[package]]
@@ -3475,21 +3461,21 @@ files = [
 
 [[package]]
 name = "werkzeug"
-version = "2.3.4"
+version = "2.2.3"
 description = "The comprehensive WSGI web application library."
 category = "main"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.7"
 files = [
-    {file = "Werkzeug-2.3.4-py3-none-any.whl", hash = "sha256:48e5e61472fee0ddee27ebad085614ebedb7af41e88f687aaf881afb723a162f"},
-    {file = "Werkzeug-2.3.4.tar.gz", hash = "sha256:1d5a58e0377d1fe39d061a5de4469e414e78ccb1e1e59c0f5ad6fa1c36c52b76"},
+    {file = "Werkzeug-2.2.3-py3-none-any.whl", hash = "sha256:56433961bc1f12533306c624f3be5e744389ac61d722175d543e1751285da612"},
+    {file = "Werkzeug-2.2.3.tar.gz", hash = "sha256:2e1ccc9417d4da358b9de6f174e3ac094391ea1d4fbef2d667865d819dfd0afe"},
 ]
 
 [package.dependencies]
 MarkupSafe = ">=2.1.1"
 
 [package.extras]
-watchdog = ["watchdog (>=2.3)"]
+watchdog = ["watchdog"]
 
 [[package]]
 name = "wheel"
@@ -3601,5 +3587,5 @@ viz = ["pydot"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8,<3.12"
-content-hash = "5752ea58aedfff6bc5f4812b27627d5b267e77099d53aeb25aac1ede21d7657c"
+python-versions = ">=3.9,<3.12"
+content-hash = "41422c7a1a6f3a91895938aca4ae8cdc8be17dee7f84f4e61866ec0ca43ade72"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.12"
+python = ">=3.9,<3.12"
 qibolab = { git = "https://github.com/qiboteam/qibolab.git", branch = "main" }
 qibo = "^0.1.9"
 pandas = "^1.4.3"

--- a/src/qibocal/auto/execute.py
+++ b/src/qibocal/auto/execute.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Optional, Set, Union
 
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 
 from .graph import Graph
 from .history import Completed, History
@@ -24,7 +24,7 @@ class Executor:
     """Output path."""
     qubits: Optional[Qubits] = None
     """Qubits to be calibrated."""
-    platform: Optional[AbstractPlatform] = None
+    platform: Optional[Platform] = None
     """Qubits' platform."""
     head: Optional[Id] = None
     """The current position."""
@@ -37,7 +37,7 @@ class Executor:
         cls,
         card: Union[dict, Path],
         output: Path,
-        platform: AbstractPlatform = None,
+        platform: Platform = None,
         qubits: Qubits = None,
     ):
         """Load execution graph and associated executor from a runcard."""

--- a/src/qibocal/auto/operation.py
+++ b/src/qibocal/auto/operation.py
@@ -2,7 +2,7 @@ import inspect
 from dataclasses import dataclass, fields
 from typing import Callable, Dict, Generic, NewType, TypeVar, Union
 
-from qibolab.platforms.abstract import Qubit
+from qibolab.qubits import Qubit
 
 OperationId = NewType("OperationId", str)
 """Identifier for a calibration routine."""

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List
 
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 
 from ..protocols.characterization import Operation
 from .operation import Data, DummyPars, Qubits, Results, Routine, dummy_operation
@@ -79,7 +79,7 @@ class Task:
         os.makedirs(path)
         return path
 
-    def run(self, folder: Path, platform: AbstractPlatform, qubits: Qubits) -> Results:
+    def run(self, folder: Path, platform: Platform, qubits: Qubits) -> Results:
         try:
             operation: Routine = self.operation
             parameters = self.parameters

--- a/src/qibocal/calibrations/characterization/allXY.py
+++ b/src/qibocal/calibrations/characterization/allXY.py
@@ -1,5 +1,5 @@
 import numpy as np
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 
 from qibocal import plots
@@ -35,7 +35,7 @@ gatelist = [
 
 @plot("Probability vs Gate Sequence", plots.allXY)
 def allXY(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     beta_param=None,
     software_averages=1,
@@ -48,7 +48,7 @@ def allXY(
     qubit in |1> state.
 
     Args:
-        platform (AbstractPlatform): Qibolab platform object
+        platform (Platform): Qibolab platform object
         qubits (dict): Dict of target Qubit objects to perform the action
         beta_param (float): Drag pi pulse coefficient. If none, teh default shape defined in the runcard will be used.
         software_averages (int): Number of executions of the routine for averaging results
@@ -116,7 +116,7 @@ def allXY(
 
 @plot("Probability vs Gate Sequence", plots.allXY_drag_pulse_tuning)
 def allXY_drag_pulse_tuning(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     beta_start,
     beta_end,
@@ -134,7 +134,7 @@ def allXY_drag_pulse_tuning(
     in order to find the optimal drag pulse coefficient for pi pulses.
 
     Args:
-        platform (AbstractPlatform): Qibolab platform object
+        platform (Platform): Qibolab platform object
         qubits (dict): Dict of target Qubit objects to perform the action
         beta_start (float): Initial drag pulse beta parameter
         beta_end (float): Maximum drag pulse beta parameter
@@ -208,7 +208,7 @@ def allXY_drag_pulse_tuning(
 
 @plot("MSR vs beta parameter", plots.drag_pulse_tuning)
 def drag_pulse_tuning(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     beta_start,
     beta_end,
@@ -221,7 +221,7 @@ def drag_pulse_tuning(
     of different beta parameter values. After fitting, we obtain the best coefficient value for a pi pulse with drag shape.
 
     Args:
-        platform (AbstractPlatform): Qibolab platform object
+        platform (Platform): Qibolab platform object
         qubits (dict): Dict of target Qubit objects to perform the action
         beta_start (float): Initial drag pulse beta parameter
         beta_end (float): Maximum drag pulse beta parameter
@@ -357,7 +357,7 @@ def drag_pulse_tuning(
 
 
 def _add_gate_pair_pulses_to_sequence(
-    platform: AbstractPlatform, gates, qubit, beta_param, sequence
+    platform: Platform, gates, qubit, beta_param, sequence
 ):
     pulse_duration = platform.create_RX_pulse(qubit, start=0).duration
     # All gates have equal pulse duration

--- a/src/qibocal/calibrations/characterization/calibrate_qubit_states.py
+++ b/src/qibocal/calibrations/characterization/calibrate_qubit_states.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import numpy as np
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 
 from qibocal import plots
@@ -16,7 +16,7 @@ MARGIN = 0
 
 @plot("Qubit States", plots.qubit_states)
 def calibrate_qubit_states(
-    platform: AbstractPlatform, qubits: dict, nshots: int, classifiers, save_dir: str
+    platform: Platform, qubits: dict, nshots: int, classifiers, save_dir: str
 ):
     """
     Method which implements the state's calibration of a chosen qubit. Two analogous tests are performed
@@ -24,7 +24,7 @@ def calibrate_qubit_states(
     The subscripts `exc` and `gnd` will represent the excited state |1> and the ground state |0>.
 
     Args:
-        platform (:class:`qibolab.platforms.abstract.AbstractPlatform`): custom abstract platform on which we perform the calibration.
+        platform (:class:`qibolab.platforms.abstract.Platform`): custom abstract platform on which we perform the calibration.
         qubits (dict): Dict of target Qubit objects to perform the action
         nshots (int): number of times the pulse sequence will be repeated.
         classifiers (list): list of classifiers

--- a/src/qibocal/calibrations/characterization/cryoscope.py
+++ b/src/qibocal/calibrations/characterization/cryoscope.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import numpy as np
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import FluxPulse, PulseSequence, Rectangular
 from qibolab.sweeper import Parameter, Sweeper
 
@@ -12,7 +12,7 @@ from qibocal.decorators import plot
 
 @plot("Flux pulse timing", plots.flux_pulse_timing)
 def flux_pulse_timing(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: list,
     flux_pulse_amplitude_start,
     flux_pulse_amplitude_end,
@@ -34,7 +34,7 @@ def flux_pulse_timing(
     the flux pulses in the implementation of 2q gates.
 
     Args:
-        platform (AbstractPlatform): Qibolab platform object
+        platform (Platform): Qibolab platform object
         qubits (list): List of target qubits to perform the action
         flux_pulse_amplitude_start (int): Initial flux pulse amplitude
         flux_pulse_amplitude_end (int): Maximum flux pulse amplitude
@@ -243,7 +243,7 @@ def flux_pulse_timing(
     plots.cryoscope_reconstructed_amplitude_time,
 )
 def cryoscope(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     flux_pulse_amplitude,
     flux_pulse_duration_start,
@@ -284,7 +284,7 @@ def cryoscope(
     https://arxiv.org/abs/1907.04818
 
     Args:
-        platform (AbstractPlatform): Qibolab platform object
+        platform (Platform): Qibolab platform object
         qubits (list): List of target qubits to perform the action
         flux_pulse_duration_start (int): Initial flux pulse duration
         flux_pulse_duration_end (int): Maximum flux pulse duration

--- a/src/qibocal/calibrations/characterization/flipping.py
+++ b/src/qibocal/calibrations/characterization/flipping.py
@@ -1,5 +1,5 @@
 import numpy as np
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 
 from qibocal import plots
@@ -10,7 +10,7 @@ from qibocal.fitting.methods import flipping_fit
 
 @plot("MSR vs Flips", plots.flips_msr)
 def flipping(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     nflips_max,
     nflips_step,
@@ -22,7 +22,7 @@ def flipping(
     a Rx(pi/2) and N flips (Rx(pi) rotations). After fitting we can obtain the delta amplitude to refine pi pulses.
 
     Args:
-        platform (AbstractPlatform): Qibolab platform object
+        platform (Platform): Qibolab platform object
         qubits (dict): Dict of target Qubit objects to perform the action
         nflips_max (int): Maximum number of flips introduced in each sequence
         nflips_step (int): Scan range step for the number of flippings

--- a/src/qibocal/calibrations/characterization/qubit_spectroscopy.py
+++ b/src/qibocal/calibrations/characterization/qubit_spectroscopy.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import numpy as np
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper
 
@@ -13,7 +13,7 @@ from qibocal.fitting.methods import lorentzian_fit, qubit_spectroscopy_flux_fit
 
 @plot("MSR and Phase vs Qubit Drive Frequency", plots.frequency_msr_phase)
 def qubit_spectroscopy(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     freq_width: int,
     freq_step: int,
@@ -29,7 +29,7 @@ def qubit_spectroscopy(
     Afterthat, a final sweep with more precision is executed centered in the new qubit frequency found.
 
     Args:
-        platform (AbstractPlatform): Qibolab platform object
+        platform (Platform): Qibolab platform object
         qubits (dict): Dict of target Qubit objects to perform the action
         freq_width (int): Width frequency in HZ to perform the high resolution sweep
         freq_step (int): Step frequency in HZ for the high resolution sweep
@@ -134,7 +134,7 @@ def qubit_spectroscopy(
     plots.frequency_flux_msr_phase_qubit,
 )
 def qubit_spectroscopy_flux(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     drive_amplitude,
     freq_width,
@@ -152,7 +152,7 @@ def qubit_spectroscopy_flux(
     This routine works for multiqubit devices flux controlled.
 
     Args:
-        platform (AbstractPlatform): Qibolab platform object
+        platform (Platform): Qibolab platform object
         qubits (dict): Dict of target Qubit objects to perform the action
         freq_width (int): Width frequency in HZ to perform the spectroscopy sweep
         freq_step (int): Step frequency in HZ for the spectroscopy sweep

--- a/src/qibocal/calibrations/characterization/rabi.py
+++ b/src/qibocal/calibrations/characterization/rabi.py
@@ -1,5 +1,5 @@
 import numpy as np
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper
 
@@ -11,7 +11,7 @@ from qibocal.fitting.methods import rabi_fit
 
 @plot("MSR vs Time", plots.time_msr_phase)
 def rabi_pulse_length(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     pulse_duration_start,
     pulse_duration_end,
@@ -25,7 +25,7 @@ def rabi_pulse_length(
     to find the drive pulse length that creates a rotation of a desired angle.
 
     Args:
-        platform (AbstractPlatform): Qibolab platform object
+        platform (Platform): Qibolab platform object
         qubits (dict): Dict of target Qubit objects to perform the action
         pulse_duration_start (int): Initial drive pulse duration for the Rabi experiment
         pulse_duration_end (int): Maximum drive pulse duration for the Rabi experiment
@@ -140,7 +140,7 @@ def rabi_pulse_length(
 
 @plot("MSR vs Gain", plots.gain_msr_phase)
 def rabi_pulse_gain(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     pulse_gain_start,
     pulse_gain_end,
@@ -153,7 +153,7 @@ def rabi_pulse_gain(
     to find the drive pulse gain that creates a rotation of a desired angle.
 
     Args:
-        platform (AbstractPlatform): Qibolab platform object
+        platform (Platform): Qibolab platform object
         qubits (dict): Dict of target Qubit objects to perform the action
         pulse_gain_start (int): Initial drive pulse gain for the Rabi experiment
         pulse_gain_end (int): Maximum drive pulse gain for the Rabi experiment
@@ -268,7 +268,7 @@ def rabi_pulse_gain(
 
 @plot("MSR vs Amplitude", plots.amplitude_msr_phase)
 def rabi_pulse_amplitude(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     pulse_amplitude_start,
     pulse_amplitude_end,
@@ -282,7 +282,7 @@ def rabi_pulse_amplitude(
     to find the drive pulse amplitude that creates a rotation of a desired angle.
 
     Args:
-        platform (AbstractPlatform): Qibolab platform object
+        platform (Platform): Qibolab platform object
         qubits (dict): Dict of target Qubit objects to perform the action
         pulse_amplitude_start (int): Initial drive pulse amplitude for the Rabi experiment
         pulse_amplitude_end (int): Maximum drive pulse amplitude for the Rabi experiment
@@ -383,7 +383,7 @@ def rabi_pulse_amplitude(
 
 @plot("MSR vs length and gain", plots.duration_gain_msr_phase)
 def rabi_pulse_length_and_gain(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     pulse_duration_start,
     pulse_duration_end,
@@ -399,7 +399,7 @@ def rabi_pulse_length_and_gain(
     combination of duration and gain to find the drive pulse amplitude that creates a rotation of a desired angle.
 
     Args:
-        platform (AbstractPlatform): Qibolab platform object
+        platform (Platform): Qibolab platform object
         qubits (dict): Dict of target Qubit objects to perform the action
         pulse_duration_start (int): Initial drive pulse duration for the Rabi experiment
         pulse_duration_end (int): Maximum drive pulse duration for the Rabi experiment
@@ -508,7 +508,7 @@ def rabi_pulse_length_and_amplitude(
     combination of duration and amplitude to find the drive pulse amplitude that creates a rotation of a desired angle.
 
     Args:
-        platform (AbstractPlatform): Qibolab platform object
+        platform (Platform): Qibolab platform object
         qubit (int): Target qubit to perform the action
         pulse_duration_start (int): Initial drive pulse duration for the Rabi experiment
         pulse_duration_end (int): Maximum drive pulse duration for the Rabi experiment

--- a/src/qibocal/calibrations/characterization/ramsey.py
+++ b/src/qibocal/calibrations/characterization/ramsey.py
@@ -1,5 +1,5 @@
 import numpy as np
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 
 from qibocal import plots
@@ -10,7 +10,7 @@ from qibocal.fitting.methods import ramsey_fit
 
 @plot("MSR vs Time", plots.time_msr)
 def ramsey_frequency_detuned(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     delay_between_pulses_start,
     delay_between_pulses_end,
@@ -31,7 +31,7 @@ def ramsey_frequency_detuned(
     Ramsey sequence: Rx(pi/2) - wait time - Rx(pi/2) - ReadOut
 
     Args:
-        platform (AbstractPlatform): Qibolab platform object
+        platform (Platform): Qibolab platform object
         qubits (dict): Dict of target Qubit objects to perform the action
         delay_between_pulses_start (int): Initial time delay between drive pulses in the Ramsey sequence
         delay_between_pulses_end (list): List of maximum time delays between drive pulses in the Ramsey sequence
@@ -227,7 +227,7 @@ def ramsey_frequency_detuned(
 
 @plot("MSR vs Time", plots.time_msr)
 def ramsey(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     delay_between_pulses_start,
     delay_between_pulses_end,
@@ -241,7 +241,7 @@ def ramsey(
     Ramsey sequence: Rx(pi/2) - wait time - Rx(pi/2) - ReadOut
 
     Args:
-        platform (AbstractPlatform): Qibolab platform object
+        platform (Platform): Qibolab platform object
         qubits (dict): Dict of target Qubit objects to perform the action
         delay_between_pulses_start (int): Initial time delay between drive pulses in the Ramsey sequence
         delay_between_pulses_end (list): Maximum time delay between drive pulses in the Ramsey sequence

--- a/src/qibocal/calibrations/characterization/resonator_spectroscopy.py
+++ b/src/qibocal/calibrations/characterization/resonator_spectroscopy.py
@@ -1,6 +1,6 @@
 import numpy as np
 from qibo.config import log
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper
 
@@ -12,7 +12,7 @@ from qibocal.fitting.methods import lorentzian_fit, resonator_spectroscopy_flux_
 
 @plot("MSR and Phase vs Resonator Frequency", plots.frequency_msr_phase)
 def resonator_spectroscopy(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     freq_width: int,
     freq_step: int,
@@ -27,7 +27,7 @@ def resonator_spectroscopy(
     resonator frequency found.
 
     Args:
-        platform (AbstractPlatform): Qibolab platform object
+        platform (Platform): Qibolab platform object
         qubits (dict): List of target qubits to perform the action
         freq_width (int): Width frequency in HZ to perform the high resolution sweep
         freq_step (int): Step frequency in HZ for the high resolution sweep
@@ -125,7 +125,7 @@ def resonator_spectroscopy(
     "Cross section at half range attenuation", plots.frequency_attenuation_msr_phase_cut
 )
 def resonator_punchout_attenuation(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     freq_width,
     freq_step,
@@ -142,7 +142,7 @@ def resonator_punchout_attenuation(
     That shows the two regimes of a given resonator, low and high-power regimes.
 
     Args:
-        platform (AbstractPlatform): Qibolab platform object
+        platform (Platform): Qibolab platform object
         qubits (dict): List of target qubits to perform the action
         freq_width (int): Width frequency in HZ to perform the spectroscopy sweep
         freq_step (int): Step frequency in HZ for the spectroscopy sweep
@@ -243,7 +243,7 @@ def resonator_punchout_attenuation(
     plots.frequency_amplitude_msr_phase,
 )
 def resonator_punchout(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     freq_width,
     freq_step,
@@ -260,7 +260,7 @@ def resonator_punchout(
     That shows the two regimes of a given resonator, low and high-power regimes.
 
     Args:
-        platform (AbstractPlatform): Qibolab platform object
+        platform (Platform): Qibolab platform object
         qubits (dict): List of target qubits to perform the action
         freq_width (int): Width frequency in HZ to perform the spectroscopy sweep
         freq_step (int): Step frequency in HZ for the spectroscopy sweep
@@ -365,7 +365,7 @@ def resonator_punchout(
     plots.frequency_flux_msr_phase_resonator,
 )
 def resonator_spectroscopy_flux(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     freq_width,
     freq_step,
@@ -382,7 +382,7 @@ def resonator_spectroscopy_flux(
     This routine works for quantum devices flux controlled.
 
     Args:
-        platform (AbstractPlatform): Qibolab platform object
+        platform (Platform): Qibolab platform object
         qubits (dict): List of target qubits to perform the action
         freq_width (int): Width frequency in HZ to perform the spectroscopy sweep
         freq_step (int): Step frequency in HZ for the spectroscopy sweep
@@ -498,7 +498,7 @@ def resonator_spectroscopy_flux(
 
 @plot("MSR and Phase vs Resonator Frequency", plots.dispersive_frequency_msr_phase)
 def dispersive_shift(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     freq_width,
     freq_step,
@@ -510,7 +510,7 @@ def dispersive_shift(
     the resonator shift produced by the coupling between the resonator and the qubit.
 
     Args:
-        platform (AbstractPlatform): Qibolab platform object
+        platform (Platform): Qibolab platform object
         qubits (dict): List of target qubits to perform the action
         freq_width (int): Width frequency in HZ to perform the spectroscopy sweep
         freq_step (int): Step frequency in HZ for the spectroscopy sweep

--- a/src/qibocal/calibrations/characterization/resonator_spectroscopy_sample.py
+++ b/src/qibocal/calibrations/characterization/resonator_spectroscopy_sample.py
@@ -1,5 +1,5 @@
 import numpy as np
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 
 from qibocal.data import DataUnits
@@ -79,7 +79,7 @@ def scan_level(
         span (int): Search space around previous best value where the next frequency is sampled.
         resolution (int): How many points are taken in the span.
         noise (float): MSR value for the background noise.
-        platform (AbstractPlatform): Platform the experiment is executed on.
+        platform (Platform): Platform the experiment is executed on.
         ro_pulse (ReadoutPulse): Used in order to execute the pulse sequence with the right parameters in the right qubit.
         qubit (int): qubit coupled to the resonator that we are probing.
         sequence (PulseSequence):
@@ -123,7 +123,7 @@ def scan_small(best_f, best_msr, span, resolution, platform, ro_pulse, qubit, se
         best_msr (float): MSR found for the previous best frequency. Used to check if a better value is found.
         span (int): Search space around previous best value where the next frequency is sampled.
         resolution (int): How many points are taken in the span. Taken as 10 for the small scan.
-        platform (AbstractPlatform): Platform the experiment is executed on.
+        platform (Platform): Platform the experiment is executed on.
         ro_pulse (ReadoutPulse): Used in order to execute the pulse sequence with the right parameters in the right qubit.
         qubit (int): qubit coupled to the resonator that we are probing.
         sequence (PulseSequence):
@@ -154,7 +154,7 @@ def scan_small(best_f, best_msr, span, resolution, platform, ro_pulse, qubit, se
 
 @plot("Frequency vs Attenuation", frequency_attenuation)
 def resonator_punchout_sample(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     min_att,
     max_att,
@@ -169,7 +169,7 @@ def resonator_punchout_sample(
     """Use gaussian samples to extract the punchout of the resonator for different values of attenuation.
 
     Args:
-        platform (AbstractPlatform): Platform the experiment is executed on.
+        platform (Platform): Platform the experiment is executed on.
         qubits (dict): Dict of target Qubit objects to perform the action
         min_att (int): minimum attenuation value where the experiment starts. Less attenuation -> more power.
         max_att (int): maximum attenuation reached in the scan.
@@ -259,7 +259,7 @@ def resonator_punchout_sample(
 
 @plot("Frequency vs Current", frequency_bias_flux)
 def resonator_flux_sample(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     bias_min,
     bias_max,
@@ -276,7 +276,7 @@ def resonator_flux_sample(
     """Use gaussian samples to extract the flux-frequency response of the resonator for different values of bias.
 
     Args:
-        platform (AbstractPlatform): Platform the experiment is executed on.
+        platform (Platform): Platform the experiment is executed on.
         qubits (dict): Dict of target Qubit objects to perform the action
         bias_min (float): minimum bias value where the experiment starts.
         bias_max (float): maximum bias reached in the scan.

--- a/src/qibocal/calibrations/characterization/ro_optimization.py
+++ b/src/qibocal/calibrations/characterization/ro_optimization.py
@@ -1,5 +1,5 @@
 import numpy as np
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper
 
@@ -11,7 +11,7 @@ from qibocal.fitting.methods import ro_optimization_fit
 
 @plot("Qubit States", plots.ro_frequency)
 def ro_frequency(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     frequency_width: float,
     frequency_step: float,
@@ -24,7 +24,7 @@ def ro_frequency(
     Their distinctiveness is then associated to the fidelity.
 
     Args:
-        platform (:class:`qibolab.platforms.abstract.AbstractPlatform`): custom abstract platform on which we perform the calibration.
+        platform (:class:`qibolab.platforms.abstract.Platform`): custom abstract platform on which we perform the calibration.
         qubits (dict): List of target qubits to perform the action
         nshots (int): number of times the pulse sequence will be repeated.
         frequency_width (float): width of the frequency range to be swept in Hz.
@@ -125,7 +125,7 @@ def ro_frequency(
 
 @plot("Qubit States", plots.ro_amplitude)
 def ro_amplitude(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     amplitude_factor_min: float,
     amplitude_factor_max: float,
@@ -139,7 +139,7 @@ def ro_amplitude(
     Their distinctiveness is then associated to the fidelity.
 
     Args:
-        platform (:class:`qibolab.platforms.abstract.AbstractPlatform`): custom abstract platform on which we perform the calibration.
+        platform (:class:`qibolab.platforms.abstract.Platform`): custom abstract platform on which we perform the calibration.
         qubits (dict): List of target qubits to perform the action
         nshots (int): number of times the pulse sequence will be repeated.
         amplitude_factor_min (float): minimum amplitude factor to be swept.
@@ -241,7 +241,7 @@ def ro_amplitude(
 
 @plot("TWPA frequency", plots.ro_frequency)
 def twpa_frequency(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     frequency_width: float,
     frequency_step: float,
@@ -254,7 +254,7 @@ def twpa_frequency(
     Their distinctiveness is then associated to the fidelity.
 
     Args:
-        platform (:class:`qibolab.platforms.abstract.AbstractPlatform`): custom abstract platform on which we perform the calibration.
+        platform (:class:`qibolab.platforms.abstract.Platform`): custom abstract platform on which we perform the calibration.
         qubits (dict): List of target qubits to perform the action
         frequency_width (float): Frequency range to sweep in Hz
         frequency_step (float): Frequency step to sweep in Hz
@@ -342,7 +342,7 @@ def twpa_frequency(
 
 @plot("TWPA power", plots.ro_power)
 def twpa_power(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: dict,
     power_width: float,
     power_step: float,
@@ -355,7 +355,7 @@ def twpa_power(
     Their distinctiveness is then associated to the fidelity.
 
     Args:
-        platform (:class:`qibolab.platforms.abstract.AbstractPlatform`): custom abstract platform on which we perform the calibration.
+        platform (:class:`qibolab.platforms.abstract.Platform`): custom abstract platform on which we perform the calibration.
         qubits (dict): List of target qubits to perform the action
         power_width (float): width of the power range to be scanned in dBm
         power_step (float): step of the power range to be scanned in dBm

--- a/src/qibocal/calibrations/characterization/spin_echo.py
+++ b/src/qibocal/calibrations/characterization/spin_echo.py
@@ -1,5 +1,5 @@
 import numpy as np
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 
 from qibocal import plots
@@ -10,7 +10,7 @@ from qibocal.fitting.methods import spin_echo_fit
 
 @plot("MSR vs Time", plots.spin_echo_time_msr)
 def spin_echo_3pulses(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: list,
     delay_between_pulses_start,
     delay_between_pulses_end,

--- a/src/qibocal/calibrations/characterization/t1.py
+++ b/src/qibocal/calibrations/characterization/t1.py
@@ -1,5 +1,5 @@
 import numpy as np
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 
 from qibocal import plots
@@ -10,7 +10,7 @@ from qibocal.fitting.methods import t1_fit
 
 @plot("MSR vs Time", plots.t1_time_msr)
 def t1(
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: list,
     delay_before_readout_start,
     delay_before_readout_end,
@@ -26,7 +26,7 @@ def t1(
     towards the ground state.
 
     Args:
-        platform (AbstractPlatform): Qibolab platform object
+        platform (Platform): Qibolab platform object
         qubits (list): List of target qubits to perform the action
         delay_before_readout_start (int): Initial time delay before ReadOut
         delay_before_readout_end (list): Maximum time delay before ReadOut

--- a/src/qibocal/cli/builders.py
+++ b/src/qibocal/cli/builders.py
@@ -174,9 +174,9 @@ class ActionBuilder:
 
         if backend_name == "qibolab":
             if platform_runcard is None:
-                from qibolab.paths import qibolab_folder
+                from qibolab import get_platforms_path
 
-                original_runcard = qibolab_folder / "runcards" / f"{platform_name}.yml"
+                original_runcard = get_platforms_path() / f"{platform_name}.yml"
             else:
                 original_runcard = platform_runcard
             # copy of the original runcard that will stay unmodified

--- a/src/qibocal/fitting/classifier/run.py
+++ b/src/qibocal/fitting/classifier/run.py
@@ -9,7 +9,7 @@ from typing import List, Optional
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from qibolab.platforms.abstract import Qubit
+from qibolab.qubits import Qubit
 from sklearn.metrics import accuracy_score
 
 from . import data, plots

--- a/src/qibocal/protocols/characterization/allxy/allxy.py
+++ b/src/qibocal/protocols/characterization/allxy/allxy.py
@@ -4,7 +4,7 @@ from typing import Optional
 import numpy as np
 import plotly.graph_objects as go
 from qibolab import AveragingMode, ExecutionParameters
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 
 from qibocal.auto.operation import Parameters, Qubits, Results, Routine
@@ -66,7 +66,7 @@ gatelist = [
 
 def _acquisition(
     params: AllXYParameters,
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: Qubits,
 ) -> AllXYData:
     r"""
@@ -118,7 +118,7 @@ def _acquisition(
 
 
 def add_gate_pair_pulses_to_sequence(
-    platform: AbstractPlatform,
+    platform: Platform,
     gates,
     qubit,
     sequence,

--- a/src/qibocal/protocols/characterization/allxy/allxy_drag_pulse_tuning.py
+++ b/src/qibocal/protocols/characterization/allxy/allxy_drag_pulse_tuning.py
@@ -4,7 +4,7 @@ from typing import Optional
 import numpy as np
 import plotly.graph_objects as go
 from qibolab import AveragingMode, ExecutionParameters
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 
 from qibocal.auto.operation import Parameters, Qubits, Results, Routine
@@ -52,7 +52,7 @@ class AllXYDragData(Data):
 
 def _acquisition(
     params: AllXYDragParameters,
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: Qubits,
 ) -> AllXYDragData:
     r"""

--- a/src/qibocal/protocols/characterization/allxy/drag_pulse_tuning.py
+++ b/src/qibocal/protocols/characterization/allxy/drag_pulse_tuning.py
@@ -5,7 +5,7 @@ import numpy as np
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 from scipy.optimize import curve_fit
 
@@ -57,7 +57,7 @@ class DragPulseTuningData(DataUnits):
 
 def _acquisition(
     params: DragPulseTuningParameters,
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: Qubits,
 ) -> DragPulseTuningData:
     r"""

--- a/src/qibocal/protocols/characterization/classification.py
+++ b/src/qibocal/protocols/characterization/classification.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Union
 import numpy as np
 import plotly.graph_objects as go
 from qibolab import AcquisitionType, ExecutionParameters
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 
 from qibocal.auto.operation import Parameters, Qubits, Results, Routine
@@ -58,7 +58,7 @@ class SingleShotClassificationResults(Results):
 
 def _acquisition(
     params: SingleShotClassificationParameters,
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: Qubits,
 ) -> SingleShotClassificationData:
     """
@@ -67,7 +67,7 @@ def _acquisition(
     The subscripts `exc` and `gnd` will represent the excited state |1> and the ground state |0>.
 
     Args:
-        platform (:class:`qibolab.platforms.abstract.AbstractPlatform`): custom abstract platform on which we perform the calibration.
+        platform (:class:`qibolab.platforms.abstract.Platform`): custom abstract platform on which we perform the calibration.
         qubits (dict): Dict of target Qubit objects to perform the action
         nshots (int): number of times the pulse sequence will be repeated.
 

--- a/src/qibocal/protocols/characterization/coherence/spin_echo.py
+++ b/src/qibocal/protocols/characterization/coherence/spin_echo.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Union
 import numpy as np
 import plotly.graph_objects as go
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 
 from qibocal.auto.operation import Parameters, Qubits, Results, Routine
@@ -48,7 +48,7 @@ class SpinEchoData(T1Data):
 
 def _acquisition(
     params: SpinEchoParameters,
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: Qubits,
 ) -> SpinEchoData:
     """Data acquisition for SpinEcho"""

--- a/src/qibocal/protocols/characterization/coherence/t1.py
+++ b/src/qibocal/protocols/characterization/coherence/t1.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Union
 import numpy as np
 import plotly.graph_objects as go
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper
 
@@ -52,9 +52,7 @@ class T1Data(DataUnits):
         )
 
 
-def _acquisition(
-    params: T1Parameters, platform: AbstractPlatform, qubits: Qubits
-) -> T1Data:
+def _acquisition(params: T1Parameters, platform: Platform, qubits: Qubits) -> T1Data:
     r"""Data acquisition for T1 experiment.
     In a T1 experiment, we measure an excited qubit after a delay. Due to decoherence processes
     (e.g. amplitude damping channel), it is possible that, at the time of measurement, after the delay,
@@ -64,7 +62,7 @@ def _acquisition(
 
     Args:
         params:
-        platform (AbstractPlatform): Qibolab platform object
+        platform (Platform): Qibolab platform object
         qubits (list): List of target qubits to perform the action
         delay_before_readout_start (int): Initial time delay before ReadOut
         delay_before_readout_end (list): Maximum time delay before ReadOut

--- a/src/qibocal/protocols/characterization/coherence/t2.py
+++ b/src/qibocal/protocols/characterization/coherence/t2.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Union
 import numpy as np
 import plotly.graph_objects as go
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 
 from qibocal.auto.operation import Parameters, Qubits, Results, Routine
@@ -45,7 +45,7 @@ class T2Data(t1.T1Data):
 
 def _acquisition(
     params: T2Parameters,
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: Qubits,
 ) -> T2Data:
     """Data acquisition for Ramsey Experiment (detuned)."""

--- a/src/qibocal/protocols/characterization/dispersive_shift.py
+++ b/src/qibocal/protocols/characterization/dispersive_shift.py
@@ -6,7 +6,7 @@ import numpy.typing as npt
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper
 
@@ -77,7 +77,7 @@ class DispersiveShiftData(DataUnits):
 
 
 def _acquisition(
-    params: DispersiveShiftParameters, platform: AbstractPlatform, qubits: Qubits
+    params: DispersiveShiftParameters, platform: Platform, qubits: Qubits
 ) -> DispersiveShiftData:
     r"""
     Data acquisition for dispersive shift experiment.
@@ -86,7 +86,7 @@ def _acquisition(
 
     Args:
         params (DispersiveShiftParameters): experiment's parameters
-        platform (AbstractPlatform): Qibolab platform object
+        platform (Platform): Qibolab platform object
         qubits (dict): List of target qubits to perform the action
 
     """

--- a/src/qibocal/protocols/characterization/flipping.py
+++ b/src/qibocal/protocols/characterization/flipping.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Union
 import numpy as np
 import plotly.graph_objects as go
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 from scipy.optimize import curve_fit
 
@@ -62,7 +62,7 @@ class FlippngData(DataUnits):
 
 def _acquisition(
     params: FlippingParameters,
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: Qubits,
 ) -> FlippngData:
     r"""
@@ -73,7 +73,7 @@ def _acquisition(
 
     Args:
         params (:class:`SingleShotClassificationParameters`): input parameters
-        platform (:class:`AbstractPlatform`): Qibolab's platform
+        platform (:class:`Platform`): Qibolab's platform
         qubits (dict): Dict of target :class:`Qubit` objects to be characterized
 
     Returns:

--- a/src/qibocal/protocols/characterization/flux_depedence/qubit_flux_dependence.py
+++ b/src/qibocal/protocols/characterization/flux_depedence/qubit_flux_dependence.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, Union
 
 import numpy as np
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper
 
@@ -53,7 +53,7 @@ class QubitFluxData(resonator_flux_dependence.ResonatorFluxData):
 
 def _acquisition(
     params: QubitFluxParameters,
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: Qubits,
 ) -> QubitFluxData:
     """Data acquisition for QubitFlux Experiment."""

--- a/src/qibocal/protocols/characterization/flux_depedence/resonator_flux_dependence.py
+++ b/src/qibocal/protocols/characterization/flux_depedence/resonator_flux_dependence.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, Union
 
 import numpy as np
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper
 
@@ -58,7 +58,7 @@ class ResonatorFluxData(DataUnits):
 
 
 def _acquisition(
-    params: ResonatorFluxParameters, platform: AbstractPlatform, qubits: Qubits
+    params: ResonatorFluxParameters, platform: Platform, qubits: Qubits
 ) -> ResonatorFluxData:
     """Data acquisition for ResonatorFlux experiment."""
     # create a sequence of pulses for the experiment:

--- a/src/qibocal/protocols/characterization/qubit_spectroscopy.py
+++ b/src/qibocal/protocols/characterization/qubit_spectroscopy.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, Union
 
 import numpy as np
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper
 
@@ -50,7 +50,7 @@ class QubitSpectroscopyData(ResonatorSpectroscopyData):
 
 
 def _acquisition(
-    params: QubitSpectroscopyParameters, platform: AbstractPlatform, qubits: Qubits
+    params: QubitSpectroscopyParameters, platform: Platform, qubits: Qubits
 ) -> QubitSpectroscopyData:
     """Data acquisition for qubit spectroscopy."""
     # create a sequence of pulses for the experiment:

--- a/src/qibocal/protocols/characterization/rabi/amplitude.py
+++ b/src/qibocal/protocols/characterization/rabi/amplitude.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, Union
 
 import numpy as np
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper
 from scipy.optimize import curve_fit
@@ -59,7 +59,7 @@ class RabiAmplitudeData(DataUnits):
 
 
 def _acquisition(
-    params: RabiAmplitudeParameters, platform: AbstractPlatform, qubits: Qubits
+    params: RabiAmplitudeParameters, platform: Platform, qubits: Qubits
 ) -> RabiAmplitudeData:
     r"""
     Data acquisition for Rabi experiment sweeping amplitude.

--- a/src/qibocal/protocols/characterization/rabi/length.py
+++ b/src/qibocal/protocols/characterization/rabi/length.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, Union
 
 import numpy as np
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 from scipy.optimize import curve_fit
 
@@ -50,7 +50,7 @@ class RabiLengthData(amplitude.RabiAmplitudeData):
 
 
 def _acquisition(
-    params: RabiLengthParameters, platform: AbstractPlatform, qubits: Qubits
+    params: RabiLengthParameters, platform: Platform, qubits: Qubits
 ) -> RabiLengthData:
     r"""
     Data acquisition for RabiLength Experiment.

--- a/src/qibocal/protocols/characterization/ramsey.py
+++ b/src/qibocal/protocols/characterization/ramsey.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Union
 import numpy as np
 import plotly.graph_objects as go
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 from scipy.optimize import curve_fit
 
@@ -83,7 +83,7 @@ class RamseyData(DataUnits):
 
 def _acquisition(
     params: RamseyParameters,
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: Qubits,
 ) -> RamseyData:
     """Data acquisition for Ramsey Experiment (detuned)."""

--- a/src/qibocal/protocols/characterization/resonator_punchout.py
+++ b/src/qibocal/protocols/characterization/resonator_punchout.py
@@ -5,7 +5,7 @@ import numpy as np
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper
 
@@ -73,7 +73,7 @@ class ResonatorPunchoutData(DataUnits):
 
 def _acquisition(
     params: ResonatorPunchoutParameters,
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: Qubits,
 ) -> ResonatorPunchoutData:
     """Data acquisition for Punchout over amplitude."""

--- a/src/qibocal/protocols/characterization/resonator_punchout_attenuation.py
+++ b/src/qibocal/protocols/characterization/resonator_punchout_attenuation.py
@@ -5,7 +5,7 @@ import numpy as np
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper
 
@@ -83,7 +83,7 @@ class ResonatorPunchoutAttenuationData(DataUnits):
 
 def _acquisition(
     params: ResonatorPunchoutAttenuationParameters,
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: Qubits,
 ) -> ResonatorPunchoutAttenuationData:
     """Data acquisition for Punchout over attenuation."""

--- a/src/qibocal/protocols/characterization/resonator_spectroscopy.py
+++ b/src/qibocal/protocols/characterization/resonator_spectroscopy.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, Union
 
 import numpy as np
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper
 
@@ -91,7 +91,7 @@ class ResonatorSpectroscopyData(DataUnits):
 
 
 def _acquisition(
-    params: ResonatorSpectroscopyParameters, platform: AbstractPlatform, qubits: Qubits
+    params: ResonatorSpectroscopyParameters, platform: Platform, qubits: Qubits
 ) -> ResonatorSpectroscopyData:
     """Data acquisition for resonator spectroscopy."""
     # create a sequence of pulses for the experiment:

--- a/src/qibocal/protocols/characterization/resonator_spectroscopy_attenuation.py
+++ b/src/qibocal/protocols/characterization/resonator_spectroscopy_attenuation.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from typing import Dict, Optional, Union
 
 import numpy as np
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper
 
@@ -102,7 +102,7 @@ class ResonatorSpectroscopyAttenuationData(DataUnits):
 
 def _acquisition(
     params: ResonatorSpectroscopyAttenuationParameters,
-    platform: AbstractPlatform,
+    platform: Platform,
     qubits: Qubits,
 ) -> ResonatorSpectroscopyAttenuationData:
     """Data acquisition for resonator spectroscopy attenuation."""

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -2,14 +2,14 @@
 import pathlib
 
 import pytest
-from qibolab.platform import Platform
+from qibolab import create_platform
 
 from qibocal.auto.runcard import Runcard
 from qibocal.auto.task import Task
 
 PATH_TO_RUNCARD = pathlib.Path(__file__).parent / "runcards/single_routines.yml"
 RUNCARD = Runcard.load(PATH_TO_RUNCARD)
-platform = Platform("dummy")
+platform = create_platform("dummy")
 
 
 @pytest.mark.parametrize("action", RUNCARD.actions)

--- a/tests/test_qq_auto.py
+++ b/tests/test_qq_auto.py
@@ -1,11 +1,15 @@
 import pathlib
 import tempfile
 
+import pytest
+
 from qibocal.cli.auto_builder import AutoCalibrationBuilder
 
 PATH_TO_RUNCARD = pathlib.Path(__file__).parent / "runcards/test_autocalibration.yml"
 
 
+# FIXME: https://github.com/qiboteam/qibolab/issues/454
+@pytest.mark.skip(reason="Waiting for dummy platform support.")
 def test_qq_auto_dummy():
     """Test full calibration pipeline for autocalibration."""
     folder = tempfile.mkdtemp()


### PR DESCRIPTION
Updates required for compatibility with qiboteam/qibolab#438:

* `from qibolab.platforms.abstract.AbstractPlatform` -> `from qibolab.platform import Platform`
* `from qibolab.platforms.abstract.Qubit` -> `from qibolab.qubits import Qubit`
* Platform runcards are removed from qibolab and moved to a new repository so the `ActionBuilder` was updated accordingly.

Tests are failing because they need qiboteam/qibolab#438.
I tested resonator_spectroscopy, punchout, resonator_flux and qubit_spectroscopy (autocalibration layout) with QM and they work.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
