### PR TITLE
Fix error in bootstrap.py and standard_rb.py

### DIFF
--- a/src/qibocal/bootstrap.py
+++ b/src/qibocal/bootstrap.py
@@ -39,7 +39,7 @@ def data_uncertainties(data, method=None, data_median=None, homogeneous=True):
         )
         return uncertainties
 
-    return None
+    return None  # TODO: # Raise an error on invalid method
 
 
 def bootstrap(

--- a/src/qibocal/protocols/characterization/randomized_benchmarking/standard_rb.py
+++ b/src/qibocal/protocols/characterization/randomized_benchmarking/standard_rb.py
@@ -222,7 +222,7 @@ def _acquisition(
                 RBType,
                 (qubit_id, depth),
                 dict(
-                    samples=sample[nqubit],
+                    samples=1 - sample[nqubit],
                 ),
             )
     return data
@@ -287,11 +287,16 @@ def _fit(data: RBData) -> StandardRBResult:
                 arr=np.array(samples),
             )
 
+        median = [np.mean(samples_row) for samples_row in samples]
+
+        # TODO: Error bars are wrong in the no bootstrap case
+        # Probably related with the resample_p0 function and samples_to_p0s
+
         # Fit the initial data and compute error bars
         error_bars = data_uncertainties(
             samples,
             uncertainties,
-            data_median=y,
+            data_median=median,
             homogeneous=(homogeneous or n_bootstrap != 0),
         )
 

--- a/src/qibocal/protocols/characterization/randomized_benchmarking/utils.py
+++ b/src/qibocal/protocols/characterization/randomized_benchmarking/utils.py
@@ -10,12 +10,12 @@ from qibocal.protocols.characterization.utils import significant_digit
 SINGLE_QUBIT_CLIFFORDS = {
     # Virtual gates
     0: gates.I,
-    1: gates.Z,
+    1: lambda q: gates.U3(q, 0, np.pi / 2, np.pi / 2),  # Z,
     2: lambda q: gates.RZ(q, np.pi / 2),
     3: lambda q: gates.RZ(q, -np.pi / 2),
     # pi rotations
-    4: gates.X,  # U3(q, np.pi, 0, np.pi),
-    5: gates.Y,  # U3(q, np.pi, 0, 0),
+    4: lambda q: gates.U3(q, np.pi, 0, np.pi),  # X,
+    5: lambda q: gates.U3(q, np.pi, 0, 0),  # Y,
     # pi/2 rotations
     6: lambda q: gates.RX(q, np.pi / 2),  # U3(q, np.pi / 2, -np.pi / 2, np.pi / 2),
     7: lambda q: gates.RX(q, -np.pi / 2),  # U3(q, -np.pi / 2, -np.pi / 2, np.pi / 2),
@@ -185,8 +185,7 @@ def samples_to_p0s(data, qubit):
     depths = data.depths
     for depth in depths:
         p0s.append(
-            1
-            - np.count_nonzero(np.array(data.data[(qubit, depth)]))
+            np.count_nonzero(np.array(data.data[(qubit, depth)]))
             / len(data.data[(qubit, depth)])
         )
     return p0s


### PR DESCRIPTION
Fixes the gate dict and [wip] error bars

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
