### PR TITLE
fix temperature

### DIFF
--- a/src/qibocal/protocols/characterization/classification.py
+++ b/src/qibocal/protocols/characterization/classification.py
@@ -254,6 +254,8 @@ def _fit(data: SingleShotClassificationData) -> SingleShotClassificationResults:
     effective_temperature = {}
     for qubit in qubits:
         qubit_data = data.data[qubit]
+        state0_data = qubit_data[qubit_data.state == 0]
+        iq_state0 = state0_data[["i", "q"]]
         benchmark_table, y_test, x_test, models, names, hpars_list = run.train_qubit(
             data, qubit
         )
@@ -264,7 +266,6 @@ def _fit(data: SingleShotClassificationData) -> SingleShotClassificationResults:
         hpars[qubit] = {}
         y_preds = []
         grid_preds = []
-
         grid = evaluate_grid(qubit_data)
         for i, model_name in enumerate(names):
             hpars[qubit][model_name] = hpars_list[i]
@@ -284,8 +285,9 @@ def _fit(data: SingleShotClassificationData) -> SingleShotClassificationResults:
                 mean_exc_states[qubit] = models[i].iq_mean1.tolist()
                 fidelity[qubit] = models[i].fidelity
                 assignment_fidelity[qubit] = models[i].assignment_fidelity
+                predictions_state0 = models[i].predict(iq_state0.tolist())
                 effective_temperature[qubit] = models[i].effective_temperature(
-                    y_preds[-1], data.qubit_frequencies[qubit]
+                    predictions_state0, data.qubit_frequencies[qubit]
                 )
         y_test_predict[qubit] = y_preds
         grid_preds_dict[qubit] = grid_preds


### PR DESCRIPTION
This PR fixes #676, the issue was that the temperature was evaluated on the dataset with ground and excited points. What it should be done (not sure) is to consider the dataset containing only the ground state and evaluate the temperature with its predictions.
 
Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
