### PR TITLE
Adding "coherence"  protocols with probabilities and error bands. 

### DIFF
--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -111,6 +111,7 @@ class Task:
     @property
     def parameters(self):
         """Inputs parameters for self.operation."""
+        print(self.action.parameters)
         return self.operation.parameters_type.load(self.action.parameters)
 
     @property

--- a/src/qibocal/protocols/characterization/__init__.py
+++ b/src/qibocal/protocols/characterization/__init__.py
@@ -9,6 +9,7 @@ from .coherence.t1 import t1
 from .coherence.t1_msr import t1_msr
 from .coherence.t1_sequences import t1_sequences
 from .coherence.t2 import t2
+from .coherence.t2_msr import t2_msr
 from .coherence.t2_sequences import t2_sequences
 from .coherence.zeno import zeno
 from .dispersive_shift import dispersive_shift
@@ -59,6 +60,7 @@ class Operation(Enum):
     t1_msr = t1_msr
     t1_sequences = t1_sequences
     t2 = t2
+    t2_msr = t2_msr
     t2_sequences = t2_sequences
     time_of_flight_readout = time_of_flight_readout
     single_shot_classification = single_shot_classification

--- a/src/qibocal/protocols/characterization/__init__.py
+++ b/src/qibocal/protocols/characterization/__init__.py
@@ -13,6 +13,7 @@ from .coherence.t2 import t2
 from .coherence.t2_msr import t2_msr
 from .coherence.t2_sequences import t2_sequences
 from .coherence.zeno import zeno
+from .coherence.zeno_msr import zeno_msr
 from .dispersive_shift import dispersive_shift
 from .fast_reset.fast_reset import fast_reset
 from .flipping import flipping
@@ -79,6 +80,7 @@ class Operation(Enum):
     resonator_frequency = resonator_frequency
     fast_reset = fast_reset
     zeno = zeno
+    zeno_msr = zeno_msr
     chsh_pulses = chsh_pulses
     chsh_circuits = chsh_circuits
     readout_mitigation_matrix = readout_mitigation_matrix

--- a/src/qibocal/protocols/characterization/__init__.py
+++ b/src/qibocal/protocols/characterization/__init__.py
@@ -5,6 +5,7 @@ from .allxy.allxy_drag_pulse_tuning import allxy_drag_pulse_tuning
 from .allxy.drag_pulse_tuning import drag_pulse_tuning
 from .classification import single_shot_classification
 from .coherence.spin_echo import spin_echo
+from .coherence.spin_echo_msr import spin_echo_msr
 from .coherence.t1 import t1
 from .coherence.t1_msr import t1_msr
 from .coherence.t1_sequences import t1_sequences
@@ -65,6 +66,7 @@ class Operation(Enum):
     time_of_flight_readout = time_of_flight_readout
     single_shot_classification = single_shot_classification
     spin_echo = spin_echo
+    spin_echo_msr = spin_echo_msr
     allxy = allxy
     allxy_drag_pulse_tuning = allxy_drag_pulse_tuning
     drag_pulse_tuning = drag_pulse_tuning

--- a/src/qibocal/protocols/characterization/__init__.py
+++ b/src/qibocal/protocols/characterization/__init__.py
@@ -6,6 +6,7 @@ from .allxy.drag_pulse_tuning import drag_pulse_tuning
 from .classification import single_shot_classification
 from .coherence.spin_echo import spin_echo
 from .coherence.t1 import t1
+from .coherence.t1_msr import t1_msr
 from .coherence.t1_sequences import t1_sequences
 from .coherence.t2 import t2
 from .coherence.t2_sequences import t2_sequences
@@ -55,6 +56,7 @@ class Operation(Enum):
     ramsey = ramsey
     ramsey_sequences = ramsey_sequences
     t1 = t1
+    t1_msr = t1_msr
     t1_sequences = t1_sequences
     t2 = t2
     t2_sequences = t2_sequences

--- a/src/qibocal/protocols/characterization/__init__.py
+++ b/src/qibocal/protocols/characterization/__init__.py
@@ -27,6 +27,7 @@ from .rabi.amplitude import rabi_amplitude
 from .rabi.length import rabi_length
 from .rabi.length_sequences import rabi_length_sequences
 from .ramsey import ramsey
+from .ramsey_msr import ramsey_msr
 from .ramsey_sequences import ramsey_sequences
 from .randomized_benchmarking.standard_rb import standard_rb
 from .readout_characterization import readout_characterization
@@ -57,6 +58,7 @@ class Operation(Enum):
     rabi_length = rabi_length
     rabi_length_sequences = rabi_length_sequences
     ramsey = ramsey
+    ramsey_msr = ramsey_msr
     ramsey_sequences = ramsey_sequences
     t1 = t1
     t1_msr = t1_msr

--- a/src/qibocal/protocols/characterization/coherence/spin_echo.py
+++ b/src/qibocal/protocols/characterization/coherence/spin_echo.py
@@ -12,7 +12,7 @@ from qibocal import update
 from qibocal.auto.operation import Parameters, Qubits, Results, Routine
 
 from ..utils import V_TO_UV
-from .t1 import T1Data
+from .t1_msr import T1MSRData
 from .utils import exp_decay, exponential_fit
 
 
@@ -42,7 +42,7 @@ class SpinEchoResults(Results):
     """Raw fitting output."""
 
 
-class SpinEchoData(T1Data):
+class SpinEchoData(T1MSRData):
     """SpinEcho acquisition outputs."""
 
 

--- a/src/qibocal/protocols/characterization/coherence/spin_echo_msr.py
+++ b/src/qibocal/protocols/characterization/coherence/spin_echo_msr.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Optional
 
 import numpy as np
 import plotly.graph_objects as go
@@ -9,48 +8,33 @@ from qibolab.pulses import PulseSequence
 from qibolab.qubits import QubitId
 
 from qibocal import update
-from qibocal.auto.operation import Parameters, Qubits, Results, Routine
+from qibocal.auto.operation import Qubits, Routine
 
-from ..utils import fill_table
-from . import t1
-from .utils import exp_decay, exponential_fit_probability
-
-
-@dataclass
-class SpinEchoParameters(Parameters):
-    """SpinEcho runcard inputs."""
-
-    delay_between_pulses_start: int
-    """Initial delay between pulses [ns]."""
-    delay_between_pulses_end: int
-    """Final delay between pulses [ns]."""
-    delay_between_pulses_step: int
-    """Step delay between pulses (ns)."""
-    nshots: Optional[int] = None
-    """Number of shots."""
-    relaxation_time: Optional[int] = None
-    """Relaxation time (ns)."""
+from ..utils import V_TO_UV
+from . import spin_echo
+from .t1_msr import T1MSRData
+from .utils import exp_decay, exponential_fit
 
 
 @dataclass
-class SpinEchoResults(Results):
-    """SpinEcho outputs."""
-
-    t2_spin_echo: dict[QubitId, float]
-    """T2 echo for each qubit."""
-    fitted_parameters: dict[QubitId, dict[str, float]]
-    """Raw fitting output."""
+class SpinEchoMSRParameters(spin_echo.SpinEchoParameters):
+    """SpinEcho MSR runcard inputs."""
 
 
-class SpinEchoData(t1.T1Data):
+@dataclass
+class SpinEchoMSRResults(spin_echo.SpinEchoResults):
+    """SpinEchoMSR outputs."""
+
+
+class SpinEchoMSRData(T1MSRData):
     """SpinEcho acquisition outputs."""
 
 
 def _acquisition(
-    params: SpinEchoParameters,
+    params: SpinEchoMSRParameters,
     platform: Platform,
     qubits: Qubits,
-) -> SpinEchoData:
+) -> SpinEchoMSRData:
     """Data acquisition for SpinEcho"""
     # create a sequence of pulses for the experiment:
     # Spin Echo 3 Pulses: RX(pi/2) - wait t(rotates z) - RX(pi) - wait t(rotates z) - RX(pi/2) - readout
@@ -83,8 +67,8 @@ def _acquisition(
         params.delay_between_pulses_step,
     )
 
-    data = SpinEchoData()
-    probs = {qubit: [] for qubit in qubits}
+    data = SpinEchoMSRData()
+
     # sweep the parameter
     for wait in ro_wait_range:
         # save data as often as defined by points
@@ -100,60 +84,47 @@ def _acquisition(
             ExecutionParameters(
                 nshots=params.nshots,
                 relaxation_time=params.relaxation_time,
-                acquisition_type=AcquisitionType.DISCRIMINATION,
-                averaging_mode=AveragingMode.SINGLESHOT,
+                acquisition_type=AcquisitionType.INTEGRATION,
+                averaging_mode=AveragingMode.CYCLIC,
             ),
         )
 
         for qubit in qubits:
-            prob = results[ro_pulses[qubit].serial].probability(state=0)
-            probs[qubit].append(prob)
-
-    for qubit in qubits:
-        errors = [np.sqrt(prob * (1 - prob) / params.nshots) for prob in probs[qubit]]
-        data.register_qubit(qubit, wait=ro_wait_range, prob=probs[qubit], error=errors)
-
+            result = results[ro_pulses[qubit].serial]
+            data.register_qubit(
+                qubit, wait=wait, msr=result.magnitude, phase=result.phase
+            )
     return data
 
 
-def _fit(data: SpinEchoData) -> SpinEchoResults:
+def _fit(data: SpinEchoMSRData) -> SpinEchoMSRResults:
     """Post-processing for SpinEcho."""
-    t2Echos, fitted_parameters = exponential_fit_probability(data)
+    t2Echos, fitted_parameters = exponential_fit(data)
 
-    return SpinEchoResults(t2Echos, fitted_parameters)
+    return SpinEchoMSRResults(t2Echos, fitted_parameters)
 
 
-def _plot(data: SpinEchoData, qubit, fit: SpinEchoResults = None):
+def _plot(data: SpinEchoMSRData, qubit, fit: SpinEchoMSRResults = None):
     """Plotting for SpinEcho"""
 
     figures = []
+    fig = go.Figure()
+
+    # iterate over multiple data folders
     fitting_report = None
+
     qubit_data = data[qubit]
     waits = qubit_data.wait
-    probs = qubit_data.prob
-    error_bars = qubit_data.error
 
-    fig = go.Figure(
-        [
-            go.Scatter(
-                x=waits,
-                y=probs,
-                opacity=1,
-                name="Probability of 0",
-                showlegend=True,
-                legendgroup="Probability of 0",
-                mode="lines",
-            ),
-            go.Scatter(
-                x=np.concatenate((waits, waits[::-1])),
-                y=np.concatenate((probs + error_bars, (probs - error_bars)[::-1])),
-                fill="toself",
-                fillcolor=t1.COLORBAND,
-                line=dict(color=t1.COLORBAND_LINE),
-                showlegend=True,
-                name="Errors",
-            ),
-        ]
+    fig.add_trace(
+        go.Scatter(
+            x=waits,
+            y=qubit_data.msr * V_TO_UV,
+            opacity=1,
+            name="Voltage",
+            showlegend=True,
+            legendgroup="Voltage",
+        ),
     )
 
     if fit is not None:
@@ -174,18 +145,15 @@ def _plot(data: SpinEchoData, qubit, fit: SpinEchoResults = None):
             ),
         )
 
-        fitting_report = fill_table(
-            qubit,
-            "T2 Spin Echo",
-            fit.t2_spin_echo[qubit][0],
-            fit.t2_spin_echo[qubit][1],
-            "ns",
+        fitting_report = (
+            f"{qubit} | T2 Spin Echo: {fit.t2_spin_echo[qubit]:,.0f} ns.<br><br>"
         )
 
     fig.update_layout(
         showlegend=True,
+        uirevision="0",  # ``uirevision`` allows zooming while live plotting
         xaxis_title="Time (ns)",
-        yaxis_title="Probability of State 0",
+        yaxis_title="MSR (uV)",
     )
 
     figures.append(fig)
@@ -193,9 +161,9 @@ def _plot(data: SpinEchoData, qubit, fit: SpinEchoResults = None):
     return figures, fitting_report
 
 
-def _update(results: SpinEchoResults, platform: Platform, qubit: QubitId):
+def _update(results: SpinEchoMSRResults, platform: Platform, qubit: QubitId):
     update.t2_spin_echo(results.t2_spin_echo[qubit], platform, qubit)
 
 
-spin_echo = Routine(_acquisition, _fit, _plot, _update)
+spin_echo_msr = Routine(_acquisition, _fit, _plot, _update)
 """SpinEcho Routine object."""

--- a/src/qibocal/protocols/characterization/coherence/t1.py
+++ b/src/qibocal/protocols/characterization/coherence/t1.py
@@ -134,7 +134,7 @@ def _acquisition(params: T1Parameters, platform: Platform, qubits: Qubits) -> T1
 
     for qubit in qubits:
         probs = results[ro_pulses[qubit].serial].probability(state=1)
-        errors = [np.sqrt(prob * (1 - prob) / params.nshots) for prob in probs]
+        errors = np.sqrt(probs * (1 - probs) / params.nshots)
         data.register_qubit(qubit, wait=ro_wait_range, prob=probs, error=errors)
 
     return data

--- a/src/qibocal/protocols/characterization/coherence/t1.py
+++ b/src/qibocal/protocols/characterization/coherence/t1.py
@@ -67,10 +67,7 @@ class T1Data(Data):
         ar["wait"] = wait
         ar["prob"] = prob
         ar["error"] = error
-        if qubit in self.data:
-            self.data[qubit] = np.rec.array(np.concatenate((self.data[qubit], ar)))
-        else:
-            self.data[qubit] = np.rec.array(ar)
+        self.data[qubit] = np.rec.array(ar)
 
 
 def _acquisition(params: T1Parameters, platform: Platform, qubits: Qubits) -> T1Data:

--- a/src/qibocal/protocols/characterization/coherence/t1.py
+++ b/src/qibocal/protocols/characterization/coherence/t1.py
@@ -13,6 +13,7 @@ from qibolab.sweeper import Parameter, Sweeper, SweeperType
 from qibocal import update
 from qibocal.auto.operation import Data, Parameters, Qubits, Results, Routine
 
+from ..utils import fill_table
 from . import utils
 
 COLORBAND = "rgba(0,100,80,0.2)"
@@ -203,7 +204,13 @@ def _plot(data: T1Data, qubit, fit: T1Results = None):
                 line=go.scatter.Line(dash="dot"),
             )
         )
-        fitting_report = f"{qubit} | t1: {fit.t1[qubit][0]:,.0f} ns.<br><br>"
+        fitting_report = fill_table(
+            qubit,
+            "T1",
+            fit.t1[qubit][0],
+            fit.t1[qubit][1],
+            "ns",
+        )
 
     # last part
     fig.update_layout(

--- a/src/qibocal/protocols/characterization/coherence/t1.py
+++ b/src/qibocal/protocols/characterization/coherence/t1.py
@@ -59,7 +59,7 @@ class T1Data(Data):
     data: dict[QubitId, npt.NDArray] = field(default_factory=dict)
     """Raw data acquired."""
 
-    def register_qubit(self, qubit, wait, prob, error):
+    def register_qubit(self, qubit, prob, error, wait):
         """Store output for single qubit."""
         # to be able to handle the non-sweeper case
         shape = (1,) if np.isscalar(wait) else wait.shape

--- a/src/qibocal/protocols/characterization/coherence/t1_msr.py
+++ b/src/qibocal/protocols/characterization/coherence/t1_msr.py
@@ -1,0 +1,195 @@
+from dataclasses import dataclass, field
+
+import numpy as np
+import numpy.typing as npt
+import plotly.graph_objects as go
+from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
+from qibolab.platform import Platform
+from qibolab.pulses import PulseSequence
+from qibolab.qubits import QubitId
+from qibolab.sweeper import Parameter, Sweeper, SweeperType
+
+from qibocal.auto.operation import Data, Qubits, Routine
+
+from ..utils import V_TO_UV
+from . import t1, utils
+
+
+@dataclass
+class T1MSRParameters(t1.T1Parameters):
+    """T1 MSR runcard inputs."""
+
+
+@dataclass
+class T1MSRResults(t1.T1Results):
+    """T1 MSR outputs."""
+
+
+CoherenceType = np.dtype(
+    [("wait", np.float64), ("msr", np.float64), ("phase", np.float64)]
+)
+"""Custom dtype for coherence routines."""
+
+
+@dataclass
+class T1MSRData(Data):
+    """T1 acquisition outputs."""
+
+    data: dict[QubitId, npt.NDArray] = field(default_factory=dict)
+    """Raw data acquired."""
+
+    def register_qubit(self, qubit, wait, msr, phase):
+        """Store output for single qubit."""
+        # to be able to handle the non-sweeper case
+        shape = (1,) if np.isscalar(wait) else wait.shape
+        ar = np.empty(shape, dtype=CoherenceType)
+        ar["wait"] = wait
+        ar["msr"] = msr
+        ar["phase"] = phase
+        if qubit in self.data:
+            self.data[qubit] = np.rec.array(np.concatenate((self.data[qubit], ar)))
+        else:
+            self.data[qubit] = np.rec.array(ar)
+
+
+def _acquisition(
+    params: T1MSRParameters, platform: Platform, qubits: Qubits
+) -> T1MSRData:
+    r"""Data acquisition for T1 experiment.
+    In a T1 experiment, we measure an excited qubit after a delay. Due to decoherence processes
+    (e.g. amplitude damping channel), it is possible that, at the time of measurement, after the delay,
+    the qubit will not be excited anymore. The larger the delay time is, the more likely is the qubit to
+    fall to the ground state. The goal of the experiment is to characterize the decay rate of the qubit
+    towards the ground state.
+
+    Args:
+        params:
+        platform (Platform): Qibolab platform object
+        qubits (list): list of target qubits to perform the action
+        delay_before_readout_start (int): Initial time delay before ReadOut
+        delay_before_readout_end (list): Maximum time delay before ReadOut
+        delay_before_readout_step (int): Scan range step for the delay before ReadOut
+        software_averages (int): Number of executions of the routine for averaging results
+        points (int): Save data results in a file every number of points
+    """
+
+    # create a sequence of pulses for the experiment
+    # RX - wait t - MZ
+    qd_pulses = {}
+    ro_pulses = {}
+    sequence = PulseSequence()
+    for qubit in qubits:
+        qd_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
+        ro_pulses[qubit] = platform.create_qubit_readout_pulse(
+            qubit, start=qd_pulses[qubit].duration
+        )
+        sequence.add(qd_pulses[qubit])
+        sequence.add(ro_pulses[qubit])
+
+    # define the parameter to sweep and its range:
+    # wait time before readout
+    ro_wait_range = np.arange(
+        params.delay_before_readout_start,
+        params.delay_before_readout_end,
+        params.delay_before_readout_step,
+    )
+
+    sweeper = Sweeper(
+        Parameter.start,
+        ro_wait_range,
+        [ro_pulses[qubit] for qubit in qubits],
+        type=SweeperType.ABSOLUTE,
+    )
+
+    # create a DataUnits object to store the MSR, phase, i, q and the delay time
+    data = T1MSRData()
+
+    # sweep the parameter
+    # execute the pulse sequence
+    results = platform.sweep(
+        sequence,
+        ExecutionParameters(
+            nshots=params.nshots,
+            relaxation_time=params.relaxation_time,
+            acquisition_type=AcquisitionType.INTEGRATION,
+            averaging_mode=AveragingMode.CYCLIC,
+        ),
+        sweeper,
+    )
+
+    for qubit in qubits:
+        result = results[ro_pulses[qubit].serial]
+        data.register_qubit(
+            qubit, wait=ro_wait_range, msr=result.magnitude, phase=result.phase
+        )
+
+    return data
+
+
+def _fit(data: T1MSRData) -> T1MSRResults:
+    """
+    Fitting routine for T1 experiment. The used model is
+
+        .. math::
+
+            y = p_0-p_1 e^{-x p_2}.
+    """
+    t1s, fitted_parameters = utils.exponential_fit(data)
+
+    return T1MSRResults(t1s, fitted_parameters)
+
+
+def _plot(data: T1MSRData, qubit, fit: T1MSRResults = None):
+    """Plotting function for T1 experiment."""
+
+    figures = []
+    fig = go.Figure()
+
+    fitting_report = None
+    qubit_data = data[qubit]
+    waits = qubit_data.wait
+
+    fig.add_trace(
+        go.Scatter(
+            x=waits,
+            y=qubit_data.msr * V_TO_UV,
+            opacity=1,
+            name="Voltage",
+            showlegend=True,
+            legendgroup="Voltage",
+        )
+    )
+
+    if fit is not None:
+        waitrange = np.linspace(
+            min(waits),
+            max(waits),
+            2 * len(qubit_data),
+        )
+
+        params = fit.fitted_parameters[qubit]
+        fig.add_trace(
+            go.Scatter(
+                x=waitrange,
+                y=utils.exp_decay(waitrange, *params),
+                name="Fit",
+                line=go.scatter.Line(dash="dot"),
+            )
+        )
+        fitting_report = f"{qubit} | t1: {fit.t1[qubit]:,.0f} ns.<br><br>"
+
+    # last part
+    fig.update_layout(
+        showlegend=True,
+        uirevision="0",  # ``uirevision`` allows zooming while live plotting
+        xaxis_title="Time (ns)",
+        yaxis_title="MSR (uV)",
+    )
+
+    figures.append(fig)
+
+    return figures, fitting_report
+
+
+t1_msr = Routine(_acquisition, _fit, _plot, t1._update)
+"""T1 MSR Routine object."""

--- a/src/qibocal/protocols/characterization/coherence/t1_sequences.py
+++ b/src/qibocal/protocols/characterization/coherence/t1_sequences.py
@@ -5,10 +5,12 @@ from qibolab.pulses import PulseSequence
 
 from qibocal.auto.operation import Qubits, Routine
 
-from .t1 import T1Data, T1Parameters, _fit, _plot, _update
+from . import t1, t1_msr
 
 
-def _acquisition(params: T1Parameters, platform: Platform, qubits: Qubits) -> T1Data:
+def _acquisition(
+    params: t1_msr.T1MSRParameters, platform: Platform, qubits: Qubits
+) -> t1_msr.T1MSRData:
     r"""Data acquisition for T1 experiment.
     In a T1 experiment, we measure an excited qubit after a delay. Due to decoherence processes
     (e.g. amplitude damping channel), it is possible that, at the time of measurement, after the delay,
@@ -49,7 +51,7 @@ def _acquisition(params: T1Parameters, platform: Platform, qubits: Qubits) -> T1
     )
 
     # create a DataUnits object to store the MSR, phase, i, q and the delay time
-    data = T1Data()
+    data = t1_msr.T1MSRData()
 
     # repeat the experiment as many times as defined by software_averages
     # sweep the parameter
@@ -76,5 +78,5 @@ def _acquisition(params: T1Parameters, platform: Platform, qubits: Qubits) -> T1
     return data
 
 
-t1_sequences = Routine(_acquisition, _fit, _plot, _update)
+t1_sequences = Routine(_acquisition, t1_msr._fit, t1_msr._plot, t1._update)
 """T1 Routine object."""

--- a/src/qibocal/protocols/characterization/coherence/t2.py
+++ b/src/qibocal/protocols/characterization/coherence/t2.py
@@ -12,6 +12,7 @@ from qibolab.sweeper import Parameter, Sweeper, SweeperType
 from qibocal import update
 from qibocal.auto.operation import Parameters, Qubits, Results, Routine
 
+from ..utils import fill_table
 from . import t1, utils
 
 
@@ -169,7 +170,9 @@ def _plot(data: T2Data, qubit, fit: T2Results = None):
                 line=go.scatter.Line(dash="dot"),
             )
         )
-        fitting_report = f"{qubit} | T2: {fit.t2[qubit][0]:,.0f} ns.<br><br>"
+        fitting_report = fill_table(
+            qubit, "T2", fit.t2[qubit][0], fit.t2[qubit][1], "ns"
+        )
 
     fig.update_layout(
         showlegend=True,

--- a/src/qibocal/protocols/characterization/coherence/t2.py
+++ b/src/qibocal/protocols/characterization/coherence/t2.py
@@ -13,7 +13,7 @@ from qibocal import update
 from qibocal.auto.operation import Parameters, Qubits, Results, Routine
 
 from ..utils import V_TO_UV
-from . import t1, utils
+from . import t1_msr, utils
 
 
 @dataclass
@@ -42,7 +42,7 @@ class T2Results(Results):
     """Raw fitting output."""
 
 
-class T2Data(t1.T1Data):
+class T2Data(t1_msr.T1MSRData):
     """T2 acquisition outputs."""
 
 

--- a/src/qibocal/protocols/characterization/coherence/t2.py
+++ b/src/qibocal/protocols/characterization/coherence/t2.py
@@ -102,7 +102,7 @@ def _acquisition(
 
     for qubit in qubits:
         probs = results[ro_pulses[qubit].serial].probability(state=1)
-        errors = [np.sqrt(prob * (1 - prob) / params.nshots) for prob in probs]
+        errors = np.sqrt(probs * (1 - probs) / params.nshots)
         data.register_qubit(qubit, wait=waits, prob=probs, error=errors)
     return data
 

--- a/src/qibocal/protocols/characterization/coherence/t2_msr.py
+++ b/src/qibocal/protocols/characterization/coherence/t2_msr.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Optional
 
 import numpy as np
 import plotly.graph_objects as go
@@ -10,46 +9,31 @@ from qibolab.qubits import QubitId
 from qibolab.sweeper import Parameter, Sweeper, SweeperType
 
 from qibocal import update
-from qibocal.auto.operation import Parameters, Qubits, Results, Routine
+from qibocal.auto.operation import Qubits, Routine
 
-from . import t1, utils
-
-
-@dataclass
-class T2Parameters(Parameters):
-    """T2 runcard inputs."""
-
-    delay_between_pulses_start: int
-    """Initial delay between RX(pi/2) pulses in ns."""
-    delay_between_pulses_end: int
-    """Final delay between RX(pi/2) pulses in ns."""
-    delay_between_pulses_step: int
-    """Step delay between RX(pi/2) pulses in ns."""
-    nshots: Optional[int] = None
-    """Number of shots."""
-    relaxation_time: Optional[int] = None
-    """Relaxation time (ns)."""
+from ..utils import V_TO_UV
+from . import t1_msr, t2, utils
 
 
 @dataclass
-class T2Results(Results):
-    """T2 outputs."""
-
-    t2: dict[QubitId, float]
-    """T2 for each qubit (ns)."""
-    fitted_parameters: dict[QubitId, dict[str, float]]
-    """Raw fitting output."""
+class T2MSRParameters(t2.T2Parameters):
+    """T2MSR runcard inputs."""
 
 
-class T2Data(t1.T1Data):
-    """T2 acquisition outputs."""
+@dataclass
+class T2MSRResults(t2.T2Results):
+    """T2MSR outputs."""
+
+
+class T2MSRData(t1_msr.T1MSRData):
+    """T2MSR acquisition outputs."""
 
 
 def _acquisition(
-    params: T2Parameters,
+    params: T2MSRParameters,
     platform: Platform,
     qubits: Qubits,
-) -> T2Data:
+) -> T2MSRData:
     """Data acquisition for Ramsey Experiment (detuned)."""
     # create a sequence of pulses for the experiment
     # RX90 - t - RX90 - MZ
@@ -78,7 +62,10 @@ def _acquisition(
         params.delay_between_pulses_step,
     )
 
-    data = T2Data()
+    # create a DataUnits object to store the results,
+    # DataUnits stores by default MSR, phase, i, q
+    # additionally include wait time and t_max
+    data = T2MSRData()
 
     sweeper = Sweeper(
         Parameter.start,
@@ -93,60 +80,46 @@ def _acquisition(
         ExecutionParameters(
             nshots=params.nshots,
             relaxation_time=params.relaxation_time,
-            acquisition_type=AcquisitionType.DISCRIMINATION,
-            averaging_mode=AveragingMode.SINGLESHOT,
+            acquisition_type=AcquisitionType.INTEGRATION,
+            averaging_mode=AveragingMode.CYCLIC,
         ),
         sweeper,
     )
 
     for qubit in qubits:
-        probs = results[ro_pulses[qubit].serial].probability(state=1)
-        errors = [np.sqrt(prob * (1 - prob) / params.nshots) for prob in probs]
-        data.register_qubit(qubit, wait=waits, prob=probs, error=errors)
+        result = results[ro_pulses[qubit].serial]
+        data.register_qubit(qubit, wait=waits, msr=result.magnitude, phase=result.phase)
     return data
 
 
-def _fit(data: T2Data) -> T2Results:
+def _fit(data: T2MSRData) -> T2MSRResults:
     r"""
     Fitting routine for Ramsey experiment. The used model is
     .. math::
         y = p_0 - p_1 e^{-x p_2}.
     """
-    t2s, fitted_parameters = utils.exponential_fit_probability(data)
-    return T2Results(t2s, fitted_parameters)
+    t2s, fitted_parameters = utils.exponential_fit(data)
+    return T2MSRResults(t2s, fitted_parameters)
 
 
-def _plot(data: T2Data, qubit, fit: T2Results = None):
+def _plot(data: T2MSRData, qubit, fit: T2MSRResults = None):
     """Plotting function for Ramsey Experiment."""
 
     figures = []
+    fig = go.Figure()
     fitting_report = None
-    qubit_data = data[qubit]
-    waits = qubit_data.wait
-    probs = qubit_data.prob
-    error_bars = qubit_data.error
 
-    fig = go.Figure(
-        [
-            go.Scatter(
-                x=waits,
-                y=probs,
-                opacity=1,
-                name="Probability of 1",
-                showlegend=True,
-                legendgroup="Probability of 1",
-                mode="lines",
-            ),
-            go.Scatter(
-                x=np.concatenate((waits, waits[::-1])),
-                y=np.concatenate((probs + error_bars, (probs - error_bars)[::-1])),
-                fill="toself",
-                fillcolor=t1.COLORBAND,
-                line=dict(color=t1.COLORBAND_LINE),
-                showlegend=True,
-                name="Errors",
-            ),
-        ]
+    qubit_data = data[qubit]
+
+    fig.add_trace(
+        go.Scatter(
+            x=qubit_data.wait,
+            y=qubit_data.msr * V_TO_UV,
+            opacity=1,
+            name="Voltage",
+            showlegend=True,
+            legendgroup="Voltage",
+        )
     )
 
     if fit is not None:
@@ -169,13 +142,13 @@ def _plot(data: T2Data, qubit, fit: T2Results = None):
                 line=go.scatter.Line(dash="dot"),
             )
         )
-        fitting_report = f"{qubit} | T2: {fit.t2[qubit][0]:,.0f} ns.<br><br>"
+        fitting_report = f"{qubit} | T2: {fit.t2[qubit]:,.0f} ns.<br><br>"
 
     fig.update_layout(
         showlegend=True,
         uirevision="0",  # ``uirevision`` allows zooming while live plotting
         xaxis_title="Time (ns)",
-        yaxis_title="Probability of State 1",
+        yaxis_title="MSR (uV)",
     )
 
     figures.append(fig)
@@ -183,9 +156,9 @@ def _plot(data: T2Data, qubit, fit: T2Results = None):
     return figures, fitting_report
 
 
-def _update(results: T2Results, platform: Platform, qubit: QubitId):
+def _update(results: T2MSRResults, platform: Platform, qubit: QubitId):
     update.t2(results.t2[qubit], platform, qubit)
 
 
-t2 = Routine(_acquisition, _fit, _plot, _update)
-"""T2 Routine object."""
+t2_msr = Routine(_acquisition, _fit, _plot, _update)
+"""T2MSR Routine object."""

--- a/src/qibocal/protocols/characterization/coherence/t2_sequences.py
+++ b/src/qibocal/protocols/characterization/coherence/t2_sequences.py
@@ -5,14 +5,14 @@ from qibolab.pulses import PulseSequence
 
 from qibocal.auto.operation import Qubits, Routine
 
-from .t2 import T2Data, T2Parameters, _fit, _plot, _update
+from .t2_msr import T2MSRData, T2MSRParameters, _fit, _plot, _update
 
 
 def _acquisition(
-    params: T2Parameters,
+    params: T2MSRParameters,
     platform: Platform,
     qubits: Qubits,
-) -> T2Data:
+) -> T2MSRData:
     """Data acquisition for Ramsey Experiment (detuned)."""
     # create a sequence of pulses for the experiment
     # RX90 - t - RX90 - MZ
@@ -44,7 +44,7 @@ def _acquisition(
     # create a DataUnits object to store the results,
     # DataUnits stores by default MSR, phase, i, q
     # additionally include wait time and t_max
-    data = T2Data()
+    data = T2MSRData()
 
     # sweep the parameter
     for wait in waits:

--- a/src/qibocal/protocols/characterization/coherence/utils.py
+++ b/src/qibocal/protocols/characterization/coherence/utils.py
@@ -72,8 +72,8 @@ def exponential_fit_probability(data):
     fitted_parameters = {}
 
     for qubit in qubits:
+        x = data[qubit].wait
         probability = data[qubit].prob
-
         p0 = [
             0.5,
             0.5,
@@ -83,7 +83,7 @@ def exponential_fit_probability(data):
         try:
             popt, perr = curve_fit(
                 exp_decay,
-                data[qubit].wait,
+                x,
                 probability,
                 p0=p0,
                 maxfev=2000000,

--- a/src/qibocal/protocols/characterization/coherence/utils.py
+++ b/src/qibocal/protocols/characterization/coherence/utils.py
@@ -95,7 +95,7 @@ def exponential_fit_probability(data):
             )
             popt = popt.tolist()
             perr = np.sqrt(np.diag(perr))
-
+            perr[2] = 0.1
         except Exception as e:
             log.warning(f"Exp decay fitting was not succesful. {e}")
             popt = [0] * 3

--- a/src/qibocal/protocols/characterization/coherence/utils.py
+++ b/src/qibocal/protocols/characterization/coherence/utils.py
@@ -93,7 +93,7 @@ def exponential_fit_probability(data):
                 ),
                 sigma=data[qubit].error,
             )
-
+            popt = popt.tolist()
             perr = np.sqrt(np.diag(perr))
 
         except Exception as e:
@@ -102,7 +102,7 @@ def exponential_fit_probability(data):
             dec = 5
             perr = [1] * 3
 
-        fitted_parameters[qubit] = popt.tolist()
+        fitted_parameters[qubit] = popt
         dec = popt[2]
         decay[qubit] = (dec, perr[2])
 

--- a/src/qibocal/protocols/characterization/coherence/utils.py
+++ b/src/qibocal/protocols/characterization/coherence/utils.py
@@ -7,7 +7,7 @@ from ..utils import V_TO_UV
 
 
 def exp_decay(x, *p):
-    return p[0] - p[1] * np.exp(-1 * x * p[2])
+    return p[0] - p[1] * np.exp(-1 * x / p[2])
 
 
 def exponential_fit(data, zeno=None):
@@ -52,7 +52,7 @@ def exponential_fit(data, zeno=None):
                 (y_max - y_min) * popt[1] * np.exp(x_min * popt[2] / (x_max - x_min)),
                 popt[2] / (x_max - x_min),
             ]
-            t2 = 1.0 / popt[2]
+            t2 = popt[2]
 
         except Exception as e:
             log.warning(f"Exp decay fitting was not succesful. {e}")
@@ -95,7 +95,6 @@ def exponential_fit_probability(data):
             )
             popt = popt.tolist()
             perr = np.sqrt(np.diag(perr))
-            perr[2] = 0.1
         except Exception as e:
             log.warning(f"Exp decay fitting was not succesful. {e}")
             popt = [0] * 3

--- a/src/qibocal/protocols/characterization/coherence/zeno.py
+++ b/src/qibocal/protocols/characterization/coherence/zeno.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 import numpy as np
-import numpy.typing as npt
 import plotly.graph_objects as go
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
 from qibolab.platform import Platform
@@ -10,10 +9,10 @@ from qibolab.pulses import PulseSequence
 from qibolab.qubits import QubitId
 
 from qibocal import update
-from qibocal.auto.operation import Data, Parameters, Qubits, Results, Routine
+from qibocal.auto.operation import Parameters, Qubits, Results, Routine
 
-from ..utils import V_TO_UV, table_dict, table_html
-from . import utils
+from ..utils import table_dict, table_html
+from . import t1, utils
 
 
 @dataclass
@@ -28,26 +27,10 @@ class ZenoParameters(Parameters):
     """Relaxation time (ns)."""
 
 
-ZenoType = np.dtype([("msr", np.float64), ("phase", np.float64)])
-"""Custom dtype for Zeno."""
-
-
 @dataclass
-class ZenoData(Data):
+class ZenoData(t1.T1Data):
     readout_duration: dict[QubitId, float] = field(default_factory=dict)
     """Readout durations for each qubit"""
-    data: dict[QubitId, npt.NDArray] = field(default_factory=dict)
-    """Raw data acquired."""
-
-    def register_qubit(self, qubit, msr, phase):
-        """Store output for single qubit."""
-        ar = np.empty((1,), dtype=ZenoType)
-        ar["msr"] = msr
-        ar["phase"] = phase
-        if qubit in self.data:
-            self.data[qubit] = np.rec.array(np.concatenate((self.data[qubit], ar)))
-        else:
-            self.data[qubit] = np.rec.array(ar)
 
 
 @dataclass
@@ -100,16 +83,23 @@ def _acquisition(
         ExecutionParameters(
             nshots=params.nshots,
             relaxation_time=params.relaxation_time,
-            acquisition_type=AcquisitionType.INTEGRATION,
-            averaging_mode=AveragingMode.CYCLIC,
+            acquisition_type=AcquisitionType.DISCRIMINATION,
+            averaging_mode=AveragingMode.SINGLESHOT,
         ),
     )
 
     # retrieve and store the results for every qubit
+    probs = {qubit: [] for qubit in qubits}
     for qubit in qubits:
         for ro_pulse in ro_pulses[qubit]:
-            result = results[ro_pulse.serial]
-            data.register_qubit(qubit=qubit, msr=result.magnitude, phase=result.phase)
+            probs[qubit].append(results[ro_pulse.serial].probability(state=1))
+        errors = [np.sqrt(prob * (1 - prob) / params.nshots) for prob in probs[qubit]]
+        data.register_qubit(
+            qubit,
+            wait=np.arange(1, len(probs[qubit]) + 1),
+            prob=probs[qubit],
+            error=errors,
+        )
     return data
 
 
@@ -121,30 +111,42 @@ def _fit(data: ZenoData) -> ZenoResults:
 
             y = p_0-p_1 e^{-x p_2}.
     """
-
-    t1s, fitted_parameters = utils.exponential_fit(data, zeno=True)
+    t1s, fitted_parameters = utils.exponential_fit_probability(data)
 
     return ZenoResults(t1s, fitted_parameters)
 
 
 def _plot(data: ZenoData, fit: ZenoResults, qubit):
     """Plotting function for T1 experiment."""
-    figures = []
-    fig = go.Figure()
 
+    figures = []
     fitting_report = ""
     qubit_data = data[qubit]
-    readouts = np.arange(1, len(qubit_data.msr) + 1)
+    probs = qubit_data.prob
+    error_bars = qubit_data.error
+    readouts = np.arange(1, len(qubit_data.prob) + 1)
 
-    fig.add_trace(
-        go.Scatter(
-            x=readouts,
-            y=qubit_data.msr * V_TO_UV,
-            opacity=1,
-            name="Voltage",
-            showlegend=True,
-            legendgroup="Voltage",
-        )
+    fig = go.Figure(
+        [
+            go.Scatter(
+                x=readouts,
+                y=probs,
+                opacity=1,
+                name="Probability of 1",
+                showlegend=True,
+                legendgroup="Probability of 1",
+                mode="lines",
+            ),
+            go.Scatter(
+                x=np.concatenate((readouts, readouts[::-1])),
+                y=np.concatenate((probs + error_bars, (probs - error_bars)[::-1])),
+                fill="toself",
+                fillcolor=t1.COLORBAND,
+                line=dict(color=t1.COLORBAND_LINE),
+                showlegend=True,
+                name="Errors",
+            ),
+        ]
     )
 
     if fit is not None:
@@ -166,11 +168,12 @@ def _plot(data: ZenoData, fit: ZenoResults, qubit):
         fitting_report = table_html(
             table_dict(
                 qubit,
-                ["Readout Pulse", "T1"],
+                ["T1 [ns]", "Readout Pulse [ns]"],
                 [
-                    np.round(fit.zeno_t1[qubit]),
-                    np.round(fit.zeno_t1[qubit] * data.readout_duration[qubit]),
+                    fit.zeno_t1[qubit],
+                    np.array(fit.zeno_t1[qubit]) * data.readout_duration[qubit],
                 ],
+                display_error=True,
             )
         )
         # FIXME: Pulse duration (+ time of flight ?)
@@ -178,9 +181,8 @@ def _plot(data: ZenoData, fit: ZenoResults, qubit):
     # last part
     fig.update_layout(
         showlegend=True,
-        uirevision="0",  # ``uirevision`` allows zooming while live plotting
         xaxis_title="Number of readouts",
-        yaxis_title="MSR (uV)",
+        yaxis_title="Probability of State 1",
     )
 
     figures.append(fig)

--- a/src/qibocal/protocols/characterization/coherence/zeno_msr.py
+++ b/src/qibocal/protocols/characterization/coherence/zeno_msr.py
@@ -1,0 +1,195 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+import numpy as np
+import numpy.typing as npt
+import plotly.graph_objects as go
+from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
+from qibolab.platform import Platform
+from qibolab.pulses import PulseSequence
+from qibolab.qubits import QubitId
+
+from qibocal import update
+from qibocal.auto.operation import Data, Parameters, Qubits, Results, Routine
+
+from ..utils import V_TO_UV, table_dict, table_html
+from . import utils
+
+
+@dataclass
+class ZenoParameters(Parameters):
+    """Zeno runcard inputs."""
+
+    readouts: int
+    "Number of readout pulses"
+    nshots: Optional[int] = None
+    """Number of shots."""
+    relaxation_time: Optional[int] = None
+    """Relaxation time (ns)."""
+
+
+ZenoType = np.dtype([("msr", np.float64), ("phase", np.float64)])
+"""Custom dtype for Zeno."""
+
+
+@dataclass
+class ZenoData(Data):
+    readout_duration: dict[QubitId, float] = field(default_factory=dict)
+    """Readout durations for each qubit"""
+    data: dict[QubitId, npt.NDArray] = field(default_factory=dict)
+    """Raw data acquired."""
+
+    def register_qubit(self, qubit, msr, phase):
+        """Store output for single qubit."""
+        ar = np.empty((1,), dtype=ZenoType)
+        ar["msr"] = msr
+        ar["phase"] = phase
+        if qubit in self.data:
+            self.data[qubit] = np.rec.array(np.concatenate((self.data[qubit], ar)))
+        else:
+            self.data[qubit] = np.rec.array(ar)
+
+
+@dataclass
+class ZenoResults(Results):
+    """Zeno outputs."""
+
+    zeno_t1: dict[QubitId, int]
+    """T1 for each qubit."""
+    fitted_parameters: dict[QubitId, dict[str, float]]
+    """Raw fitting output."""
+
+
+def _acquisition(
+    params: ZenoParameters,
+    platform: Platform,
+    qubits: Qubits,
+) -> ZenoData:
+    """
+    In a T1_Zeno experiment, we measure an excited qubit repeatedly. Due to decoherence processes,
+    it is possible that, at the time of measurement, the qubit will not be excited anymore.
+    The quantum zeno effect consists of measuring allowing a particle's time evolution to be slowed
+    down by measuring it frequently enough. However, in the experiments we see that due the QND-ness of the readout
+    pulse that the qubit decoheres faster.
+    Reference: https://link.aps.org/accepted/10.1103/PhysRevLett.118.240401.
+    """
+
+    # create sequence of pulses:
+    sequence = PulseSequence()
+    RX_pulses = {}
+    ro_pulses = {}
+    ro_pulse_duration = {}
+    for qubit in qubits:
+        RX_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
+        sequence.add(RX_pulses[qubit])
+        start = RX_pulses[qubit].finish
+        ro_pulses[qubit] = []
+        for _ in range(params.readouts):
+            ro_pulse = platform.create_qubit_readout_pulse(qubit, start=start)
+            start += ro_pulse.duration
+            sequence.add(ro_pulse)
+            ro_pulses[qubit].append(ro_pulse)
+        ro_pulse_duration[qubit] = ro_pulse.duration
+
+    # create a DataUnits object to store the results
+    data = ZenoData(readout_duration=ro_pulse_duration)
+
+    # execute the first pulse sequence
+    results = platform.execute_pulse_sequence(
+        sequence,
+        ExecutionParameters(
+            nshots=params.nshots,
+            relaxation_time=params.relaxation_time,
+            acquisition_type=AcquisitionType.INTEGRATION,
+            averaging_mode=AveragingMode.CYCLIC,
+        ),
+    )
+
+    # retrieve and store the results for every qubit
+    for qubit in qubits:
+        for ro_pulse in ro_pulses[qubit]:
+            result = results[ro_pulse.serial]
+            data.register_qubit(qubit=qubit, msr=result.magnitude, phase=result.phase)
+    return data
+
+
+def _fit(data: ZenoData) -> ZenoResults:
+    """
+    Fitting routine for T1 experiment. The used model is
+
+        .. math::
+
+            y = p_0-p_1 e^{-x p_2}.
+    """
+
+    t1s, fitted_parameters = utils.exponential_fit(data, zeno=True)
+
+    return ZenoResults(t1s, fitted_parameters)
+
+
+def _plot(data: ZenoData, fit: ZenoResults, qubit):
+    """Plotting function for T1 experiment."""
+    figures = []
+    fig = go.Figure()
+
+    fitting_report = ""
+    qubit_data = data[qubit]
+    readouts = np.arange(1, len(qubit_data.msr) + 1)
+
+    fig.add_trace(
+        go.Scatter(
+            x=readouts,
+            y=qubit_data.msr * V_TO_UV,
+            opacity=1,
+            name="Voltage",
+            showlegend=True,
+            legendgroup="Voltage",
+        )
+    )
+
+    if fit is not None:
+        fitting_report = ""
+        waitrange = np.linspace(
+            min(readouts),
+            max(readouts),
+            2 * len(qubit_data),
+        )
+        params = fit.fitted_parameters[qubit]
+        fig.add_trace(
+            go.Scatter(
+                x=waitrange,
+                y=utils.exp_decay(waitrange, *params),
+                name="Fit",
+                line=go.scatter.Line(dash="dot"),
+            )
+        )
+        fitting_report = table_html(
+            table_dict(
+                qubit,
+                ["T1", "Readout Pulse"],
+                [
+                    np.round(fit.zeno_t1[qubit]),
+                    np.round(fit.zeno_t1[qubit] * data.readout_duration[qubit]),
+                ],
+            )
+        )
+        # FIXME: Pulse duration (+ time of flight ?)
+
+    # last part
+    fig.update_layout(
+        showlegend=True,
+        uirevision="0",  # ``uirevision`` allows zooming while live plotting
+        xaxis_title="Number of readouts",
+        yaxis_title="MSR (uV)",
+    )
+
+    figures.append(fig)
+
+    return figures, fitting_report
+
+
+def _update(results: ZenoResults, platform: Platform, qubit: QubitId):
+    update.t1(results.zeno_t1[qubit], platform, qubit)
+
+
+zeno_msr = Routine(_acquisition, _fit, _plot, _update)

--- a/src/qibocal/protocols/characterization/ramsey_msr.py
+++ b/src/qibocal/protocols/characterization/ramsey_msr.py
@@ -1,52 +1,35 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 
 import numpy as np
-import numpy.typing as npt
 import plotly.graph_objects as go
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
 from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
 from qibolab.qubits import QubitId
 from qibolab.sweeper import Parameter, Sweeper, SweeperType
-from scipy.optimize import curve_fit
-from scipy.signal import find_peaks
 
-from qibocal import update
-from qibocal.auto.operation import Data, Parameters, Qubits, Results, Routine
+from qibocal.auto.operation import Qubits, Results, Routine
 
-from .utils import GHZ_TO_HZ, chi2_reduced, table_dict, table_html
-
-POPT_EXCEPTION = [0, 0, 0, 0, 0]
-"""Fit parameters output to handle exceptions"""
-PERR_EXCEPTION = [1] * 5
-"""Fit errors to handle exceptions; their choice has no physical meaning
-and is meant to avoid breaking the code."""
-COLORBAND = "rgba(0,100,80,0.2)"
-COLORBAND_LINE = "rgba(255,255,255,0)"
+from .ramsey import (
+    PERR_EXCEPTION,
+    POPT_EXCEPTION,
+    RamseyData,
+    RamseyParameters,
+    _update,
+    fitting,
+    ramsey_fit,
+)
+from .utils import GHZ_TO_HZ, V_TO_UV, table_dict, table_html
 
 
 @dataclass
-class RamseyParameters(Parameters):
+class RamseyMSRParameters(RamseyParameters):
     """Ramsey runcard inputs."""
 
-    delay_between_pulses_start: int
-    """Initial delay between RX(pi/2) pulses in ns."""
-    delay_between_pulses_end: int
-    """Final delay between RX(pi/2) pulses in ns."""
-    delay_between_pulses_step: int
-    """Step delay between RX(pi/2) pulses in ns."""
-    n_osc: Optional[int] = 0
-    """Number of oscillations to induce detuning (optional).
-        If 0 standard Ramsey experiment is performed."""
-    nshots: Optional[int] = None
-    """Number of shots."""
-    relaxation_time: Optional[int] = None
-    """Relaxation time (ns)."""
-
 
 @dataclass
-class RamseyResults(Results):
+class RamseyMSRResults(Results):
     """Ramsey outputs."""
 
     frequency: dict[QubitId, tuple[float, Optional[float]]]
@@ -57,38 +40,23 @@ class RamseyResults(Results):
     """Drive frequency [Hz] correction for each qubit."""
     fitted_parameters: dict[QubitId, list[float]]
     """Raw fitting output."""
-    chi2: dict[QubitId, tuple[float, Optional[float]]]
 
 
-RamseyType = np.dtype(
-    [("wait", np.float64), ("prob", np.float64), ("errors", np.float64)]
-)
+RamseyMSRType = np.dtype([("wait", np.float64), ("msr", np.float64)])
 """Custom dtype for coherence routines."""
 
 
 @dataclass
-class RamseyData(Data):
+class RamseyMSRData(RamseyData):
     """Ramsey acquisition outputs."""
 
-    n_osc: int
-    """Number of oscillations for detuning."""
-    t_max: int
-    """Final delay between RX(pi/2) pulses in ns."""
-    detuning_sign: int
-    """Sign for induced detuning."""
-    qubit_freqs: dict[QubitId, float] = field(default_factory=dict)
-    """Qubit freqs for each qubit."""
-    data: dict[QubitId, npt.NDArray] = field(default_factory=dict)
-    """Raw data acquired."""
-
-    def register_qubit(self, qubit, wait, prob, errors):
+    def register_qubit(self, qubit, wait, msr):
         """Store output for single qubit."""
         # to be able to handle the non-sweeper case
-        shape = (1,) if np.isscalar(prob) else prob.shape
-        ar = np.empty(shape, dtype=RamseyType)
+        shape = (1,) if np.isscalar(msr) else msr.shape
+        ar = np.empty(shape, dtype=RamseyMSRType)
         ar["wait"] = wait
-        ar["prob"] = prob
-        ar["errors"] = errors
+        ar["msr"] = msr
         if qubit in self.data:
             self.data[qubit] = np.rec.array(np.concatenate((self.data[qubit], ar)))
         else:
@@ -104,10 +72,10 @@ class RamseyData(Data):
 
 
 def _acquisition(
-    params: RamseyParameters,
+    params: RamseyMSRParameters,
     platform: Platform,
     qubits: Qubits,
-) -> RamseyData:
+) -> RamseyMSRData:
     """Data acquisition for Ramsey Experiment (detuned)."""
     # create a sequence of pulses for the experiment
     # RX90 - t - RX90 - MZ
@@ -138,7 +106,7 @@ def _acquisition(
         params.delay_between_pulses_step,
     )
 
-    data = RamseyData(
+    data = RamseyMSRData(
         n_osc=params.n_osc,
         t_max=params.delay_between_pulses_end,
         detuning_sign=+1,
@@ -159,20 +127,18 @@ def _acquisition(
             ExecutionParameters(
                 nshots=params.nshots,
                 relaxation_time=params.relaxation_time,
-                acquisition_type=AcquisitionType.DISCRIMINATION,
-                averaging_mode=AveragingMode.SINGLESHOT,
+                acquisition_type=AcquisitionType.INTEGRATION,
+                averaging_mode=AveragingMode.CYCLIC,
             ),
             sweeper,
         )
         for qubit in qubits:
-            probs = results[qubit].probability()
+            result = results[ro_pulses[qubit].serial]
             # The probability errors are the standard errors of the binomial distribution
-            errors = [np.sqrt(prob * (1 - prob) / params.nshots) for prob in probs]
             data.register_qubit(
                 qubit,
                 wait=waits,
-                prob=probs,
-                errors=errors,
+                msr=result.magnitude,
             )
 
     else:
@@ -193,34 +159,22 @@ def _acquisition(
                 ExecutionParameters(
                     nshots=params.nshots,
                     relaxation_time=params.relaxation_time,
-                    acquisition_type=AcquisitionType.DISCRIMINATION,
-                    averaging_mode=(AveragingMode.SINGLESHOT),
+                    acquisition_type=AcquisitionType.INTEGRATION,
+                    averaging_mode=(AveragingMode.CYCLIC),
                 ),
             )
 
             for qubit in qubits:
-                prob = results[qubit].probability()
-                error = np.sqrt(prob * (1 - prob) / params.nshots)
+                result = results[ro_pulses[qubit].serial]
                 data.register_qubit(
                     qubit,
                     wait=wait,
-                    prob=prob,
-                    errors=error,
+                    msr=result.magnitude,
                 )
     return data
 
 
-def ramsey_fit(x, p0, p1, p2, p3, p4):
-    # A fit to Superconducting Qubit Rabi Oscillation
-    #   Offset                       : p[0]
-    #   Oscillation amplitude        : p[1]
-    #   DeltaFreq                    : p[2]
-    #   Phase                        : p[3]
-    #   Arbitrary parameter T_2      : 1/p[4]
-    return p0 + p1 * np.sin(x * p2 + p3) * np.exp(-x * p4)
-
-
-def _fit(data: RamseyData) -> RamseyResults:
+def _fit(data: RamseyMSRData) -> RamseyMSRResults:
     r"""
     Fitting routine for Ramsey experiment. The used model is
     .. math::
@@ -232,13 +186,12 @@ def _fit(data: RamseyData) -> RamseyResults:
     freq_measure = {}
     t2_measure = {}
     delta_phys_measure = {}
-    chi2 = {}
     for qubit in qubits:
         qubit_data = data[qubit]
         qubit_freq = data.qubit_freqs[qubit]
-        probs = qubit_data["prob"]
+        msr = qubit_data["msr"]
         try:
-            popt, perr = fitting(waits, probs, qubit_data.errors)
+            popt, perr = fitting(waits, msr)
         except:
             popt = POPT_EXCEPTION
             perr = PERR_EXCEPTION
@@ -259,18 +212,11 @@ def _fit(data: RamseyData) -> RamseyResults:
             delta_phys,
             popt[2] * GHZ_TO_HZ / (2 * np.pi * data.t_max),
         )
-        chi2[qubit] = (
-            chi2_reduced(
-                probs,
-                ramsey_fit(waits, *popts[qubit]),
-                qubit_data.errors,
-            ),
-            np.sqrt(2 / len(probs)),
-        )
-    return RamseyResults(freq_measure, t2_measure, delta_phys_measure, popts, chi2)
+
+    return RamseyMSRResults(freq_measure, t2_measure, delta_phys_measure, popts)
 
 
-def _plot(data: RamseyData, qubit, fit: RamseyResults = None):
+def _plot(data: RamseyMSRData, qubit, fit: RamseyMSRResults = None):
     """Plotting function for Ramsey Experiment."""
 
     figures = []
@@ -279,27 +225,17 @@ def _plot(data: RamseyData, qubit, fit: RamseyResults = None):
 
     qubit_data = data.data[qubit]
     waits = data.waits
-    probs = qubit_data["prob"]
-    error_bars = qubit_data["errors"]
+    msr = qubit_data["msr"]
     fig = go.Figure(
         [
             go.Scatter(
                 x=waits,
-                y=probs,
+                y=msr * V_TO_UV,
                 opacity=1,
                 name="Voltage",
                 showlegend=True,
                 legendgroup="Voltage",
                 mode="lines",
-            ),
-            go.Scatter(
-                x=np.concatenate((waits, waits[::-1])),
-                y=np.concatenate((probs + error_bars, (probs - error_bars)[::-1])),
-                fill="toself",
-                fillcolor=COLORBAND,
-                line=dict(color=COLORBAND_LINE),
-                showlegend=True,
-                name="Errors",
             ),
         ]
     )
@@ -315,7 +251,8 @@ def _plot(data: RamseyData, qubit, fit: RamseyResults = None):
                     float(fit.fitted_parameters[qubit][2]),
                     float(fit.fitted_parameters[qubit][3]),
                     float(fit.fitted_parameters[qubit][4]),
-                ),
+                )
+                * V_TO_UV,
                 name="Fit",
                 line=go.scatter.Line(dash="dot"),
             )
@@ -327,15 +264,12 @@ def _plot(data: RamseyData, qubit, fit: RamseyResults = None):
                     "Delta Frequency [Hz]",
                     "Drive Frequency [Hz]",
                     "T2* [ns]",
-                    "chi2 reduced",
                 ],
                 [
-                    fit.delta_phys[qubit],
-                    fit.frequency[qubit],
-                    fit.t2[qubit],
-                    fit.chi2[qubit],
+                    np.round(fit.delta_phys[qubit][0], 3),
+                    np.round(fit.frequency[qubit][0], 3),
+                    np.round(fit.t2[qubit][0], 3),
                 ],
-                display_error=True,
             )
         )
 
@@ -343,7 +277,7 @@ def _plot(data: RamseyData, qubit, fit: RamseyResults = None):
         showlegend=True,
         uirevision="0",  # ``uirevision`` allows zooming while live plotting
         xaxis_title="Time (ns)",
-        yaxis_title="Ground state probability",
+        yaxis_title="MSR [uV]",
     )
 
     figures.append(fig)
@@ -351,69 +285,5 @@ def _plot(data: RamseyData, qubit, fit: RamseyResults = None):
     return figures, fitting_report
 
 
-def _update(results: RamseyResults, platform: Platform, qubit: QubitId):
-    update.drive_frequency(results.frequency[qubit], platform, qubit)
-
-
-ramsey = Routine(_acquisition, _fit, _plot, _update)
+ramsey_msr = Routine(_acquisition, _fit, _plot, _update)
 """Ramsey Routine object."""
-
-
-def fitting(x: list, y: list, errors: list = None) -> list:
-    """
-    Given the inputs list `x` and outputs one `y`, this function fits the
-    `ramsey_fit` function and returns a list with the fit parameters.
-    """
-    y_max = np.max(y)
-    y_min = np.min(y)
-    x_max = np.max(x)
-    x_min = np.min(x)
-    delta_y = y_max - y_min
-    delta_x = x_max - x_min
-    y = (y - y_min) / delta_y
-    x = (x - x_min) / delta_x
-    err = errors / delta_y if errors is not None else None
-    ft = np.fft.rfft(y)
-    freqs = np.fft.rfftfreq(len(y), x[1] - x[0])
-    mags = abs(ft)
-    local_maxima = find_peaks(mags, threshold=10)[0]
-    index = local_maxima[0] if len(local_maxima) > 0 else None
-    # 0.5 hardcoded guess for less than one oscillation
-    f = freqs[index] * 2 * np.pi if index is not None else 0.5
-    p0 = [
-        0.5,
-        0.5,
-        f,
-        0,
-        1,
-    ]
-    popt, perr = curve_fit(
-        ramsey_fit,
-        x,
-        y,
-        p0=p0,
-        maxfev=5000,
-        bounds=(
-            [0, 0, 0, -np.pi, 0],
-            [1, 1, np.inf, np.pi, np.inf],
-        ),
-        sigma=err,
-    )
-    popt = [
-        delta_y * popt[0] + y_min,
-        delta_y * popt[1] * np.exp(x_min * popt[4] / delta_x),
-        popt[2] / delta_x,
-        popt[3] - x_min * popt[2] / delta_x,
-        popt[4] / delta_x,
-    ]
-    perr = np.sqrt(np.diag(perr))
-    perr = [
-        delta_y * perr[0],
-        delta_y
-        * np.exp(x_min * popt[4] / delta_x)
-        * np.sqrt(perr[1] ** 2 + (popt[1] * x_min * perr[4] / delta_x) ** 2),
-        perr[2] / delta_x,
-        np.sqrt(perr[3] ** 2 + (perr[2] * x_min / delta_x) ** 2),
-        perr[4] / delta_x,
-    ]
-    return popt, perr

--- a/src/qibocal/update.py
+++ b/src/qibocal/update.py
@@ -135,7 +135,10 @@ def t1(t1: int, platform: Platform, qubit: QubitId):
 
 def t2(t2: int, platform: Platform, qubit: QubitId):
     """Update mean excited state value in platform for specific qubit."""
-    platform.qubits[qubit].t2 = int(t2)
+    if isinstance(t2, tuple):
+        platform.qubits[qubit].t2 = int(t2[0])
+    else:
+        platform.qubits[qubit].t2 = int(t2)
 
 
 def t2_spin_echo(t2_spin_echo: float, platform: Platform, qubit: QubitId):

--- a/src/qibocal/update.py
+++ b/src/qibocal/update.py
@@ -127,7 +127,10 @@ def CZ_amplitude(amp: float, platform: Platform, pair: QubitPairId):
 
 def t1(t1: int, platform: Platform, qubit: QubitId):
     """Update mean excited state value in platform for specific qubit."""
-    platform.qubits[qubit].t1 = int(t1)
+    if isinstance(t1, tuple):
+        platform.qubits[qubit].t1 = int(t1[0])
+    else:
+        platform.qubits[qubit].t1 = int(t1)
 
 
 def t2(t2: int, platform: Platform, qubit: QubitId):

--- a/src/qibocal/update.py
+++ b/src/qibocal/update.py
@@ -136,7 +136,7 @@ def CZ_amplitude(amp: float, platform: Platform, pair: QubitPairId):
 
 
 def t1(t1: int, platform: Platform, qubit: QubitId):
-    """Update mean excited state value in platform for specific qubit."""
+    """Update t1 value in platform for specific qubit."""
     if isinstance(t1, tuple):
         platform.qubits[qubit].t1 = int(t1[0])
     else:
@@ -144,7 +144,7 @@ def t1(t1: int, platform: Platform, qubit: QubitId):
 
 
 def t2(t2: int, platform: Platform, qubit: QubitId):
-    """Update mean excited state value in platform for specific qubit."""
+    """Update t2 value in platform for specific qubit."""
     if isinstance(t2, tuple):
         platform.qubits[qubit].t2 = int(t2[0])
     else:
@@ -152,8 +152,11 @@ def t2(t2: int, platform: Platform, qubit: QubitId):
 
 
 def t2_spin_echo(t2_spin_echo: float, platform: Platform, qubit: QubitId):
-    """Update mean excited state value in platform for specific qubit."""
-    platform.qubits[qubit].t2_spin_echo = int(t2_spin_echo)
+    """Update t2 echo value in platform for specific qubit."""
+    if isinstance(t2_spin_echo, tuple):
+        platform.qubits[qubit].t2_spin_echo = int(t2_spin_echo[0])
+    else:
+        platform.qubits[qubit].t2_spin_echo = int(t2_spin_echo)
 
 
 def drag_pulse_beta(beta: float, platform: Platform, qubit: QubitId):

--- a/tests/runcards/protocols.yml
+++ b/tests/runcards/protocols.yml
@@ -226,7 +226,14 @@ actions:
     priority: 00
     operation: zeno
     parameters:
-      readouts: 2
+      readouts: 10
+      nshots: 10
+
+  - id: zeno_msr
+    priority: 00
+    operation: zeno_msr
+    parameters:
+      readouts: 10
       nshots: 10
 
   - id: t2

--- a/tests/runcards/protocols.yml
+++ b/tests/runcards/protocols.yml
@@ -273,6 +273,25 @@ actions:
       n_osc: 2
       nshots: 10
 
+  - id: ramsey_msr
+    priority: 0
+    operation: ramsey_msr
+    parameters:
+      delay_between_pulses_start: 0
+      delay_between_pulses_end: 50
+      delay_between_pulses_step: 1
+      n_osc: 2
+      nshots: 10
+
+  - id: ramsey_msr_detuned
+    priority: 0
+    operation: ramsey_msr
+    parameters:
+      delay_between_pulses_start: 0
+      delay_between_pulses_end: 50
+      delay_between_pulses_step: 1
+      nshots: 10
+
   - id: ramsey detuned sequences
     priority: 0
     operation: ramsey_sequences

--- a/tests/runcards/protocols.yml
+++ b/tests/runcards/protocols.yml
@@ -238,6 +238,15 @@ actions:
       delay_between_pulses_step: 100
       nshots: 10
 
+  - id: t2_msr
+    priority: 0
+    operation: t2_msr
+    parameters:
+      delay_between_pulses_start: 16
+      delay_between_pulses_end: 20000
+      delay_between_pulses_step: 100
+      nshots: 10
+
   - id: t2 sequences
     priority: 0
     operation: t2_sequences

--- a/tests/runcards/protocols.yml
+++ b/tests/runcards/protocols.yml
@@ -204,6 +204,15 @@ actions:
       delay_before_readout_step: 2000
       nshots: 1024
 
+  - id: t1_msr
+    priority: 0
+    operation: t1_msr
+    parameters:
+      delay_before_readout_start: 0
+      delay_before_readout_end: 20_000
+      delay_before_readout_step: 2000
+      nshots: 1024
+
   - id: t1 sequences
     priority: 0
     operation: t1_sequences


### PR DESCRIPTION
In this PR I'm planning to add new protocols where the y axes correspond to probabilities and not longer MSR.
In this way we can use again the error given by the binomial distribution.
Protocols to modify:

- [x] T1
- [x] T2
- [x] SpinEcho
- [x] Zeno
- [x] Restore Ramsey with MSR

For the time being I'm keeping the ones with MSR. In the future we can think about removing them and just compute T1, T2, .. after single shot classification.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
- [x] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [x] Qibo: `master`
    - [x] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
