### PR TITLE
Fix problems with Rabi fitting

### DIFF
--- a/src/qibocal/protocols/characterization/rabi/amplitude.py
+++ b/src/qibocal/protocols/characterization/rabi/amplitude.py
@@ -166,7 +166,6 @@ def _fit(data: RabiAmplitudeData) -> RabiAmplitudeResults:
         index = local_maxima[0] if len(local_maxima) > 0 else None
         # 0.5 hardcoded guess for less than one oscillation
         f = x[index] / (x[1] - x[0]) if index is not None else 0.5
-        print(f)
         pguess = [0.5, 1, f, np.pi / 2]
         try:
             popt, _ = curve_fit(

--- a/src/qibocal/protocols/characterization/rabi/amplitude.py
+++ b/src/qibocal/protocols/characterization/rabi/amplitude.py
@@ -9,6 +9,7 @@ from qibolab.pulses import PulseSequence
 from qibolab.qubits import QubitId
 from qibolab.sweeper import Parameter, Sweeper, SweeperType
 from scipy.optimize import curve_fit
+from scipy.signal import find_peaks
 
 from qibocal.auto.operation import Data, Parameters, Qubits, Results, Routine
 from qibocal.config import log
@@ -161,9 +162,11 @@ def _fit(data: RabiAmplitudeData) -> RabiAmplitudeResults:
         # Guessing period using fourier transform
         ft = np.fft.rfft(y)
         mags = abs(ft)
-        index = np.argmax(mags) if np.argmax(mags) != 0 else np.argmax(mags[1:]) + 1
-        f = x[index] / (x[1] - x[0])
-
+        local_maxima = find_peaks(mags, threshold=10)[0]
+        index = local_maxima[0] if len(local_maxima) > 0 else None
+        # 0.5 hardcoded guess for less than one oscillation
+        f = x[index] / (x[1] - x[0]) if index is not None else 0.5
+        print(f)
         pguess = [0.5, 1, f, np.pi / 2]
         try:
             popt, _ = curve_fit(

--- a/src/qibocal/protocols/characterization/rabi/length.py
+++ b/src/qibocal/protocols/characterization/rabi/length.py
@@ -9,6 +9,7 @@ from qibolab.pulses import PulseSequence
 from qibolab.qubits import QubitId
 from qibolab.sweeper import Parameter, Sweeper, SweeperType
 from scipy.optimize import curve_fit
+from scipy.signal import find_peaks
 
 from qibocal.auto.operation import Data, Parameters, Qubits, Results, Routine
 from qibocal.config import log
@@ -168,8 +169,10 @@ def _fit(data: RabiLengthData) -> RabiLengthResults:
         # Guessing period using fourier transform
         ft = np.fft.rfft(y)
         mags = abs(ft)
-        index = np.argmax(mags) if np.argmax(mags) != 0 else np.argmax(mags[1:]) + 1
-        f = x[index] / (x[1] - x[0])
+        local_maxima = find_peaks(mags, threshold=1)[0]
+        index = local_maxima[0] if len(local_maxima) > 0 else None
+        # 0.5 hardcoded guess for less than one oscillation
+        f = x[index] / (x[1] - x[0]) if index is not None else 0.5
 
         pguess = [1, 1, f, np.pi / 2, 0]
         try:


### PR DESCRIPTION
Closes #475.
After performing the FFT I added the [`find_peaks`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.find_peaks.html) primitive from `scipy`.
In the case where not oscillations are observed the initial guess for the oscillations is 0.5.

I tried it on hardware and it seems to work as expected.

![image](https://github.com/qiboteam/qibocal/assets/49183315/60ae0607-a9ac-4be8-988f-8e52e5d00908)



Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
