### PR TITLE
Fix dispersive shift (qubit as str)

### DIFF
--- a/src/qibocal/protocols/characterization/dispersive_shift.py
+++ b/src/qibocal/protocols/characterization/dispersive_shift.py
@@ -203,14 +203,14 @@ def _fit(data: DispersiveShiftData) -> DispersiveShiftResults:
     iq_couples = np.array(iq_couples)
     best_freqs = {}
     best_iqs = {}
-    for qubit in qubits:
+    for idx, qubit in enumerate(qubits):
         frequencies = data[qubit, 0].freq * HZ_TO_GHZ
 
         max_index = np.argmax(
-            np.linalg.norm(iq_couples[0][qubit] - iq_couples[1][qubit], axis=-1)
+            np.linalg.norm(iq_couples[0][idx] - iq_couples[1][idx], axis=-1)
         )
         best_freqs[qubit] = frequencies[max_index]
-        best_iqs[qubit] = iq_couples[:, qubit, max_index].tolist()
+        best_iqs[qubit] = iq_couples[:, idx, max_index].tolist()
 
     return DispersiveShiftResults(
         results_0=results[0],


### PR DESCRIPTION
Basically, the dispersive shift didn't work for qubitId that weren't number, this should solve it

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
