### PR TITLE
Return url when running `qq upload`

### DIFF
--- a/src/qibocal/cli/upload.py
+++ b/src/qibocal/cli/upload.py
@@ -91,3 +91,4 @@ def upload_report(path: pathlib.Path, tag: str, author: str):
 
     url = urljoin(ROOT_URL, randname)
     log.info(f"Upload completed. The result is available at:\n{url}")
+    return url


### PR DESCRIPTION
Closes #671 (point 2).

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
