### PR TITLE
Hotfix for rabi period estimate

### DIFF
--- a/src/qibocal/protocols/characterization/rabi/utils.py
+++ b/src/qibocal/protocols/characterization/rabi/utils.py
@@ -213,4 +213,5 @@ def period_correction_factor(phase: float):
 
     """
 
-    return np.round(1 + phase / np.pi) - phase / np.pi
+    x = phase / np.pi
+    return np.round(1 + x) - x

--- a/src/qibocal/protocols/characterization/rabi/utils.py
+++ b/src/qibocal/protocols/characterization/rabi/utils.py
@@ -213,4 +213,4 @@ def period_correction_factor(phase: float):
 
     """
 
-    return 1 - np.modf(phase / np.pi)[0]
+    return np.round(1 + phase / np.pi) - phase / np.pi


### PR DESCRIPTION
Closes #656.
I think there was a problem with some simplification in the correction formula for the rabi period estimate.

Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
- [x] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [x] Qibo: `master`
    - [x] Qibolab: `main`
    - [x] Qibolab_platforms_qrc: `main`
