### PR TITLE
Added qq upload instructions to documentation

### DIFF
--- a/doc/source/getting-started/interface.rst
+++ b/doc/source/getting-started/interface.rst
@@ -77,10 +77,8 @@ by other users as well.
 
     qq upload <output_folder>
 
-
-
-
 In order to upload the report to a centralized server, send to the server administrators
 your public ssh key (from the machine(s) you are planning to upload the report) and then
 use the ``qq upload <output_folder>`` command.
+You can also add a tag to be displayed on the server using ``qq upload <output_folder> --tag <tag_name>``.
 This program will upload your report to the server and generate an unique URL.

--- a/doc/source/getting-started/interface.rst
+++ b/doc/source/getting-started/interface.rst
@@ -78,8 +78,6 @@ by other users as well.
     qq upload <output_folder>
 
 
-Uploading reports to server
-"""""""""""""""""""""""""""
 
 
 In order to upload the report to a centralized server, send to the server administrators

--- a/doc/source/getting-started/interface.rst
+++ b/doc/source/getting-started/interface.rst
@@ -76,3 +76,13 @@ by other users as well.
 .. code-block::
 
     qq upload <output_folder>
+
+
+Uploading reports to server
+"""""""""""""""""""""""""""
+
+
+In order to upload the report to a centralized server, send to the server administrators
+your public ssh key (from the machine(s) you are planning to upload the report) and then
+use the ``qq upload <output_folder>`` command.
+This program will upload your report to the server and generate an unique URL.


### PR DESCRIPTION
I added instructions explaining how to access the servers with uploaded reports. It is just a copy-paste from `Reame.md`.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
