### PR TITLE
fixing ordering table

### DIFF
--- a/serverscripts/web/index.html
+++ b/serverscripts/web/index.html
@@ -21,7 +21,7 @@
       var data = json['data'];
       var global_table = $('#global').DataTable({
         "data": data,
-        "order": [[2, "desc"]],
+        "order": [[1, "desc"]],
         "dom": "frtipl"
       });
     });


### PR DESCRIPTION
Fixes ordering of report based on date instead of execution start.
The server is already updated.