### PR TITLE
add branches in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,6 @@
+Compatible branches:
+- Qibolab: `main`
+- Qibolab_platform_qrc: `main`
 
 Checklist:
 - [ ] Reviewers confirm new code works as expected.


### PR DESCRIPTION
I would like to introduce this new PR template to force people to specify which branches should be used by the reviewers to test the PRs.
 
Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
