### PR TITLE
RB fix U3

### DIFF
--- a/src/qibocal/protocols/characterization/randomized_benchmarking/utils.py
+++ b/src/qibocal/protocols/characterization/randomized_benchmarking/utils.py
@@ -11,12 +11,12 @@ from qibocal.protocols.characterization.utils import significant_digit
 SINGLE_QUBIT_CLIFFORDS = {
     # Virtual gates
     0: gates.I,
-    1: gates.Z,
+    1: lambda q: gates.U3(q, 0, np.pi / 2, np.pi / 2),  # Z,
     2: lambda q: gates.RZ(q, np.pi / 2),
     3: lambda q: gates.RZ(q, -np.pi / 2),
     # pi rotations
-    4: gates.X,  # U3(q, np.pi, 0, np.pi),
-    5: gates.Y,  # U3(q, np.pi, 0, 0),
+    4: lambda q: gates.U3(q, np.pi, 0, np.pi),  # X,
+    5: lambda q: gates.U3(q, np.pi, 0, 0),  # Y,
     # pi/2 rotations
     6: lambda q: gates.RX(q, np.pi / 2),  # U3(q, np.pi / 2, -np.pi / 2, np.pi / 2),
     7: lambda q: gates.RX(q, -np.pi / 2),  # U3(q, -np.pi / 2, -np.pi / 2, np.pi / 2),


### PR DESCRIPTION
Fixes an issue regarding how Qibo handles U3 parameters for the RB

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
