### PR TITLE
Platform default parameters read from qibolab platforms

### DIFF
--- a/src/qibocal/auto/operation.py
+++ b/src/qibocal/auto/operation.py
@@ -1,7 +1,7 @@
-from copy import deepcopy
 import inspect
 import json
 import time
+from copy import deepcopy
 from dataclasses import asdict, dataclass
 from functools import wraps
 from typing import Callable, Generic, NewType, Optional, TypeVar, Union

--- a/src/qibocal/auto/operation.py
+++ b/src/qibocal/auto/operation.py
@@ -74,7 +74,7 @@ class Parameters:
     """Wait time for the qubit to decohere back to the `gnd` state"""
 
     @classmethod
-    def load(cls, parameters):
+    def load(cls, input_parameters):
         """Load parameters from runcard.
 
         Possibly looking into previous steps outputs.
@@ -89,6 +89,7 @@ class Parameters:
 
         """
         default_parent_parameters = deepcopy(DEFAULT_PARENT_PARAMETERS)
+        parameters = deepcopy(input_parameters)
         for parameter, value in default_parent_parameters.items():
             default_parent_parameters[parameter] = parameters.pop(parameter, value)
         instantiated_class = cls(**parameters)

--- a/src/qibocal/auto/operation.py
+++ b/src/qibocal/auto/operation.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import inspect
 import json
 import time
@@ -87,10 +88,11 @@ class Parameters:
             the linked outputs
 
         """
-        for parameter, value in DEFAULT_PARENT_PARAMETERS.items():
-            DEFAULT_PARENT_PARAMETERS[parameter] = parameters.pop(parameter, value)
+        default_parent_parameters = deepcopy(DEFAULT_PARENT_PARAMETERS)
+        for parameter, value in default_parent_parameters.items():
+            default_parent_parameters[parameter] = parameters.pop(parameter, value)
         instantiated_class = cls(**parameters)
-        for parameter, value in DEFAULT_PARENT_PARAMETERS.items():
+        for parameter, value in default_parent_parameters.items():
             setattr(instantiated_class, parameter, value)
         return instantiated_class
 

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -135,9 +135,9 @@ class Task:
         task_qubits = self._allocate_local_qubits(qubits, platform)
 
         if self.parameters.nshots is None:
-            self.parameters.nshots = platform.settings.nshots
+            self.action.parameters["nshots"] = platform.settings.nshots
         if self.parameters.relaxation_time is None:
-            self.parameters.relaxation_time = platform.settings.relaxation_time
+            self.action.parameters["relaxation_time"] = platform.settings.relaxation_time
 
         try:
             operation: Routine = self.operation

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -19,9 +19,9 @@ from .operation import (
     RESULTSFILE,
     Data,
     DummyPars,
+    Parameters,
     Qubits,
     QubitsPairs,
-    Parameters,
     Results,
     Routine,
     dummy_operation,
@@ -134,12 +134,14 @@ class Task:
     ):
         completed = Completed(self, Normal(), folder)
         task_qubits = self._allocate_local_qubits(qubits, platform)
-        
+
         # get parent and child class data_members
-        parameters_keys = set(self.operation.parameters_type.__dict__["__annotations__"].keys()) | set(Parameters.__dict__["__annotations__"].keys())
+        parameters_keys = set(
+            self.operation.parameters_type.__dict__["__annotations__"].keys()
+        ) | set(Parameters.__dict__["__annotations__"].keys())
         # read all settings defined in platform-specific qibolab runcard
         for setting, value in platform.settings.__dict__.items():
-            # save values non defined in qibocal runcard, 
+            # save values non defined in qibocal runcard,
             # but that are used by the class
             if setting not in self.action.parameters:
                 if setting in parameters_keys:

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -137,7 +137,9 @@ class Task:
         if self.parameters.nshots is None:
             self.action.parameters["nshots"] = platform.settings.nshots
         if self.parameters.relaxation_time is None:
-            self.action.parameters["relaxation_time"] = platform.settings.relaxation_time
+            self.action.parameters[
+                "relaxation_time"
+            ] = platform.settings.relaxation_time
 
         try:
             operation: Routine = self.operation

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -21,6 +21,7 @@ from .operation import (
     DummyPars,
     Qubits,
     QubitsPairs,
+    Parameters,
     Results,
     Routine,
     dummy_operation,
@@ -133,6 +134,16 @@ class Task:
     ):
         completed = Completed(self, Normal(), folder)
         task_qubits = self._allocate_local_qubits(qubits, platform)
+        
+        # get parent and child class data_members
+        parameters_keys = set(self.operation.parameters_type.__dict__["__annotations__"].keys()) | set(Parameters.__dict__["__annotations__"].keys())
+        # read all settings defined in platform-specific qibolab runcard
+        for setting, value in platform.settings.__dict__.items():
+            # save values non defined in qibocal runcard, 
+            # but that are used by the class
+            if setting not in self.action.parameters:
+                if setting in parameters_keys:
+                    self.action.parameters[setting] = value
 
         try:
             operation: Routine = self.operation

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -135,22 +135,11 @@ class Task:
         completed = Completed(self, Normal(), folder)
         task_qubits = self._allocate_local_qubits(qubits, platform)
 
-        # if self.parameters.nshots is None:
-        #     self.parameters.nshots = platform.settings.nshots
-        # if self.parameters.relaxation_time is None:
-        #     self.parameters.relaxation_time = platform.settings.relaxation_time
-
-        parameters_keys = set(
-            self.operation.parameters_type.__dict__["__annotations__"].keys()
-        ) | set(Parameters.__dict__["__annotations__"].keys())
-        # read all settings defined in platform-specific qibolab runcard
-        for setting in parameters_keys:
-            if setting not in self.action.parameters:
-                if hasattr(platform.settings, setting):
-                    self.action.parameters[setting] = getattr(
-                        platform.settings, setting
-                    )
-
+        if self.parameters.nshots is None:
+            self.parameters.nshots = platform.settings.nshots
+        if self.parameters.relaxation_time is None:
+            self.parameters.relaxation_time = platform.settings.relaxation_time
+        
         try:
             operation: Routine = self.operation
             parameters = self.parameters

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -135,17 +135,11 @@ class Task:
         completed = Completed(self, Normal(), folder)
         task_qubits = self._allocate_local_qubits(qubits, platform)
 
-        # get parent and child class data_members
-        parameters_keys = set(
-            self.operation.parameters_type.__dict__["__annotations__"].keys()
-        ) | set(Parameters.__dict__["__annotations__"].keys())
-        # read all settings defined in platform-specific qibolab runcard
-        for setting, value in platform.settings.__dict__.items():
-            # save values non defined in qibocal runcard,
-            # but that are used by the class
-            if setting not in self.action.parameters:
-                if setting in parameters_keys:
-                    self.action.parameters[setting] = value
+        if self.parameters.nshots is None:
+            self.parameters.nshots = platform.settings.nshots
+
+        if self.parameters.relaxation_time is None:
+            self.parameters.relaxation_time = platform.settings.relaxation_time
 
         try:
             operation: Routine = self.operation

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -134,14 +134,14 @@ class Task:
         completed = Completed(self, Normal(), folder)
         task_qubits = self._allocate_local_qubits(qubits, platform)
 
-        if self.parameters.nshots is None:
-            self.action.parameters["nshots"] = platform.settings.nshots
-        if self.parameters.relaxation_time is None:
-            self.action.parameters[
-                "relaxation_time"
-            ] = platform.settings.relaxation_time
-
         try:
+            if self.parameters.nshots is None:
+                print(self.action)
+                self.action.parameters["nshots"] = platform.settings.nshots
+            if self.parameters.relaxation_time is None:
+                self.action.parameters[
+                    "relaxation_time"
+                ] = platform.settings.relaxation_time
             operation: Routine = self.operation
             parameters = self.parameters
         except RuntimeError:

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -136,7 +136,6 @@ class Task:
 
         try:
             if self.parameters.nshots is None:
-                print(self.action)
                 self.action.parameters["nshots"] = platform.settings.nshots
             if self.parameters.relaxation_time is None:
                 self.action.parameters[

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -19,7 +19,6 @@ from .operation import (
     RESULTSFILE,
     Data,
     DummyPars,
-    Parameters,
     Qubits,
     QubitsPairs,
     Results,

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -139,7 +139,7 @@ class Task:
         #     self.parameters.nshots = platform.settings.nshots
         # if self.parameters.relaxation_time is None:
         #     self.parameters.relaxation_time = platform.settings.relaxation_time
-        
+
         parameters_keys = set(
             self.operation.parameters_type.__dict__["__annotations__"].keys()
         ) | set(Parameters.__dict__["__annotations__"].keys())
@@ -147,8 +147,10 @@ class Task:
         for setting in parameters_keys:
             if setting not in self.action.parameters:
                 if hasattr(platform.settings, setting):
-                    self.action.parameters[setting]=getattr(platform.settings, setting)
-        
+                    self.action.parameters[setting] = getattr(
+                        platform.settings, setting
+                    )
+
         try:
             operation: Routine = self.operation
             parameters = self.parameters

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -19,7 +19,6 @@ from .operation import (
     RESULTSFILE,
     Data,
     DummyPars,
-    Parameters,
     Qubits,
     QubitsPairs,
     Results,
@@ -139,7 +138,7 @@ class Task:
             self.parameters.nshots = platform.settings.nshots
         if self.parameters.relaxation_time is None:
             self.parameters.relaxation_time = platform.settings.relaxation_time
-        
+
         try:
             operation: Routine = self.operation
             parameters = self.parameters

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -19,6 +19,7 @@ from .operation import (
     RESULTSFILE,
     Data,
     DummyPars,
+    Parameters,
     Qubits,
     QubitsPairs,
     Results,
@@ -134,12 +135,20 @@ class Task:
         completed = Completed(self, Normal(), folder)
         task_qubits = self._allocate_local_qubits(qubits, platform)
 
-        if self.parameters.nshots is None:
-            self.parameters.nshots = platform.settings.nshots
-
-        if self.parameters.relaxation_time is None:
-            self.parameters.relaxation_time = platform.settings.relaxation_time
-
+        # if self.parameters.nshots is None:
+        #     self.parameters.nshots = platform.settings.nshots
+        # if self.parameters.relaxation_time is None:
+        #     self.parameters.relaxation_time = platform.settings.relaxation_time
+        
+        parameters_keys = set(
+            self.operation.parameters_type.__dict__["__annotations__"].keys()
+        ) | set(Parameters.__dict__["__annotations__"].keys())
+        # read all settings defined in platform-specific qibolab runcard
+        for setting in parameters_keys:
+            if setting not in self.action.parameters:
+                if hasattr(platform.settings, setting):
+                    self.action.parameters[setting]=getattr(platform.settings, setting)
+        
         try:
             operation: Routine = self.operation
             parameters = self.parameters

--- a/tests/runcards/protocols.yml
+++ b/tests/runcards/protocols.yml
@@ -214,6 +214,15 @@ actions:
       pulse_length: 30
       nshots: 1024
 
+  - id: rabi without nshots
+    priority: 0
+    operation: rabi_amplitude
+    parameters:
+      min_amp_factor: 0.0
+      max_amp_factor: 4.0
+      step_amp_factor: 0.1
+      pulse_length: 30
+
   - id: rabi msr
     priority: 0
     operation: rabi_amplitude_msr


### PR DESCRIPTION
Closes #594 

Parameters not explicitly defined in the qibocal runcard are read from qibolab runcards.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
