### PR TITLE
Adding logs

### DIFF
--- a/src/qibocal/auto/execute.py
+++ b/src/qibocal/auto/execute.py
@@ -5,6 +5,8 @@ from typing import Optional, Set
 
 from qibolab.platform import Platform
 
+from qibocal.config import log
+
 from .graph import Graph
 from .history import Completed, History
 from .runcard import Id, Runcard
@@ -132,6 +134,7 @@ class Executor:
 
         while self.head is not None:
             task = self.current
+            log.info(f"Running task {task.id}.")
             task_execution = task.run(platform=self.platform, qubits=self.qubits)
             completed = Completed(task, Normal(), self.output)
             completed.data = next(task_execution)

--- a/src/qibocal/auto/execute.py
+++ b/src/qibocal/auto/execute.py
@@ -137,11 +137,11 @@ class Executor:
             log.info(f"Running task {task.id}.")
             task_execution = task.run(platform=self.platform, qubits=self.qubits)
             completed = Completed(task, Normal(), self.output)
-            completed.data = next(task_execution)
-            completed.results = next(task_execution)
+            completed.data, acquisition_time = next(task_execution)
+            completed.results, fit_time = next(task_execution)
             self.history.push(completed)
             self.head = self.next()
             if self.platform is not None:
                 if self.update and task.update:
                     self.platform.update(completed.results.update)
-            yield
+            yield acquisition_time, fit_time, task.id

--- a/src/qibocal/auto/operation.py
+++ b/src/qibocal/auto/operation.py
@@ -30,7 +30,6 @@ RESULTSFILE = "results.json"
 
 def show_logs(func):
     """Decorator to add logs."""
-
     @wraps(func)
     # necessary to maintain the function signature
     def wrapper(*args, **kwds):

--- a/src/qibocal/auto/operation.py
+++ b/src/qibocal/auto/operation.py
@@ -28,10 +28,11 @@ RESULTSFILE = "results.json"
 """Name of the file where results are dumped."""
 
 
-def add_logg(func):
-    """Decorator"""
+def show_logs(func):
+    """Decorator to add logs."""
 
     @wraps(func)
+    # necessary to maintain the function signature
     def wrapper(*args, **kwds):
         log.info(f"Starting {func.__name__[1:]}.")
         start = time.time()
@@ -172,9 +173,9 @@ class Routine(Generic[_ParametersT, _DataT, _ResultsT]):
     """Plotting function."""
 
     def __post_init__(self):
-        self.acquisition = add_logg(self.acquisition)
-        self.fit = add_logg(self.fit)
-        self.report = add_logg(self.report)
+        self.acquisition = show_logs(self.acquisition)
+        self.fit = show_logs(self.fit)
+        self.report = show_logs(self.report)
 
         # TODO: this could be improved
         if self.fit is None:

--- a/src/qibocal/auto/operation.py
+++ b/src/qibocal/auto/operation.py
@@ -30,6 +30,7 @@ RESULTSFILE = "results.json"
 
 def show_logs(func):
     """Decorator to add logs."""
+
     @wraps(func)
     # necessary to maintain the function signature
     def wrapper(*args, **kwds):

--- a/src/qibocal/auto/operation.py
+++ b/src/qibocal/auto/operation.py
@@ -173,9 +173,9 @@ class Routine(Generic[_ParametersT, _DataT, _ResultsT]):
     """Plotting function."""
 
     def __post_init__(self):
+        # add decorator to show logs
         self.acquisition = show_logs(self.acquisition)
         self.fit = show_logs(self.fit)
-        self.report = show_logs(self.report)
 
         # TODO: this could be improved
         if self.fit is None:

--- a/src/qibocal/auto/operation.py
+++ b/src/qibocal/auto/operation.py
@@ -35,11 +35,11 @@ def show_logs(func):
     # necessary to maintain the function signature
     def wrapper(*args, **kwds):
         log.info(f"Starting {func.__name__[1:]}.")
-        start = time.time()
+        start = time.perf_counter()
         out = func(*args, **kwds)
-        end = time.time()
+        end = time.perf_counter()
         log.info(f"Finished {func.__name__[1:]} after {end-start:.2f} seconds.")
-        return out
+        return out, end - start
 
     return wrapper
 

--- a/src/qibocal/auto/operation.py
+++ b/src/qibocal/auto/operation.py
@@ -34,11 +34,14 @@ def show_logs(func):
     @wraps(func)
     # necessary to maintain the function signature
     def wrapper(*args, **kwds):
-        log.info(f"Starting {func.__name__[1:]}.")
         start = time.perf_counter()
         out = func(*args, **kwds)
         end = time.perf_counter()
-        log.info(f"Finished {func.__name__[1:]} after {end-start:.2f} seconds.")
+        if end - start < 1:
+            message = " in less than 1 second."
+        else:
+            message = f" in {end-start:.2f} seconds"
+        log.info(f"Finished {func.__name__[1:]}" + message)
         return out, end - start
 
     return wrapper

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -129,13 +129,13 @@ class Task:
                 else:
                     qubits = self.qubits
 
-            data: Data = operation.acquisition(
+            data, time = operation.acquisition(
                 parameters, platform=platform, qubits=qubits
             )
             # after acquisition we update the qubit parameter
             self.qubits = list(qubits)
         else:
-            data: Data = operation.acquisition(parameters, platform=platform)
-        yield data
-        results: Results = operation.fit(data)
-        yield results
+            data, time = operation.acquisition(parameters, platform=platform)
+        yield data, time
+        results, time = operation.fit(data)
+        yield results, time

--- a/src/qibocal/cli/builders.py
+++ b/src/qibocal/cli/builders.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import tempfile
 from pathlib import Path
 
@@ -11,7 +12,7 @@ from qibocal.auto.task import TaskId
 from qibocal.cli.utils import generate_output_folder
 from qibocal.utils import allocate_qubits_pairs, allocate_single_qubits
 
-META = "meta.yml"
+META = "meta.json"
 RUNCARD = "runcard.yml"
 UPDATED_PLATFORM = "new_platform.yml"
 PLATFORM = "platform.yml"
@@ -90,8 +91,7 @@ class ActionBuilder:
         meta["versions"] = self.backend.versions  # pylint: disable=E1101
         meta["versions"]["qibocal"] = qibocal.__version__
 
-        with open(self.folder / META, "w") as file:
-            yaml.dump(meta, file)
+        (self.folder / META).write_text(json.dumps(meta, indent=4))
 
         return meta
 
@@ -122,8 +122,7 @@ class ActionBuilder:
         # update end time
         e = datetime.datetime.now(datetime.timezone.utc)
         self.meta["end-time"] = e.strftime("%H:%M:%S")
-        with open(self.folder / META, "w") as file:
-            yaml.dump(self.meta, file)
+        (self.folder / META).write_text(json.dumps(self.meta, indent=4))
 
         create_report(self.folder, self.executor.history)
 
@@ -138,7 +137,7 @@ class ReportBuilder:
         """Helper class to generate html report."""
         # FIXME: currently the title of the report is the output folder
         self.path = self.title = path
-        self.metadata = yaml.safe_load((path / META).read_text())
+        self.metadata = json.loads((path / META).read_text())
         self.runcard = Runcard.load(yaml.safe_load((path / RUNCARD).read_text()))
         self.qubits = self.runcard.qubits
 

--- a/src/qibocal/config.py
+++ b/src/qibocal/config.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 # Logging levels available here https://docs.python.org/3/library/logging.html#logging-levels
-QIBOCAL_LOG_LEVEL = 30
+QIBOCAL_LOG_LEVEL = 10
 if "QIBOCAL_LOG_LEVEL" in os.environ:  # pragma: no cover
     QIBOCAL_LOG_LEVEL = 10 * int(os.environ.get("QIBOCAL_LOG_LEVEL"))
 


### PR DESCRIPTION
This PR adds some logs in order to show which protocol is being executed.
The timing of both the acquisition and the fitting are shown for each protocol.
Here is an example

![image](https://github.com/qiboteam/qibocal/assets/49183315/bdd1d528-323a-4c67-9990-2dab20192216)



Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
