### PR TITLE
Indent typo in the runcard

### DIFF
--- a/doc/source/getting-started/example.rst
+++ b/doc/source/getting-started/example.rst
@@ -16,14 +16,14 @@ presented in :ref:`runcard`, we can use this runcard.
 
     actions:
         - id: resonator high power high amplitude
-        priority: 0
-        operation: resonator_spectroscopy
-        parameters:
-            freq_width: 10_000_000
-            freq_step: 100_000
-            amplitude: 0.4
-            power_level: high
-            nshots: 1024
+          priority: 0
+          operation: resonator_spectroscopy
+          parameters:
+              freq_width: 10_000_000
+              freq_step: 100_000
+              amplitude: 0.4
+              power_level: high
+              nshots: 1024
 
 More examples of runcards are available on `Github <https://github.com/qiboteam/qibocal/tree/main/runcards>`_ .
 


### PR DESCRIPTION
Indent typo in the example runcard doc.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
