### PR TITLE
David/qubit flux track

### DIFF
--- a/src/qibocal/protocols/characterization/flux_dependence/resonator_flux_dependence.py
+++ b/src/qibocal/protocols/characterization/flux_dependence/resonator_flux_dependence.py
@@ -45,6 +45,7 @@ class ResonatorFluxResults(Results):
     """Sweetspot for each qubit."""
     frequency: dict[QubitId, float] = field(metadata=dict(update="readout_frequency"))
     """Readout frequency for each qubit."""
+    #TODO: add a dict per each fitted popt coeff (asymmetry, Ec, Ej, g)
     fitted_parameters: dict[QubitId, dict[str, float]]
     """Raw fitting output."""
     resonator_polycoef_flux: dict[QubitId, List[float]] = field(
@@ -261,6 +262,7 @@ def _fit(data: ResonatorFluxData) -> ResonatorFluxResults:
                     maxfev=2000000,
                 )[0]
 
+                #TODO: save each popt value as single qubit attribute
                 resonator_polycoef_flux[qubit] = popt.tolist()
 
                 popt[4] *= GHZ_TO_HZ

--- a/src/qibocal/protocols/characterization/flux_dependence/resonator_flux_dependence.py
+++ b/src/qibocal/protocols/characterization/flux_dependence/resonator_flux_dependence.py
@@ -209,6 +209,7 @@ def _fit(data: ResonatorFluxData) -> ResonatorFluxResults:
             "f_r_offset": 0,
             "C_ii": 0,
         }
+
         resonator_polycoef_flux[qubit] = 0
 
         biases = qubit_data.bias
@@ -222,7 +223,6 @@ def _fit(data: ResonatorFluxData) -> ResonatorFluxResults:
             frequencies, biases, msr, msr_mask=0.5
         )
 
-        # scaler = 10**9
         bare_resonator_frequency = data.bare_resonator_frequency[
             qubit
         ]  # Resonator frequency at high power.
@@ -259,7 +259,7 @@ def _fit(data: ResonatorFluxData) -> ResonatorFluxResults:
                     maxfev=2000000,
                 )[0]
 
-                resonator_polycoef_flux[qubit] = popt
+                resonator_polycoef_flux[qubit] = popt.tolist()
 
                 popt[4] *= GHZ_TO_HZ
                 popt[5] *= GHZ_TO_HZ
@@ -317,8 +317,8 @@ def _fit(data: ResonatorFluxData) -> ResonatorFluxResults:
                     maxfev=2000000,
                 )[0]
 
-                resonator_polycoef_flux[qubit] = popt
-                
+                resonator_polycoef_flux[qubit] = popt.tolist()
+
                 popt[0] *= GHZ_TO_HZ
                 popt[1] *= GHZ_TO_HZ
                 popt[5] *= GHZ_TO_HZ
@@ -361,6 +361,7 @@ def _fit(data: ResonatorFluxData) -> ResonatorFluxResults:
         frequency=frequency,
         sweetspot=sweetspot,
         fitted_parameters=fitted_parameters,
+        resonator_polycoef_flux=resonator_polycoef_flux,
     )
 
 

--- a/src/qibocal/protocols/characterization/flux_dependence/resonator_flux_dependence.py
+++ b/src/qibocal/protocols/characterization/flux_dependence/resonator_flux_dependence.py
@@ -40,18 +40,27 @@ class ResonatorFluxParameters(Parameters):
 @dataclass
 class ResonatorFluxResults(Results):
     """ResonatoFlux outputs."""
-
+    #pop[0]
     sweetspot: dict[QubitId, float] = field(metadata=dict(update="sweetspot"))
     """Sweetspot for each qubit."""
     frequency: dict[QubitId, float] = field(metadata=dict(update="readout_frequency"))
     """Readout frequency for each qubit."""
     #TODO: add a dict per each fitted popt coeff (asymmetry, Ec, Ej, g)
+    
+    #popt[0] = ss
+    #popt[1] = Xi
+    #popt[2] = asimmetry
+    #popt[3] = asimmetry
+    #popt[4] = asimmetry
+    #popt[5] = Ec
+    #popt[6] = Ej
+
     fitted_parameters: dict[QubitId, dict[str, float]]
     """Raw fitting output."""
-    resonator_polycoef_flux: dict[QubitId, List[float]] = field(
-        metadata=dict(update="resonator_polycoef_flux")
-    )
-    """Optimal coeficents for flux curve fited for each qubit."""
+    # resonator_polycoef_flux: dict[QubitId, List[float]] = field(
+    #     metadata=dict(update="resonator_polycoef_flux")
+    # )
+    # """Optimal coeficents for flux curve fited for each qubit."""
 
 
 ResFluxType = np.dtype(

--- a/src/qibocal/protocols/characterization/flux_dependence/resonator_flux_dependence.py
+++ b/src/qibocal/protocols/characterization/flux_dependence/resonator_flux_dependence.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from functools import partial
-from typing import Optional, List
+from typing import List, Optional
 
 import numpy as np
 import numpy.typing as npt
@@ -47,7 +47,9 @@ class ResonatorFluxResults(Results):
     """Readout frequency for each qubit."""
     fitted_parameters: dict[QubitId, dict[str, float]]
     """Raw fitting output."""
-    resonator_polycoef_flux: dict[QubitId, List[float]] = field(metadata=dict(update="resonator_polycoef_flux"))
+    resonator_polycoef_flux: dict[QubitId, List[float]] = field(
+        metadata=dict(update="resonator_polycoef_flux")
+    )
     """Optimal coeficents for flux curve fited for each qubit."""
 
 
@@ -287,7 +289,6 @@ def _fit(data: ResonatorFluxData) -> ResonatorFluxResults:
                     "C_ii": C_ii,
                 }
 
-                
             except:
                 log.warning(
                     "resonator_flux_fit: First order approximation fitting was not succesful"

--- a/src/qibocal/protocols/characterization/flux_dependence/utils.py
+++ b/src/qibocal/protocols/characterization/flux_dependence/utils.py
@@ -382,29 +382,32 @@ def image_to_curve(x, y, z, msr_mask=0.5, alpha=1e-5, order=50):
 def get_resonator_freq_flux(bias, resonator_polycoef_flux):
     if len(resonator_polycoef_flux) == 6:
         # First order approximation used during resonator flux fitting
-        freq_resonator = freq_r_transmon(bias, 
-                                        resonator_polycoef_flux[0], 
-                                        resonator_polycoef_flux[1], 
-                                        resonator_polycoef_flux[2], 
-                                        resonator_polycoef_flux[3], 
-                                        resonator_polycoef_flux[4], 
-                                        resonator_polycoef_flux[5], 
-                                        )
+        freq_resonator = freq_r_transmon(
+            bias,
+            resonator_polycoef_flux[0],
+            resonator_polycoef_flux[1],
+            resonator_polycoef_flux[2],
+            resonator_polycoef_flux[3],
+            resonator_polycoef_flux[4],
+            resonator_polycoef_flux[5],
+        )
         return freq_resonator
-    
+
     elif len(resonator_polycoef_flux) == 7:
         # Second order approximation used during resonator flux fitting
-        freq_resonator = freq_r_mathieu(bias, 
-                                        resonator_polycoef_flux[0], 
-                                        resonator_polycoef_flux[1], 
-                                        resonator_polycoef_flux[2], 
-                                        resonator_polycoef_flux[3], 
-                                        resonator_polycoef_flux[4], 
-                                        resonator_polycoef_flux[5], 
-                                        resonator_polycoef_flux[6], 
-                                        )
+        freq_resonator = freq_r_mathieu(
+            bias,
+            resonator_polycoef_flux[0],
+            resonator_polycoef_flux[1],
+            resonator_polycoef_flux[2],
+            resonator_polycoef_flux[3],
+            resonator_polycoef_flux[4],
+            resonator_polycoef_flux[5],
+            resonator_polycoef_flux[6],
+        )
         return freq_resonator
-    
-    else:
-        raise ValueError("Void resonator_polycoef_flux in runcard. Track mode not supported")
 
+    else:
+        raise ValueError(
+            "Void resonator_polycoef_flux in runcard. Track mode not supported"
+        )

--- a/src/qibocal/protocols/characterization/flux_dependence/utils.py
+++ b/src/qibocal/protocols/characterization/flux_dependence/utils.py
@@ -377,3 +377,34 @@ def image_to_curve(x, y, z, msr_mask=0.5, alpha=1e-5, order=50):
     X_pred = feature(x_pred, order)
     y_pred = model.predict(X_pred)
     return y_pred, x_pred
+
+
+def get_resonator_freq_flux(bias, resonator_polycoef_flux):
+    if len(resonator_polycoef_flux) == 6:
+        # First order approximation used during resonator flux fitting
+        freq_resonator = freq_r_transmon(bias, 
+                                        resonator_polycoef_flux[0], 
+                                        resonator_polycoef_flux[1], 
+                                        resonator_polycoef_flux[2], 
+                                        resonator_polycoef_flux[3], 
+                                        resonator_polycoef_flux[4], 
+                                        resonator_polycoef_flux[5], 
+                                        )
+        return freq_resonator
+    
+    elif len(resonator_polycoef_flux) == 7:
+        # Second order approximation used during resonator flux fitting
+        freq_resonator = freq_r_mathieu(bias, 
+                                        resonator_polycoef_flux[0], 
+                                        resonator_polycoef_flux[1], 
+                                        resonator_polycoef_flux[2], 
+                                        resonator_polycoef_flux[3], 
+                                        resonator_polycoef_flux[4], 
+                                        resonator_polycoef_flux[5], 
+                                        resonator_polycoef_flux[6], 
+                                        )
+        return freq_resonator
+    
+    else:
+        raise ValueError("Void resonator_polycoef_flux in runcard. Track mode not supported")
+


### PR DESCRIPTION
This PR implements the qubit spectroscopy flux tracking. 

For that, we first save the polinomial coefficients obtained during the fitting resonator spectroscopy flux  in the runcard.
Afterthat, the "track" option has been added to Qubit Spec Flux to enable the flux tracking. If it is enabled, we modifiy the RO frequency with the estimated value using the "resonator_polycoef_flux" parameters stored in the runcard, for each bias value, in order to track the qubit during the spectroscopy. 


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [x] Documentation is updated.
- [x] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [x] Qibo: `master`
    - [x] Qibolab: `https://github.com/qiboteam/qibolab/pull/573/`
    - [x] Qibolab_platforms_qrc: `main`
   