### PR TITLE
fix mitigation matrix

### DIFF
--- a/src/qibocal/protocols/characterization/readout_mitigation_matrix.py
+++ b/src/qibocal/protocols/characterization/readout_mitigation_matrix.py
@@ -3,8 +3,7 @@ from typing import Optional
 
 import numpy as np
 import numpy.typing as npt
-import plotly.figure_factory as ff
-import plotly.graph_objects as go
+import plotly.express as px
 from qibo import gates
 from qibo.models import Circuit
 from qibolab import ExecutionParameters
@@ -172,30 +171,17 @@ def _plot(
 ):
     """Plotting function for readout mitigation matrix."""
     fitting_report = ""
-    fig = go.Figure()
 
     if fit is not None:
         computational_basis = [
             format(i, f"0{len(qubit)}b") for i in range(2 ** len(qubit))
         ]
+        z = fit.measurement_matrix[tuple(qubit)]
 
-        x = computational_basis
-        y = computational_basis[::-1]
-
-        [X, Y] = np.meshgrid(x, y)
-
-        Z = fit.measurement_matrix[tuple(qubit)]
-
-        fig = ff.create_annotated_heatmap(Z, showscale=True)
-        fig.update_layout(
-            uirevision="0",  # ``uirevision`` allows zooming while live plotting
-            xaxis_title="State prepared",
-            yaxis_title="State measured",
-            width=700,
-            height=700,
+        fig = px.imshow(
+            z, x=computational_basis, y=computational_basis[::-1], text_auto=True
         )
-
-    return [fig], None
+    return [fig], fitting_report
 
 
 readout_mitigation_matrix = Routine(_acquisition, _fit, _plot)

--- a/src/qibocal/protocols/characterization/readout_mitigation_matrix.py
+++ b/src/qibocal/protocols/characterization/readout_mitigation_matrix.py
@@ -179,7 +179,17 @@ def _plot(
         z = fit.measurement_matrix[tuple(qubit)]
 
         fig = px.imshow(
-            z, x=computational_basis, y=computational_basis[::-1], text_auto=True
+            z,
+            x=computational_basis,
+            y=computational_basis[::-1],
+            text_auto=True,
+            labels={
+                "x": "Prepeared States",
+                "y": "Measured States",
+                "color": "Probabilities",
+            },
+            width=700,
+            height=700,
         )
     return [fig], fitting_report
 


### PR DESCRIPTION
It closes #615.
I decided to delete `create_annotated_heatmap` since it is [deprecated](https://plotly.com/python/annotated-heatmap/#:~:text=As%20of%20version%205.5.0%20of%20plotly%2C%20the%20recommended%20way%20to%20display%20annotated%20heatmaps%20is%20to%20use%20px.imshow()%20rather%20than%20the%20now%2Ddeprecated%20create_annotated_heatmap%20figure%20factory%20documented%20below%20for%20historical%20reasons.).
The suggested replacement is `imshow` from plotly express, but because of a problem with dash, it is not able to diplay the text on the matrix cells.
Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
