### PR TITLE
Fix fitting with probabilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qibocal"
-version = "0.0.7"
+version = "0.0.8"
 description = "Qibo's quantum calibration, characterization and validation module."
 authors = ["andrea-pasquale <andreapasquale97@gmail.com>"]
 license = "Apache License 2.0"

--- a/src/qibocal/protocols/characterization/coherence/spin_echo.py
+++ b/src/qibocal/protocols/characterization/coherence/spin_echo.py
@@ -90,8 +90,8 @@ def _acquisition(
         # save data as often as defined by points
 
         for qubit in qubits:
-            RX_pulses[qubit].start = RX90_pulses1[qubit].finish + wait
-            RX90_pulses2[qubit].start = RX_pulses[qubit].finish + wait
+            RX_pulses[qubit].start = RX90_pulses1[qubit].finish + wait // 2
+            RX90_pulses2[qubit].start = RX_pulses[qubit].finish + wait // 2
             ro_pulses[qubit].start = RX90_pulses2[qubit].finish
 
         # execute the pulse sequence

--- a/src/qibocal/protocols/characterization/coherence/spin_echo_sequence.py
+++ b/src/qibocal/protocols/characterization/coherence/spin_echo_sequence.py
@@ -74,8 +74,8 @@ def _acquisition(
         # save data as often as defined by points
 
         for qubit in qubits:
-            RX_pulses[qubit].start = RX90_pulses1[qubit].finish + wait
-            RX90_pulses2[qubit].start = RX_pulses[qubit].finish + wait
+            RX_pulses[qubit].start = RX90_pulses1[qubit].finish + wait // 2
+            RX90_pulses2[qubit].start = RX_pulses[qubit].finish + wait // 2
             ro_pulses[qubit].start = RX90_pulses2[qubit].finish
 
         # execute the pulse sequence

--- a/src/qibocal/protocols/characterization/coherence/utils.py
+++ b/src/qibocal/protocols/characterization/coherence/utils.py
@@ -70,7 +70,10 @@ def exponential_fit_probability(data):
     fitted_parameters = {}
 
     for qubit in qubits:
-        x = data[qubit].wait
+        times = data[qubit].wait
+        x_max = np.max(times)
+        x_min = np.min(times)
+        x = (times - x_min) / (x_max - x_min)
         probability = data[qubit].prob
         p0 = [
             0.5,
@@ -91,7 +94,11 @@ def exponential_fit_probability(data):
                 ),
                 sigma=data[qubit].error,
             )
-            popt = popt.tolist()
+            popt = [
+                popt[0],
+                popt[1] * np.exp(x_min * popt[2] / (x_max - x_min)),
+                popt[2] * (x_max - x_min),
+            ]
             perr = np.sqrt(np.diag(perr))
         except Exception as e:
             log.warning(f"Exp decay fitting was not succesful. {e}")


### PR DESCRIPTION
Improved fitting in exponential decays involving probabilities by adding a z_score normalization for data on the x_axis.
Here are some reports with T1, T2 and Spin Echo
http://login.qrccluster.com:9000/ETjYKXbbTM-cxWOuiWYz7Q==
http://login.qrccluster.com:9000/NsZ1y2OrRcy2tA3XbIKmTw==
http://login.qrccluster.com:9000/z8xLdg6NSseFpLQam7O-7g==


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
- [x] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [x] Qibo: `master`
    - [x] Qibolab: `main`
    - [x] Qibolab_platforms_qrc: `main`
