### PR TITLE
Fix bug in lorentzian plot for spectroscopies

### DIFF
--- a/src/qibocal/protocols/characterization/utils.py
+++ b/src/qibocal/protocols/characterization/utils.py
@@ -225,11 +225,10 @@ def spectroscopy_plot(data, qubit, fit: Results = None):
 
     if fit is not None:
         params = fit.fitted_parameters[qubit]
-
         fig.add_trace(
             go.Scatter(
                 x=freqrange,
-                y=lorentzian(freqrange * GHZ_TO_HZ, *params),
+                y=lorentzian(freqrange, *params),
                 name="Fit",
                 line=go.scatter.Line(dash="dot"),
             ),


### PR DESCRIPTION
Closes #741.
There was no error in the fit since also the table shows the correct fitted value, the problem was just a factor 10^9 in the plot.
It is possible to test the fit by simply running 
```sh
qq fit <output_folder>
```
 and to generate the new report
```sh
qq report <output_folder>
```

Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
- [x] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [x] Qibo: `master`
    - [x] Qibolab: `main`
    - [x] Qibolab_platforms_qrc: `main`
