### PR TITLE
Dump platform iteratively

### DIFF
--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -240,8 +240,8 @@ class Completed:
         if self.task.update and update:
             for qubit in self.task.qubits:
                 self.task.operation.update(self.results, platform, qubit)
-            (self.datapath / "platform").mkdir(parents=True, exist_ok=True)
-            dump_platform(platform, self.datapath / "platform")
+            (self.datapath / PLATFORM_FOLDER).mkdir(parents=True, exist_ok=True)
+            dump_platform(platform, self.datapath / PLATFORM_FOLDER)
 
     def validate(self) -> tuple[Optional[TaskId], Optional[dict]]:
         """Check status of completed and handle Failure using handler."""

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -240,8 +240,8 @@ class Completed:
         if self.task.update and update:
             for qubit in self.task.qubits:
                 self.task.operation.update(self.results, platform, qubit)
-        (self.datapath / "platform").mkdir(parents=True, exist_ok=True)
-        dump_platform(platform, self.datapath / "platform")
+            (self.datapath / "platform").mkdir(parents=True, exist_ok=True)
+            dump_platform(platform, self.datapath / "platform")
 
     def validate(self) -> tuple[Optional[TaskId], Optional[dict]]:
         """Check status of completed and handle Failure using handler."""

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -8,6 +8,7 @@ from typing import Optional, Union
 
 from qibolab.platform import Platform
 from qibolab.qubits import QubitId, QubitPairId
+from qibolab.serialize import dump_platform
 
 from ..config import raise_error
 from ..protocols.characterization import Operation
@@ -33,6 +34,8 @@ MAX_PRIORITY = int(1e9)
 """A number bigger than whatever will be manually typed. But not so insanely big not to fit in a native integer."""
 TaskId = tuple[Id, int]
 """Unique identifier for executed tasks."""
+PLATFORM_FOLDER = "platform"
+"""Folder where platform will be dumped."""
 
 
 @dataclass
@@ -237,6 +240,8 @@ class Completed:
         if self.task.update and update:
             for qubit in self.task.qubits:
                 self.task.operation.update(self.results, platform, qubit)
+        (self.datapath / "platform").mkdir(parents=True, exist_ok=True)
+        dump_platform(platform, self.datapath / "platform")
 
     def validate(self) -> tuple[Optional[TaskId], Optional[dict]]:
         """Check status of completed and handle Failure using handler."""

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -34,7 +34,7 @@ MAX_PRIORITY = int(1e9)
 """A number bigger than whatever will be manually typed. But not so insanely big not to fit in a native integer."""
 TaskId = tuple[Id, int]
 """Unique identifier for executed tasks."""
-PLATFORM_FOLDER = "platform"
+PLATFORM_DIR = "platform"
 """Folder where platform will be dumped."""
 
 
@@ -240,8 +240,8 @@ class Completed:
         if self.task.update and update:
             for qubit in self.task.qubits:
                 self.task.operation.update(self.results, platform, qubit)
-            (self.datapath / PLATFORM_FOLDER).mkdir(parents=True, exist_ok=True)
-            dump_platform(platform, self.datapath / PLATFORM_FOLDER)
+            (self.datapath / PLATFORM_DIR).mkdir(parents=True, exist_ok=True)
+            dump_platform(platform, self.datapath / PLATFORM_DIR)
 
     def validate(self) -> tuple[Optional[TaskId], Optional[dict]]:
         """Check status of completed and handle Failure using handler."""

--- a/tests/runcards/protocols.yml
+++ b/tests/runcards/protocols.yml
@@ -217,7 +217,6 @@ actions:
   - id: rabi
     priority: 0
     operation: rabi_amplitude
-    update: false
     parameters:
       min_amp_factor: 0.0
       max_amp_factor: 4.0
@@ -237,7 +236,6 @@ actions:
   - id: rabi signal
     priority: 0
     operation: rabi_amplitude_signal
-    update: false
     parameters:
       min_amp_factor: 0.0
       max_amp_factor: 4.0
@@ -517,7 +515,6 @@ actions:
   - id: flipping
     priority: 0
     operation: flipping
-    update: false
     parameters:
       nflips_max: 5
       nflips_step: 1

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -7,6 +7,8 @@ import yaml
 from click.testing import CliRunner
 from qibolab import create_platform
 
+from qibocal.auto.task import PLATFORM_FOLDER
+from qibocal.cli import utils
 from qibocal.cli._base import command
 from qibocal.protocols.characterization.rabi.amplitude import RabiAmplitudeData
 from qibocal.protocols.characterization.rabi.ef import RabiAmplitudeEFData
@@ -64,8 +66,8 @@ def test_auto_command(runcard, update, platform, backend, tmp_path, request):
     assert not results.exception
     assert results.exit_code == 0
     if update == "--update":
-        assert (tmp_path / "new_platform").is_dir()
-        assert (tmp_path / "data" / f"{protocol}_0" / "platform").is_dir()
+        assert (tmp_path / utils.UPDATED_PLATFORM).is_dir()
+        assert (tmp_path / "data" / f"{protocol}_0" / PLATFORM_FOLDER).is_dir()
 
 
 @pytest.mark.parametrize("platform", ["dummy"])
@@ -132,8 +134,8 @@ def test_fit_command(runcard, update, tmp_path):
     assert results_fit.exit_code == 0
 
     if update == "--update":
-        assert (tmp_path / "new_platform").is_dir()
-        assert (tmp_path / "data" / f"{protocol}_0" / "platform").is_dir()
+        assert (tmp_path / utils.UPDATED_PLATFORM).is_dir()
+        assert (tmp_path / "data" / f"{protocol}_0" / PLATFORM_FOLDER).is_dir()
 
     # generate report with fit and plot
     results_plot = runner.invoke(command, ["report", str(tmp_path)])

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -42,7 +42,7 @@ def idfn(val):
 @pytest.mark.parametrize("backend", ["qibolab"])
 @pytest.mark.parametrize("update", ["--update", "--no-update"])
 @pytest.mark.parametrize("runcard", generate_runcard_single_protocol(), ids=idfn)
-def test_auto_command(runcard, update, platform, backend, tmp_path, request):
+def test_auto_command(runcard, update, platform, backend, tmp_path):
     """Test auto command pipeline."""
 
     protocol = runcard["actions"][0]["id"]

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -7,7 +7,7 @@ import yaml
 from click.testing import CliRunner
 from qibolab import create_platform
 
-from qibocal.auto.task import PLATFORM_FOLDER
+from qibocal.auto.task import PLATFORM_DIR
 from qibocal.cli import utils
 from qibocal.cli._base import command
 from qibocal.protocols.characterization.rabi.amplitude import RabiAmplitudeData
@@ -67,7 +67,7 @@ def test_auto_command(runcard, update, platform, backend, tmp_path):
     assert results.exit_code == 0
     if update == "--update":
         assert (tmp_path / utils.UPDATED_PLATFORM).is_dir()
-        assert (tmp_path / "data" / f"{protocol}_0" / PLATFORM_FOLDER).is_dir()
+        assert (tmp_path / "data" / f"{protocol}_0" / PLATFORM_DIR).is_dir()
 
 
 @pytest.mark.parametrize("platform", ["dummy"])
@@ -135,7 +135,7 @@ def test_fit_command(runcard, update, tmp_path):
 
     if update == "--update":
         assert (tmp_path / utils.UPDATED_PLATFORM).is_dir()
-        assert (tmp_path / "data" / f"{protocol}_0" / PLATFORM_FOLDER).is_dir()
+        assert (tmp_path / "data" / f"{protocol}_0" / PLATFORM_DIR).is_dir()
 
     # generate report with fit and plot
     results_plot = runner.invoke(command, ["report", str(tmp_path)])


### PR DESCRIPTION
Closes #709.
A `platform` folder will now appear under each `protocol` folder in the report.
I've also made tests a bit more robust by checking if certain files/folders are present.

Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
- [x] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [x] Qibo: `master`
    - [x] Qibolab: `main`
    - [x] Qibolab_platforms_qrc: `main`
