### PR TITLE
Implementing validation using Chi squared

### DIFF
--- a/doc/source/getting-started/index.rst
+++ b/doc/source/getting-started/index.rst
@@ -12,5 +12,6 @@ your quantum hardware.
     interface
     runcard
     autoruncard
+    validation
     protocols
     example

--- a/doc/source/getting-started/validation.rst
+++ b/doc/source/getting-started/validation.rst
@@ -1,0 +1,52 @@
+How to add validation to your protocol?
+=======================================
+
+In Qibocal there is the possibility to add a validation step
+during the execution of your protocols.
+Here is an example of a runcard which validates the results through
+:math:`\chi^2`.
+
+.. code-block:: yaml
+
+   actions:
+    - id: t1
+      priority: 0
+      operation: t1
+      validator:
+        scheme: chi2
+        parameters:
+            chi2_max_value: 1
+      parameters:
+        ...
+
+The execution will be interrupted in this case if the :math:`\chi^2` exceed
+`chi_max_value`.
+
+Adding a custom validator at runtime
+------------------------------------
+
+.. TO COMPLETE
+The user is also able to define a custom validator through the python API.
+For example let's suppose that we want to write a validator that implements
+the following condition: "stop if T1 is less than 10us".
+
+.. code-block:: python
+
+   from qibocal.protocols.characterization import Operation
+   from qibolab.qubits import QubitId
+   from qibocal.auto.status import Normal, Failure
+   from qibocal.auto.validators import VALIDATORS
+
+   # retrieve t1 object
+   t1 = Operation["t1"].value
+
+   def t1_threshold(results: t1.results_type, qubit: QubitId, t1_min: float = 10e4):
+        # store T1 value for qubit
+        t1 = results.t1[qubit][0]
+
+        if t1 > t1_min:
+            return Normal()
+        else:
+            return Failure()
+
+    VALIDATORS["t1_threshold"] = t1_threshold

--- a/doc/source/getting-started/validation.rst
+++ b/doc/source/getting-started/validation.rst
@@ -21,32 +21,3 @@ Here is an example of a runcard which validates the results through
 
 The execution will be interrupted in this case if the :math:`\chi^2` exceeds
 `chi_max_value`.
-
-Adding a custom validator at runtime
-------------------------------------
-
-.. TO COMPLETE
-The user is also able to define a custom validator through the python API.
-For example let's suppose that we want to write a validator that implements
-the following condition: "stop if T1 is less than 10us".
-
-.. code-block:: python
-
-   from qibocal.protocols.characterization import Operation
-   from qibolab.qubits import QubitId
-   from qibocal.auto.status import Normal, Failure
-   from qibocal.auto.validators import VALIDATORS
-
-   # retrieve t1 object
-   t1 = Operation["t1"].value
-
-   def t1_threshold(results: t1.results_type, qubit: QubitId, t1_min: float = 10e4):
-        # store T1 value for qubit
-        t1 = results.t1[qubit][0]
-
-        if t1 > t1_min:
-            return Normal()
-        else:
-            return Failure()
-
-    VALIDATORS["t1_threshold"] = t1_threshold

--- a/doc/source/getting-started/validation.rst
+++ b/doc/source/getting-started/validation.rst
@@ -19,7 +19,7 @@ Here is an example of a runcard which validates the results through
       parameters:
         ...
 
-The execution will be interrupted in this case if the :math:`\chi^2` exceed
+The execution will be interrupted in this case if the :math:`\chi^2` exceeds
 `chi_max_value`.
 
 Adding a custom validator at runtime

--- a/src/qibocal/auto/execute.py
+++ b/src/qibocal/auto/execute.py
@@ -10,6 +10,7 @@ from qibocal.config import log
 from .graph import Graph
 from .history import History
 from .runcard import Id, Runcard
+from .status import Broken
 from .task import Qubits, Task
 
 
@@ -140,6 +141,10 @@ class Executor:
                 mode=mode,
             )
             self.history.push(completed)
+            if isinstance(completed.status, Broken) and mode.name == "autocalibration":
+                log.warning("Stopping execution due to error in validation.")
+                yield task.uid
+                break
             self.head = self.next()
             update = self.update and task.update
             if (

--- a/src/qibocal/auto/execute.py
+++ b/src/qibocal/auto/execute.py
@@ -10,7 +10,7 @@ from qibocal.config import log
 from .graph import Graph
 from .history import History
 from .runcard import Id, Runcard
-from .status import Broken
+from .status import Failure
 from .task import Qubits, Task
 
 
@@ -141,7 +141,7 @@ class Executor:
                 mode=mode,
             )
             self.history.push(completed)
-            if isinstance(completed.status, Broken) and mode.name == "autocalibration":
+            if isinstance(completed.status, Failure) and mode.name == "autocalibration":
                 log.warning("Stopping execution due to error in validation.")
                 yield task.uid
                 break

--- a/src/qibocal/auto/runcard.py
+++ b/src/qibocal/auto/runcard.py
@@ -10,6 +10,7 @@ from qibolab.platform import Platform
 from qibolab.qubits import QubitId
 
 from .operation import OperationId
+from .validation import Validator
 
 Id = NewType("Id", str)
 """Action identifiers type."""
@@ -35,7 +36,7 @@ class Action:
     """Local qubits (optional)."""
     update: bool = True
     """Runcard update mechanism."""
-    validator: Optional[dict[str, Any]] = None
+    validator: Optional[Validator] = None
     """Define validation scheme and parameters."""
     parameters: Optional[dict[str, Any]] = None
     """Input parameters, either values or provider reference."""

--- a/src/qibocal/auto/runcard.py
+++ b/src/qibocal/auto/runcard.py
@@ -35,6 +35,8 @@ class Action:
     """Local qubits (optional)."""
     update: bool = True
     """Runcard update mechanism."""
+    validator: Optional[dict[str, Any]] = None
+    """Define validation scheme and parameters."""
     parameters: Optional[dict[str, Any]] = None
     """Input parameters, either values or provider reference."""
 

--- a/src/qibocal/auto/status.py
+++ b/src/qibocal/auto/status.py
@@ -38,5 +38,5 @@ class Normal(Status):
     """All green."""
 
 
-class Broken(Status):
+class Failure(Status):
     """Unrecoverable."""

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -27,7 +27,7 @@ from .operation import (
 )
 from .runcard import Action, Id
 from .status import Normal, Status
-from .validation import ValidationSchemes
+from .validation import ValidationSchemes, Validator
 
 MAX_PRIORITY = int(1e9)
 """A number bigger than whatever will be manually typed. But not so insanely big not to fit in a native integer."""
@@ -88,9 +88,9 @@ class Task:
         return Operation[self.action.operation].value
 
     @property
-    def validator(self):
+    def validator(self) -> Validator:
         """Validator object from ValidationSchemes Enum"""
-        if self.action.update is None:
+        if self.action.validator is None:
             return None
         return ValidationSchemes[self.action.validator["scheme"]].value.load(
             self.action.validator
@@ -100,7 +100,7 @@ class Task:
         if self.validator is not None:
             status = {}
             for qubit in self.qubits:
-                status[qubit] = self.validator(results, qubit)
+                status[qubit] = self.validator.__call__(results, qubit)
 
     @property
     def main(self):
@@ -175,7 +175,8 @@ class Task:
 
         if mode.name in ["autocalibration", "fit"]:
             completed.results, completed.results_time = operation.fit(completed.data)
-            self.validate(completed.results)
+            if self.validator is not None:
+                self.validate(completed.results)
 
         return completed
 

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -86,16 +86,19 @@ class Task:
 
         return Operation[self.action.operation].value
 
-    def validate(self, results: Results):
-        if self.action.validator is not None:
-            status = {}
-            for qubit in self.qubits:
-                status[qubit] = self.action.validator.__call__(results, qubit)
-            # exit if any of the qubit state is Failure
-            if any(isinstance(stat, Failure) for stat in status.values()):
-                return Failure()
-            else:
-                return Normal()
+    def validate(self, results: Results) -> Optional[Status]:
+        """Performs validation only if validator is provided."""
+
+        if self.action.validator is None:
+            return None
+        status = {}
+        for qubit in self.qubits:
+            status[qubit] = self.action.validator.__call__(results, qubit)
+        # exit if any of the qubit state is Failure
+        if any(isinstance(stat, Failure) for stat in status.values()):
+            return Failure()
+        else:
+            return Normal()
 
     @property
     def main(self):

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -27,7 +27,6 @@ from .operation import (
 )
 from .runcard import Action, Id
 from .status import Normal, Status
-from .validation import ValidationSchemes, Validator
 
 MAX_PRIORITY = int(1e9)
 """A number bigger than whatever will be manually typed. But not so insanely big not to fit in a native integer."""
@@ -87,20 +86,11 @@ class Task:
 
         return Operation[self.action.operation].value
 
-    @property
-    def validator(self) -> Validator:
-        """Validator object from ValidationSchemes Enum"""
-        if self.action.validator is None:
-            return None
-        return ValidationSchemes[self.action.validator["scheme"]].value.load(
-            self.action.validator
-        )
-
     def validate(self, results: Results):
-        if self.validator is not None:
+        if self.action.validator is not None:
             status = {}
             for qubit in self.qubits:
-                status[qubit] = self.validator.__call__(results, qubit)
+                status[qubit] = self.action.validator.__call__(results, qubit)
 
     @property
     def main(self):
@@ -175,8 +165,7 @@ class Task:
 
         if mode.name in ["autocalibration", "fit"]:
             completed.results, completed.results_time = operation.fit(completed.data)
-            if self.validator is not None:
-                self.validate(completed.results)
+            self.validate(completed.results)
 
         return completed
 

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -26,7 +26,7 @@ from .operation import (
     dummy_operation,
 )
 from .runcard import Action, Id
-from .status import Broken, Normal, Status
+from .status import Failure, Normal, Status
 
 MAX_PRIORITY = int(1e9)
 """A number bigger than whatever will be manually typed. But not so insanely big not to fit in a native integer."""
@@ -91,9 +91,9 @@ class Task:
             status = {}
             for qubit in self.qubits:
                 status[qubit] = self.action.validator.__call__(results, qubit)
-            # exit if any of the qubit state is Broken
-            if any(isinstance(stat, Broken) for stat in status.values()):
-                return Broken()
+            # exit if any of the qubit state is Failure
+            if any(isinstance(stat, Failure) for stat in status.values()):
+                return Failure()
             else:
                 return Normal()
 

--- a/src/qibocal/auto/validation.py
+++ b/src/qibocal/auto/validation.py
@@ -44,6 +44,9 @@ class Chi2Validator(Validator):
     def __call__(
         self, results: Results, qubit: Union[QubitId, QubitPairId, list[QubitId]]
     ) -> Status:
+        log.info(
+            f"Performing validation in qubit {qubit} of {results.__class__.__name__} using {self.scheme} scheme."
+        )
         try:
             chi2 = getattr(results, "chi2")[qubit][0]
             if chi2 < self.chi2_max_value:

--- a/src/qibocal/auto/validation.py
+++ b/src/qibocal/auto/validation.py
@@ -4,9 +4,10 @@ from typing import NewType, Optional, Union
 
 from qibolab.qubits import QubitId, QubitPairId
 
-from . import validators
+from ..config import log
 from .operation import Results
 from .status import Status
+from .validators import VALIDATORS
 
 ValidatorId = NewType("ValidatorId", str)
 """Identifier for validator object."""
@@ -22,5 +23,8 @@ class Validator:
     def __call__(
         self, results: Results, qubit: Union[QubitId, QubitPairId, list[QubitId]]
     ) -> Status:
-        validator = getattr(validators, self.scheme)
+        log.info(
+            f"Performing validation in qubit {qubit} of {results.__class__.__name__} using {self.scheme} scheme."
+        )
+        validator = VALIDATORS[self.scheme]
         return validator(results, qubit, **self.parameters)

--- a/src/qibocal/auto/validation.py
+++ b/src/qibocal/auto/validation.py
@@ -1,17 +1,13 @@
 """Validation module."""
 from dataclasses import dataclass
-from enum import Enum
 from typing import NewType, Optional, Union
 
 from qibolab.qubits import QubitId, QubitPairId
 
-from qibocal.config import log, raise_error
-
+from . import validators
 from .operation import Results
-from .status import Broken, Normal, Status
+from .status import Status
 
-CHI2_MAX = 0.05
-"""Max value for accepting fit result."""
 ValidatorId = NewType("ValidatorId", str)
 """Identifier for validator object."""
 
@@ -21,44 +17,10 @@ class Validator:
     """Generic validator object."""
 
     scheme: ValidatorId
+    parameters: Optional[dict] = None
 
     def __call__(
         self, results: Results, qubit: Union[QubitId, QubitPairId, list[QubitId]]
     ) -> Status:
-        """Perform validation and returns qibocal.status.Status object."""
-        raise_error(NotImplementedError)
-
-    @classmethod
-    def load(cls, params: dict):
-        """Load validator from dict."""
-        return cls(**params)
-
-
-@dataclass
-class Chi2Validator(Validator):
-    """Chi2 validator."""
-
-    chi2_max_value: Optional[float] = CHI2_MAX
-    """Custom maximum chi2 value."""
-
-    def __call__(
-        self, results: Results, qubit: Union[QubitId, QubitPairId, list[QubitId]]
-    ) -> Status:
-        log.info(
-            f"Performing validation in qubit {qubit} of {results.__class__.__name__} using {self.scheme} scheme."
-        )
-        try:
-            chi2 = getattr(results, "chi2")[qubit][0]
-            if chi2 < self.chi2_max_value:
-                return Normal()
-            else:
-                return Broken()
-        except AttributeError:
-            log.warning(f"Chi2 attribute not present in {type(results)}")
-            return Broken()
-
-
-class ValidationSchemes(Enum):
-    """Validation schemes."""
-
-    chi2 = Chi2Validator
+        validator = getattr(validators, self.scheme)
+        return validator(results, qubit, **self.parameters)

--- a/src/qibocal/auto/validation.py
+++ b/src/qibocal/auto/validation.py
@@ -1,0 +1,61 @@
+"""Validation module."""
+from dataclasses import dataclass
+from enum import Enum
+from typing import NewType, Optional, Union
+
+from qibolab.qubits import QubitId, QubitPairId
+
+from qibocal.config import log, raise_error
+
+from .operation import Results
+from .status import Broken, Normal, Status
+
+CHI2_MAX = 0.05
+"""Max value for accepting fit result."""
+ValidatorId = NewType("ValidatorId", str)
+"""Identifier for validator object."""
+
+
+@dataclass
+class Validator:
+    """Generic validator object."""
+
+    scheme: ValidatorId
+
+    def __call__(
+        self, results: Results, qubit: Union[QubitId, QubitPairId, list[QubitId]]
+    ) -> Status:
+        """Perform validation and returns qibocal.status.Status object."""
+        raise_error(NotImplementedError)
+
+    @classmethod
+    def load(cls, params: dict):
+        """Load validator from dict."""
+        return cls(**params)
+
+
+@dataclass
+class Chi2Validator(Validator):
+    """Chi2 validator."""
+
+    chi2_max_value: Optional[float] = CHI2_MAX
+    """Custom maximum chi2 value."""
+
+    def __call__(
+        self, results: Results, qubit: Union[QubitId, QubitPairId, list[QubitId]]
+    ) -> Status:
+        try:
+            chi2 = getattr(results, "chi2")[qubit][0]
+            if chi2 < self.chi2_max_value:
+                return Normal()
+            else:
+                return Broken()
+        except AttributeError:
+            log.warning(f"Chi2 attribute not present in {type(results)}")
+            return Broken()
+
+
+class ValidationSchemes(Enum):
+    """Validation schemes."""
+
+    chi2 = Chi2Validator

--- a/src/qibocal/auto/validators.py
+++ b/src/qibocal/auto/validators.py
@@ -1,0 +1,38 @@
+"""Possible validators."""
+from typing import Union
+
+from qibolab.qubits import QubitId, QubitPairId
+
+from qibocal.config import log
+
+from .operation import Results
+from .status import Broken, Normal
+
+CHI2_MAX = 0.05
+"""Max value for accepting fit result."""
+
+
+def chi2(
+    results: Results,
+    qubit: Union[QubitId, QubitPairId, list[QubitId]],
+    chi2_max_value=None,
+):
+    """Performs validation of results using chi2.
+
+    It assesses that chi2 is below the chi2_max_value threshold.
+
+    """
+    log.info(
+        f"Performing validation in qubit {qubit} of {results.__class__.__name__} using chi2 scheme."
+    )
+    if chi2_max_value is None:
+        chi2_max_value = CHI2_MAX
+    try:
+        chi2 = getattr(results, "chi2")[qubit][0]
+        if chi2 < chi2_max_value:
+            return Normal()
+        else:
+            return Broken()
+    except AttributeError:
+        log.warning(f"Chi2 attribute not present in {type(results)}")
+        return Broken()

--- a/src/qibocal/auto/validators/__init__.py
+++ b/src/qibocal/auto/validators/__init__.py
@@ -1,0 +1,4 @@
+from .chi2 import chi2
+
+VALIDATORS = {"chi2": chi2}
+"""Dict with available validators."""

--- a/src/qibocal/auto/validators/__init__.py
+++ b/src/qibocal/auto/validators/__init__.py
@@ -1,4 +1,4 @@
-from .chi2 import chi2
+from .chi2 import check_chi2
 
-VALIDATORS = {"chi2": chi2}
+VALIDATORS = {"chi2": check_chi2}
 """Dict with available validators."""

--- a/src/qibocal/auto/validators/chi2.py
+++ b/src/qibocal/auto/validators/chi2.py
@@ -12,7 +12,7 @@ CHI2_MAX = 0.05
 """Max value for accepting fit result."""
 
 
-def chi2(
+def check_chi2(
     results: Results,
     qubit: Union[QubitId, QubitPairId, list[QubitId]],
     chi2_max_value=None,

--- a/src/qibocal/auto/validators/chi2.py
+++ b/src/qibocal/auto/validators/chi2.py
@@ -6,7 +6,7 @@ from qibolab.qubits import QubitId, QubitPairId
 from qibocal.config import raise_error
 
 from ..operation import Results
-from ..status import Broken, Normal
+from ..status import Failure, Normal
 
 CHI2_MAX = 0.05
 """Max value for accepting fit result."""
@@ -30,7 +30,7 @@ def chi2(
         if chi2 < chi2_max_value:
             return Normal()
         else:
-            return Broken()
+            return Failure()
     except AttributeError:
         raise_error(
             NotImplementedError, f"Chi2 validation not available for {type(results)}"

--- a/src/qibocal/auto/validators/chi2.py
+++ b/src/qibocal/auto/validators/chi2.py
@@ -1,12 +1,12 @@
-"""Possible validators."""
+"""Chi2 validation"""
 from typing import Union
 
 from qibolab.qubits import QubitId, QubitPairId
 
 from qibocal.config import log
 
-from .operation import Results
-from .status import Broken, Normal
+from ..operation import Results
+from ..status import Broken, Normal
 
 CHI2_MAX = 0.05
 """Max value for accepting fit result."""
@@ -22,9 +22,7 @@ def chi2(
     It assesses that chi2 is below the chi2_max_value threshold.
 
     """
-    log.info(
-        f"Performing validation in qubit {qubit} of {results.__class__.__name__} using chi2 scheme."
-    )
+
     if chi2_max_value is None:
         chi2_max_value = CHI2_MAX
     try:

--- a/src/qibocal/auto/validators/chi2.py
+++ b/src/qibocal/auto/validators/chi2.py
@@ -3,7 +3,7 @@ from typing import Union
 
 from qibolab.qubits import QubitId, QubitPairId
 
-from qibocal.config import log
+from qibocal.config import raise_error
 
 from ..operation import Results
 from ..status import Broken, Normal
@@ -32,5 +32,6 @@ def chi2(
         else:
             return Broken()
     except AttributeError:
-        log.warning(f"Chi2 attribute not present in {type(results)}")
-        return Broken()
+        raise_error(
+            NotImplementedError, f"Chi2 validation not available for {type(results)}"
+        )

--- a/src/qibocal/protocols/characterization/coherence/t2.py
+++ b/src/qibocal/protocols/characterization/coherence/t2.py
@@ -196,8 +196,7 @@ def _plot(data: T2Data, qubit, fit: T2Results = None):
         )
     fig.update_layout(
         showlegend=True,
-        uirevision="0",  # ``uirevision`` allows zooming while live plotting
-        xaxis_title="Time (ns)",
+        xaxis_title="Time [ns]",
         yaxis_title="Probability of State 1",
     )
 

--- a/src/qibocal/protocols/characterization/coherence/t2.py
+++ b/src/qibocal/protocols/characterization/coherence/t2.py
@@ -1,4 +1,5 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Optional
 
 import numpy as np
 import plotly.graph_objects as go
@@ -11,7 +12,7 @@ from qibolab.sweeper import Parameter, Sweeper, SweeperType
 from qibocal import update
 from qibocal.auto.operation import Parameters, Qubits, Results, Routine
 
-from ..utils import table_dict, table_html
+from ..utils import chi2_reduced, table_dict, table_html
 from . import t1, utils
 
 
@@ -35,6 +36,10 @@ class T2Results(Results):
     """T2 for each qubit (ns)."""
     fitted_parameters: dict[QubitId, dict[str, float]]
     """Raw fitting output."""
+    chi2: Optional[dict[QubitId, tuple[float, Optional[float]]]] = field(
+        default_factory=dict
+    )
+    """Chi squared estimate mean value and error."""
 
 
 class T2Data(t1.T1Data):
@@ -111,7 +116,18 @@ def _fit(data: T2Data) -> T2Results:
         y = p_0 - p_1 e^{-x p_2}.
     """
     t2s, fitted_parameters = utils.exponential_fit_probability(data)
-    return T2Results(t2s, fitted_parameters)
+    chi2 = {
+        qubit: (
+            chi2_reduced(
+                data[qubit].prob,
+                utils.exp_decay(data[qubit].wait, *fitted_parameters[qubit]),
+                data[qubit].error,
+            ),
+            np.sqrt(2 / len(data[qubit].prob)),
+        )
+        for qubit in data.qubits
+    }
+    return T2Results(t2s, fitted_parameters, chi2)
 
 
 def _plot(data: T2Data, qubit, fit: T2Results = None):
@@ -168,7 +184,15 @@ def _plot(data: T2Data, qubit, fit: T2Results = None):
             )
         )
         fitting_report = table_html(
-            table_dict(qubit, ["T2 [ns]"], [fit.t2[qubit]], display_error=True)
+            table_dict(
+                qubit,
+                [
+                    "T2 [ns]",
+                    "chi2 reduced",
+                ],
+                [fit.t2[qubit], fit.chi2[qubit]],
+                display_error=True,
+            )
         )
     fig.update_layout(
         showlegend=True,

--- a/src/qibocal/protocols/characterization/ramsey.py
+++ b/src/qibocal/protocols/characterization/ramsey.py
@@ -54,6 +54,7 @@ class RamseyResults(Results):
     fitted_parameters: dict[QubitId, list[float]]
     """Raw fitting output."""
     chi2: dict[QubitId, tuple[float, Optional[float]]]
+    """Chi squared estimate mean value and error. """
 
 
 RamseyType = np.dtype(

--- a/tests/runcards/chi_squared.yml
+++ b/tests/runcards/chi_squared.yml
@@ -1,0 +1,20 @@
+actions:
+  - id: t1
+    priority: 0
+    main: single shot
+    operation: t1
+    validator:
+      scheme: chi2
+      parameters:
+        chi2_max_value: 0
+    parameters:
+      delay_before_readout_start: 0
+      delay_before_readout_end: 20_000
+      delay_before_readout_step: 2000
+      nshots: 1024
+
+  - id: single shot
+    priority: 0
+    operation: single_shot_classification
+    parameters:
+      nshots: 10

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -50,7 +50,6 @@ def test_auto_command(runcard, update, platform, backend, tmp_path):
             update,
         ],
     )
-    print(results.output)
     assert not results.exception
     assert results.exit_code == 0
 

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -50,6 +50,7 @@ def test_auto_command(runcard, update, platform, backend, tmp_path):
             update,
         ],
     )
+    print(results.output)
     assert not results.exception
     assert results.exit_code == 0
 

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -14,6 +14,7 @@ SINGLE_ACTION_RUNCARD = "action.yml"
 
 
 def generate_runcard_single_protocol():
+    actions = yaml.safe_load(PATH_TO_RUNCARD.read_text(encoding="utf-8"))
     with open(PATH_TO_RUNCARD) as file:
         actions = yaml.safe_load(file)
     for action in actions["actions"]:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -44,7 +44,7 @@ DUMMY_CARD = {
 # TODO: generalize to all protocols that support chi2.
 
 
-@pytest.mark.parametrize("chi2_max_value", [100, 1e-5])
+@pytest.mark.parametrize("chi2_max_value", [1000, 1e-5])
 def test_chi2(chi2_max_value, tmp_path):
     """Dummy test only for t1"""
     DUMMY_CARD["actions"][0]["validator"]["parameters"][

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,64 @@
+"""Testing validators."""
+
+import pytest
+from qibolab import create_platform
+
+from qibocal.auto.execute import Executor
+from qibocal.auto.runcard import Runcard
+from qibocal.cli.report import ExecutionMode
+
+PLATFORM = create_platform("dummy")
+QUBITS = list(PLATFORM.qubits)
+DUMMY_CARD = {
+    "qubits": QUBITS,
+    "actions": [
+        {
+            "id": "t1",
+            "priority": 0,
+            "main": "single shot",
+            "operation": "t1",
+            "validator": {
+                "scheme": "chi2",
+                "parameters": {
+                    "chi2_max_value": 0,
+                },
+            },
+            "parameters": {
+                "delay_before_readout_start": 0,
+                "delay_before_readout_end": 20_000,
+                "delay_before_readout_step": 2000,
+                "nshots": 10,
+            },
+        },
+        {
+            "id": "single shot",
+            "priority": 0,
+            "operation": "single_shot_classification",
+            "parameters": {
+                "nshots": 10,
+            },
+        },
+    ],
+}
+
+# TODO: generalize to all protocols that support chi2.
+
+
+@pytest.mark.parametrize("chi2_max_value", [100, 1e-5])
+def test_chi2(chi2_max_value, tmp_path):
+    """Dummy test only for t1"""
+    DUMMY_CARD["actions"][0]["validator"]["parameters"][
+        "chi2_max_value"
+    ] = chi2_max_value
+    executor = Executor.load(
+        Runcard.load(DUMMY_CARD),
+        tmp_path,
+        PLATFORM,
+        PLATFORM.qubits,
+    )
+
+    list(executor.run(mode=ExecutionMode.autocalibration))
+
+    # for large chi2 value executor will execute 2 protocols
+    # only 1 with low chi2
+    assert len(executor.history.keys()) == 2 if chi2_max_value == 100 else 1

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,60 +1,29 @@
 """Testing validators."""
 
+import pathlib
+
 import pytest
+import yaml
 from qibolab import create_platform
 
 from qibocal.auto.execute import Executor
 from qibocal.auto.runcard import Runcard
 from qibocal.cli.report import ExecutionMode
 
+RUNCARD = pathlib.Path(__file__).parent / "runcards/chi_squared.yml"
 PLATFORM = create_platform("dummy")
-QUBITS = list(PLATFORM.qubits)
-DUMMY_CARD = {
-    "qubits": QUBITS,
-    "actions": [
-        {
-            "id": "t1",
-            "priority": 0,
-            "main": "single shot",
-            "operation": "t1",
-            "validator": {
-                "scheme": "chi2",
-                "parameters": {
-                    "chi2_max_value": 0,
-                },
-            },
-            "parameters": {
-                "delay_before_readout_start": 0,
-                "delay_before_readout_end": 20_000,
-                "delay_before_readout_step": 2000,
-                "nshots": 10,
-            },
-        },
-        {
-            "id": "single shot",
-            "priority": 0,
-            "operation": "single_shot_classification",
-            "parameters": {
-                "nshots": 10,
-            },
-        },
-    ],
-}
-
-# TODO: generalize to all protocols that support chi2.
 
 
 @pytest.mark.parametrize("chi2_max_value", [1000, 1e-5])
 def test_chi2(chi2_max_value, tmp_path):
     """Dummy test only for t1"""
-    DUMMY_CARD["actions"][0]["validator"]["parameters"][
-        "chi2_max_value"
-    ] = chi2_max_value
+    card = yaml.safe_load(RUNCARD.read_text(encoding="utf-8"))
+    card["actions"][0]["validator"]["parameters"]["chi2_max_value"] = chi2_max_value
     executor = Executor.load(
-        Runcard.load(DUMMY_CARD),
+        Runcard.load(card),
         tmp_path,
         PLATFORM,
-        PLATFORM.qubits,
+        list(PLATFORM.qubits),
     )
 
     list(executor.run(mode=ExecutionMode.autocalibration))


### PR DESCRIPTION
First attempt at introducing a validation in Qibocal through chi2.
Here is a possible runcard:

```yaml
platform: dummy

qubits: [0,1]


actions:

  - id: ramsey
    priority: 0
    operation: ramsey
    validator:
      scheme: chi2
      parameters:
        chi2_max_value: 0.1
    parameters:
      delay_between_pulses_start: 16 # must be a multiple of 4 incl 0
      delay_between_pulses_end: 1000
      delay_between_pulses_step: 4 # must be a multiple of 4
      n_osc: 10
```
For now I am just planning to add the `chi2` attribute in all protocols that implements errors.
Currently I believe that this works for `ramsey`, `rabi amplitude` and `rabi length`.
I tried to make it already quite validation scheme agnostic in case we want to add other validation schemes.
I am still not sure about how to handle the `Broken` status case. For now the easiest possibility will be just to fail
(which is not implemented in the code yet). We could add a handler which should specify how to act in the `Broken` solution. 
Also everything now should be intended only for a single qubit.
The PR is still missing tests and documentation which I will add once we agree on what to do.
Suggestions are welcomed :)

TODOs:

- [x] add chi2 protocols with errors
- [x] define exit condition with `Broken()` status

Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
- [x] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [x] Qibo: `master`
    - [x] Qibolab: `main`
    - [x] Qibolab_platforms_qrc: `main`
