### PR TITLE
Add support for sequence unrolling in flipping and flipping_signal

### DIFF
--- a/src/qibocal/protocols/characterization/ramsey.py
+++ b/src/qibocal/protocols/characterization/ramsey.py
@@ -218,7 +218,7 @@ def _acquisition(
                 for sequence in sequences
             ]
 
-        # We dont need ig as everty serial is different
+        # We dont need ig as every serial is different
         for ig, (wait, ro_pulses) in enumerate(zip(waits, all_ro_pulses)):
             for qubit in qubits:
                 serial = ro_pulses[qubit].serial

--- a/tests/runcards/protocols.yml
+++ b/tests/runcards/protocols.yml
@@ -528,6 +528,24 @@ actions:
       nflips_step: 1
       nshots: 50
 
+  - id: flipping unrolling
+    priority: 0
+    operation: flipping
+    parameters:
+      nflips_max: 10
+      nflips_step: 1
+      nshots: 50
+      unrolling: True
+
+  - id: flipping_signal unrolling
+    priority: 0
+    operation: flipping_signal
+    parameters:
+      nflips_max: 10
+      nflips_step: 1
+      nshots: 50
+      unrolling: True
+
 
   - id: dispersive shift
     priority: 0


### PR DESCRIPTION
It adds support for sequence unrolling in flipping and flipping_signal as requested in https://github.com/qiboteam/qibolab_platforms_qrc/pull/119. It has only been tested with dummy.


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
