### PR TITLE
Store mitigation matrix when running  CHSH

### DIFF
--- a/src/qibocal/protocols/characterization/two_qubit_interaction/chsh/protocol.py
+++ b/src/qibocal/protocols/characterization/two_qubit_interaction/chsh/protocol.py
@@ -1,6 +1,8 @@
 """Protocol for CHSH experiment using both circuits and pulses."""
 
+import json
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Optional
 
 import numpy as np
@@ -23,6 +25,10 @@ from .pulses import create_chsh_sequences
 from .utils import READOUT_BASIS, compute_chsh
 
 COMPUTATIONAL_BASIS = ["00", "01", "10", "11"]
+
+
+MITIGATION_MATRIX_FILE = "mitigation_matrix"
+"""File where readout mitigation matrix is stored."""
 
 
 @dataclass
@@ -59,6 +65,29 @@ class CHSHData(Data):
         default_factory=dict
     )
     """Mitigation matrix computed using the readout_mitigation_matrix protocol."""
+
+    def save(self, path: Path):
+        """Saving data including mitigation matrix."""
+
+        np.savez(
+            path / f"{MITIGATION_MATRIX_FILE}.npz",
+            **{
+                json.dumps((control, target)): self.mitigation_matrix[control, target]
+                for control, target, _, _, _ in self.data
+            },
+        )
+        super().save(path=path)
+
+    @classmethod
+    def load(cls, path: Path):
+        """Custom loading to acco   modate mitigation matrix"""
+        instance = super().load(path=path)
+        # load readout mitigation matrix
+        mitigation_matrix = super().load_data(
+            path=path, filename=MITIGATION_MATRIX_FILE
+        )
+        instance.mitigation_matrix = mitigation_matrix
+        return instance
 
     def register_basis(self, pair, bell_state, basis, frequencies):
         """Store output for single qubit."""


### PR DESCRIPTION
Now when running CHSH the mitigation matrix will be stored in a `mitgation_matrix.npz` file.
It should be useful for debugging but also in order to generate the CHSH value after performing the acquisition (`qq acquire`) with `qq fit`. 
For the future it might be interesting to have this behave like kernels if we want to support readout mitigation (of course also qibolab will need to be updated to support this feature).

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
