### PR TITLE
Reducing import overhead

### DIFF
--- a/src/qibocal/fitting/classifier/qubit_fit.py
+++ b/src/qibocal/fitting/classifier/qubit_fit.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import numpy as np
 import numpy.typing as npt
-import skops.io as sio
 
 from qibocal.protocols.characterization.utils import cumulative
 
@@ -37,6 +36,9 @@ normalize = lambda x: x
 
 def dump(model, save_path: Path):
     r"""Dumps the `model` in `save_path`"""
+    # relative import to reduce overhead when importing qibocal
+    import skops.io as sio
+
     sio.dump(model, save_path.with_suffix(".skops"))
 
 
@@ -44,6 +46,9 @@ def predict_from_file(loading_path: Path, input: np.typing.NDArray):
     r"""This function loads the model saved in `loading_path`
     and returns the predictions of `input`.
     """
+    # relative import to reduce overhead when importing qibocal
+    import skops.io as sio
+
     model = sio.load(loading_path, trusted=True)
     return model.predict(input)
 

--- a/src/qibocal/fitting/classifier/run.py
+++ b/src/qibocal/fitting/classifier/run.py
@@ -63,10 +63,10 @@ def pretty_name(classifier_name: str):
 
 
 class Classifier:
-    r"""Classs to define the different classifiers used in the benchmarking.
+    r"""Class to define the different classifiers used in the benchmarking.
 
     Args:
-        mod: Classsification model.
+        mod: Classification model.
         base_dir (Path): Where to store the classification results.
 
     """

--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -1,6 +1,5 @@
 """Test graph execution."""
 import pathlib
-import tempfile
 
 import pytest
 import yaml
@@ -29,7 +28,7 @@ class TestCard:
 
 
 @pytest.mark.parametrize("card", cards.glob("*.yaml"))
-def test_execution(card: pathlib.Path):
+def test_execution(card: pathlib.Path, tmp_path):
     """Execute a set of example runcards.
 
     The declared result is asserted to be the expected one.
@@ -38,7 +37,7 @@ def test_execution(card: pathlib.Path):
     testcard = TestCard(**yaml.safe_load(card.read_text(encoding="utf-8")))
     executor = Executor.load(
         testcard.runcard,
-        output=pathlib.Path(tempfile.mkdtemp()),
+        output=tmp_path,
         qubits=testcard.runcard.qubits,
     )
     list(executor.run(mode=ExecutionMode.acquire))

--- a/tests/test_classifiers.py
+++ b/tests/test_classifiers.py
@@ -1,4 +1,9 @@
+import numpy as np
+
 from qibocal.fitting.classifier import run
+
+MODEL_FILE = "model.skops"
+"""Filename for storing the model."""
 
 
 def test_load_model(tmp_path):
@@ -7,3 +12,14 @@ def test_load_model(tmp_path):
     classifier.dump_hyper(tmp_path)
     new_classifier = run.Classifier.model_from_dir(tmp_path / "qubit_fit")
     assert new_classifier == classifier.trainable_model
+
+
+def test_predict_from_file(tmp_path):
+    """Testing predict_from_file method."""
+    classifier = run.Classifier(run.import_classifiers(["qubit_fit"])[0], tmp_path)
+    model = classifier.create_model({"par1": 1})
+    iqs = np.random.rand(10, 2)
+    classifier.mod.dump(model, classifier.base_dir / MODEL_FILE)
+    target_predictions = model.predict(iqs)
+    predictions = classifier.mod.predict_from_file(tmp_path / MODEL_FILE, iqs)
+    assert np.array_equal(target_predictions, predictions)

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -1,6 +1,5 @@
 """Test routines' acquisition method using dummy platform"""
 import pathlib
-import tempfile
 
 import pytest
 import yaml
@@ -29,28 +28,25 @@ def idfn(val):
 
 @pytest.mark.parametrize("update", [True, False])
 @pytest.mark.parametrize("runcard", generate_runcard_single_protocol(), ids=idfn)
-def test_action_builder(runcard, update):
+def test_action_builder(runcard, update, tmp_path):
     """Test ActionBuilder for all protocols."""
-    path = pathlib.Path(tempfile.mkdtemp())
-    autocalibrate(runcard, path, force=True, update=update)
-    report(path)
+    autocalibrate(runcard, tmp_path, force=True, update=update)
+    report(tmp_path)
 
 
 @pytest.mark.parametrize("runcard", generate_runcard_single_protocol(), ids=idfn)
-def test_acquisition_builder(runcard):
+def test_acquisition_builder(runcard, tmp_path):
     """Test AcquisitionBuilder for all protocols."""
-    path = pathlib.Path(tempfile.mkdtemp())
-    acquire(runcard, path, force=True)
-    report(path)
+    acquire(runcard, tmp_path, force=True)
+    report(tmp_path)
 
 
 @pytest.mark.parametrize("runcard", generate_runcard_single_protocol(), ids=idfn)
-def test_fit_builder(runcard):
+def test_fit_builder(runcard, tmp_path):
     """Test FitBuilder."""
-    output_folder = pathlib.Path(tempfile.mkdtemp())
-    acquire(runcard, output_folder, force=True)
-    fit(output_folder, update=False)
-    report(output_folder)
+    acquire(runcard, tmp_path, force=True)
+    fit(tmp_path, update=False)
+    report(tmp_path)
 
 
 # TODO: compare report by calling qq report

--- a/tests/test_task_options.py
+++ b/tests/test_task_options.py
@@ -1,6 +1,4 @@
 """Test routines' acquisition method using dummy platform"""
-import pathlib
-import tempfile
 from copy import deepcopy
 
 import pytest
@@ -93,7 +91,7 @@ UPDATE_CARD = {
 
 @pytest.mark.parametrize("global_update", [True, False])
 @pytest.mark.parametrize("local_update", [True, False])
-def test_update_argument(global_update, local_update):
+def test_update_argument(global_update, local_update, tmp_path):
     """Test possible update combinations between global and local."""
     platform = deepcopy(create_platform("dummy"))
     old_readout_frequency = platform.qubits[0].readout_frequency
@@ -101,7 +99,7 @@ def test_update_argument(global_update, local_update):
     NEW_CARD = modify_card(deepcopy(UPDATE_CARD), update=local_update)
     executor = Executor.load(
         Runcard.load(NEW_CARD),
-        pathlib.Path(tempfile.mkdtemp()),
+        tmp_path,
         platform,
         platform.qubits,
         global_update,


### PR DESCRIPTION
After talking with @stavros11 we realized that now importing qibocal takes longer than usual.
After profiling the import we discover that importing `skops` introduces an overhead of around 2 seconds.
Here is the profiling with skops:
![image](https://github.com/qiboteam/qibocal/assets/49183315/04ac20e7-f307-4f87-a544-937726f6bcc9)
This PR reduces the import time by moving `skops` as a relative import.
Here is the updated profiling:
![image](https://github.com/qiboteam/qibocal/assets/49183315/0da7eabd-2a36-4794-b895-46e68370f4d9)


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
