### PR TITLE
Remove outdated keys after DAG remove

### DIFF
--- a/doc/source/protocols/resonator_punchout.rst
+++ b/doc/source/protocols/resonator_punchout.rst
@@ -26,7 +26,7 @@ This is and example of a runcard for a resonator punchout:
     actions:
 
       - id: resonator punchout
-        priority: 0
+
         operation: resonator_punchout
         parameters:
           freq_width: 40_000_000
@@ -116,7 +116,7 @@ This is and example of a runcard for a resonator punchout with attenuation:
     actions:
 
       - id: resonator_punchout_attenuation
-        priority: 0
+
         operation: resonator_punchout_attenuation
         parameters:
           freq_width: 10_000_000

--- a/doc/source/protocols/resonator_spectroscopy.rst
+++ b/doc/source/protocols/resonator_spectroscopy.rst
@@ -34,7 +34,7 @@ The bare resonator frequency can be found setting a large value for the amplitud
     actions:
 
       - id: resonator_spectroscopy high power
-        priority: 0
+
         operation: resonator_spectroscopy
         parameters:
             freq_width: 60_000_000
@@ -57,7 +57,7 @@ Lowering the amplitude we can see a shift in the peak, e.g.:
     actions:
 
       - id: resonator_spectroscopy low power
-        priority: 0
+
         operation: resonator_spectroscopy
         parameters:
             freq_width: 60_000_000

--- a/doc/source/tutorials/advanced.rst
+++ b/doc/source/tutorials/advanced.rst
@@ -459,7 +459,7 @@ To launch the protocol a possible runcard could be the following one:
 
     actions:
         - id: rotate
-          priority: 0
+
           operation: rotation
           parameters:
             theta_start: 0

--- a/doc/source/tutorials/basic.rst
+++ b/doc/source/tutorials/basic.rst
@@ -38,7 +38,7 @@ with qibocal it is sufficient to write the following action:
 .. code-block:: yaml
 
     - id: resonator_spectroscopy high power
-      priority: 0
+
       operation: resonator_spectroscopy
       parameters:
           freq_width: 60_000_000
@@ -70,7 +70,7 @@ power we observe this shift it is possible to run a resonator punchout using the
 .. code-block:: yaml
 
     - id: resonator punchout
-      priority: 0
+
       operation: resonator_punchout
       parameters:
           freq_width: 40_000_000
@@ -99,7 +99,7 @@ Here is an example of a runcard.
 .. code-block:: yaml
 
     - id: resonator_spectroscopy low power
-      priority: 0
+
       operation: resonator_spectroscopy
       parameters:
           freq_width: 60_000_000
@@ -136,7 +136,7 @@ Here is an example runcard:
 .. code-block:: yaml
 
     - id: qubit spectroscopy 01
-      priority: 0
+
       operation: qubit_spectroscopy
       parameters:
           drive_amplitude: 0.5
@@ -179,7 +179,7 @@ the following runcard:
 .. code-block:: yaml
 
       - id: rabi
-        priority: 0
+
         operation: rabi_amplitude_signal
         parameters:
             min_amp_factor: 0
@@ -208,7 +208,7 @@ The simplest model can be trained by running the following experiment:
 .. code-block:: yaml
 
     - id: single shot classification 1
-      priority: 0
+
       operation: single_shot_classification
       parameters:
           nshots: 5000
@@ -236,7 +236,7 @@ We can study the flux dependence of the qubit using the following runcard:
 .. code-block:: yaml
 
     - id: qubit flux dependence
-      priority: 0
+
       operation: qubit_flux
       parameters:
           freq_width: 100_000_000
@@ -277,7 +277,7 @@ Here is the runcard:
 .. code-block:: yaml
 
     - id: t1
-      priority: 0
+
       operation: t1
       parameters:
           delay_before_readout_end: 200000
@@ -301,7 +301,7 @@ denoted with :math:`\\T_2` and can be estimated through a Ramsey experiment.
 .. code-block:: yaml
 
     - id: ramsey detuned
-      priority: 0
+
       operation: ramsey
       parameters:
           delay_between_pulses_end: 40000
@@ -332,7 +332,7 @@ after having prepared  :math:`\ket{Y}`.
 .. code-block:: yaml
 
     - id: readout characterization
-      priority: 0
+
       operation: readout_characterization
       parameters:
           nshots: 5000
@@ -349,7 +349,7 @@ randomized benchmarking.
 .. code-block:: yaml
 
     - id: standard rb bootstrap
-      priority: 0
+
       operation: standard_rb
       parameters:
           depths: [10, 50, 100, 150, 200, 250, 300, 350, 400, 450, 500]

--- a/runcards/benchmarks/routines_benchmarks.yml
+++ b/runcards/benchmarks/routines_benchmarks.yml
@@ -5,9 +5,9 @@ qubits: [0]
 actions:
 
   - id: resonator spectroscopy high power
-    priority: 0
+
     operation: resonator_spectroscopy
-    main: resonator punchout
+
     parameters:
       freq_width: 10_000_000
       freq_step: 500_000
@@ -16,9 +16,9 @@ actions:
       relaxation_time: 5_000
 
   - id: resonator punchout
-    priority: 10
+
     operation: resonator_punchout
-    main: resonator spectroscopy low power
+
     parameters:
       freq_width: 20_000_000
       freq_step: 2_000_000
@@ -28,9 +28,9 @@ actions:
       relaxation_time: 5_000
 
   - id: resonator spectroscopy low power
-    priority: 20
+
     operation: resonator_spectroscopy
-    main: qubit spectroscopy
+
     parameters:
       freq_width: 100_000_000
       freq_step: 1_000_000
@@ -39,9 +39,9 @@ actions:
       relaxation_time: 5_000
 
   - id: qubit spectroscopy
-    priority: 30
+
     operation: qubit_spectroscopy
-    main: rabi amplitude
+
     parameters:
       drive_amplitude: 0.1
       drive_duration: 5000
@@ -50,9 +50,9 @@ actions:
       relaxation_time: 5_000
 
   - id: rabi amplitude
-    priority: 40
+
     operation: rabi_amplitude
-    main: ramsey detuned
+
     parameters:
       min_amp_factor: 0.0
       max_amp_factor: 1.5
@@ -60,9 +60,9 @@ actions:
       pulse_length: 40
 
   - id: ramsey detuned
-    priority: 50
+
     operation: ramsey
-    main: t1
+
     parameters:
       delay_between_pulses_start: 0
       delay_between_pulses_end: 30_000
@@ -70,18 +70,18 @@ actions:
       n_osc: 10
 
   - id: t1
-    priority: 60
+
     operation: t1
-    main: ramsey
+
     parameters:
       delay_before_readout_start: 0
       delay_before_readout_end: 200_000
       delay_before_readout_step: 5_000
 
   - id: ramsey
-    priority: 70
+
     operation: ramsey
-    main: single shot classification
+
     parameters:
       delay_between_pulses_start: 16
       delay_between_pulses_end: 65_000
@@ -89,14 +89,14 @@ actions:
       n_osc: 0
 
   - id: single shot classification
-    priority: 80
-    main: standard rb
+
+
     operation: single_shot_classification
     parameters:
       nshots: 5_000
 
   - id: standard rb
-    priority: 90
+
     operation: standard_rb
     parameters:
       depths: [10, 20, 30, 40]

--- a/runcards/benchmarks/scaling_benchmarks.yml
+++ b/runcards/benchmarks/scaling_benchmarks.yml
@@ -9,9 +9,9 @@ actions:
 
   # - id: resonator spectroscopy 1
   #   # ideal 0.0184
-  #   priority: 00
+
   #   operation: resonator_spectroscopy
-  #   main: resonator spectroscopy 10
+
   #   parameters:
   #     freq_width: 10_000
   #     freq_step: 10_000
@@ -22,9 +22,9 @@ actions:
 
   # - id: resonator spectroscopy 10
   #   # ideal 0.1013
-  #   priority: 00
+
   #   operation: resonator_spectroscopy
-  #   main: resonator spectroscopy 100
+
   #   parameters:
   #     freq_width: 100_000_000
   #     freq_step: 10_000_000
@@ -35,9 +35,9 @@ actions:
 
   # - id: resonator spectroscopy 100
   #   # ideal 0.93
-  #   priority: 00
+
   #   operation: resonator_spectroscopy
-  #   main: resonator spectroscopy 1000
+
   #   parameters:
   #     freq_width: 100_000_000
   #     freq_step: 1_000_000
@@ -48,7 +48,7 @@ actions:
 
   # - id: resonator spectroscopy 1000
   #   # ideal 9.22
-  #   priority: 00
+
   #   operation: resonator_spectroscopy
   #   parameters:
   #     freq_width: 100_000_000
@@ -62,9 +62,9 @@ actions:
 
 #  - id: qubit spectroscopy 1
 #    # ideal 0.0286
-#    priority: 00
+
 #    operation: qubit_spectroscopy
-#    main: qubit spectroscopy 10
+
 #    parameters:
 #      drive_amplitude: 0.001
 #      drive_duration: 5000
@@ -75,9 +75,9 @@ actions:
 
 #  - id: qubit spectroscopy 10
 #    # ideal 0.157
-#    priority: 00
+
 #    operation: qubit_spectroscopy
-#    main: qubit spectroscopy 100
+
 #    parameters:
 #      drive_amplitude: 0.001
 #      drive_duration: 5000
@@ -88,9 +88,9 @@ actions:
 
 #  - id: qubit spectroscopy 100
 #    # ideal 1.44
-#    priority: 00
+
 #    operation: qubit_spectroscopy
-#    main: qubit spectroscopy 1000
+
 #    parameters:
 #      drive_amplitude: 0.001
 #      drive_duration: 5000
@@ -101,7 +101,7 @@ actions:
 
 #  - id: qubit spectroscopy 1000
 #    # ideal 14.35
-#    priority: 00
+
 #    operation: qubit_spectroscopy
 #    parameters:
 #      drive_amplitude: 0.001
@@ -114,9 +114,9 @@ actions:
 # Pulse amplitude
 
 #  - id: rabi amplitude 1
-#    priority: 00
+
 #    operation: rabi_amplitude
-#    main: rabi amplitude 10
+
 #    parameters:
 #      min_amp_factor: 0
 #      max_amp_factor: 1.1
@@ -126,9 +126,9 @@ actions:
 #      nshots: 1000
 
 #  - id: rabi amplitude 10
-#    priority: 00
+
 #    operation: rabi_amplitude
-#    main: rabi amplitude 100
+
 #    parameters:
 #      min_amp_factor: 0.0
 #      max_amp_factor: 1.0000
@@ -138,9 +138,9 @@ actions:
 #      nshots: 1000
 
 #  - id: rabi amplitude 100
-#    priority: 00
+
 #    operation: rabi_amplitude
-#    main: rabi amplitude 1000
+
 #    parameters:
 #      min_amp_factor: 0.0
 #      max_amp_factor: 1.0000
@@ -150,7 +150,7 @@ actions:
 #      nshots: 1000
 
 #  - id: rabi amplitude 1000
-#    priority: 00
+
 #    operation: rabi_amplitude
 #    parameters:
 #      min_amp_factor: 0.0
@@ -163,9 +163,9 @@ actions:
 # Pulse duration
 
 #  - id: rabi lenght 1
-#    priority: 00
+
 #    operation: rabi_length
-#    main: rabi lenght 10
+
 #    parameters:
 #      pulse_duration_start: 20
 #      pulse_duration_end: 120
@@ -175,9 +175,9 @@ actions:
 #      nshots: 1000
 
 #  - id: rabi lenght 10
-#    priority: 00
+
 #    operation: rabi_length
-#    main: rabi lenght 100
+
 #    parameters:
 #      pulse_duration_start: 20
 #      pulse_duration_end: 120
@@ -187,9 +187,9 @@ actions:
 #      nshots: 1000
 
 #  - id: rabi lenght 100
-#    priority: 00
+
 #    operation: rabi_length
-#   #  main: rabi lenght 1000
+
 #    parameters:
 #      pulse_duration_start: 20
 #      pulse_duration_end: 120
@@ -199,7 +199,7 @@ actions:
 #      nshots: 1000
 
 #  - id: rabi lenght 1000
-#    priority: 00
+
 #    operation: rabi_length
 #    parameters:
 #      pulse_duration_start: 20
@@ -212,9 +212,9 @@ actions:
 # Pulse start
 
 #  - id: t1 1
-#    priority: 00
+
 #    operation: t1
-#    main: t1 10
+
 #    parameters:
 #      delay_before_readout_start: 0
 #      delay_before_readout_end: 3_00
@@ -223,9 +223,9 @@ actions:
 #      nshots: 1000
 
 #  - id: t1 10
-#    priority: 00
+
 #    operation: t1
-#    main: t1 100
+
 #    parameters:
 #      delay_before_readout_start: 0
 #      delay_before_readout_end: 30_00
@@ -234,9 +234,9 @@ actions:
 #      nshots: 1000
 
 #  - id: t1 100
-#    priority: 00
+
 #    operation: t1
-#    main: t1 1000
+
 #    parameters:
 #      delay_before_readout_start: 0
 #      delay_before_readout_end: 300_00
@@ -245,7 +245,7 @@ actions:
 #      nshots: 1000
 
 #  - id: t1 1000
-#    priority: 00
+
 #    operation: t1
 #    parameters:
 #      delay_before_readout_start: 0
@@ -257,9 +257,9 @@ actions:
 # Circuits
 
  - id: standard rb bootstrap 1
-   priority: 0
+
    operation: standard_rb
-   main: standard rb bootstrap 10
+
    qubits: [0]
    parameters:
      depths: [10]
@@ -269,9 +269,9 @@ actions:
      seed: 420
 
  - id: standard rb bootstrap 10
-   priority: 0
+
    operation: standard_rb
-   main: standard rb bootstrap 100
+
    qubits: [0]
    parameters:
      depths: [10]
@@ -281,7 +281,7 @@ actions:
      seed: 420
 
  - id: standard rb bootstrap 100
-   priority: 0
+
    operation: standard_rb
    qubits: [0]
    parameters:

--- a/runcards/calibration_tutorial/classification.yaml
+++ b/runcards/calibration_tutorial/classification.yaml
@@ -4,7 +4,7 @@ qubits: [0]
 
 actions:
   - id: single shot classification 1
-    priority: 0
+
     operation: single_shot_classification
     parameters:
         nshots: 5000

--- a/runcards/calibration_tutorial/qubit_flux_dependence.yaml
+++ b/runcards/calibration_tutorial/qubit_flux_dependence.yaml
@@ -4,7 +4,7 @@ qubits: [0]
 
 actions:
   - id: qubit flux dependence
-    priority: 0
+
     operation: qubit_flux
     parameters:
         freq_width: 100_000_000

--- a/runcards/calibration_tutorial/qubit_spectroscopy.yaml
+++ b/runcards/calibration_tutorial/qubit_spectroscopy.yaml
@@ -4,7 +4,7 @@ qubits: [0]
 
 actions:
   - id: qubit spectroscopy 01
-    priority: 0
+
     operation: qubit_spectroscopy
     parameters:
         drive_amplitude: 0.5

--- a/runcards/calibration_tutorial/rabi.yaml
+++ b/runcards/calibration_tutorial/rabi.yaml
@@ -5,7 +5,7 @@ qubits: [0]
 actions:
 
   - id: rabi
-    priority: 0
+
     operation: rabi_amplitude_signal
     parameters:
         min_amp_factor: 0

--- a/runcards/calibration_tutorial/ramsey.yaml
+++ b/runcards/calibration_tutorial/ramsey.yaml
@@ -4,7 +4,7 @@ qubits: [0]
 
 actions:
   - id: ramsey detuned
-    priority: 0
+
     operation: ramsey
     parameters:
         delay_between_pulses_end: 40000

--- a/runcards/calibration_tutorial/rb.yaml
+++ b/runcards/calibration_tutorial/rb.yaml
@@ -4,7 +4,7 @@ qubits: [0]
 
 actions:
   - id: standard rb bootstrap
-    priority: 0
+
     operation: standard_rb
     parameters:
         depths: [10, 50, 100, 150, 200, 250, 300, 350, 400, 450, 500]

--- a/runcards/calibration_tutorial/readout_characterization.yaml
+++ b/runcards/calibration_tutorial/readout_characterization.yaml
@@ -4,7 +4,7 @@ qubits: [0]
 
 actions:
   - id: readout characterization
-    priority: 0
+
     operation: readout_characterization
     parameters:
         nshots: 5000

--- a/runcards/calibration_tutorial/resonator_punchout.yaml
+++ b/runcards/calibration_tutorial/resonator_punchout.yaml
@@ -4,7 +4,7 @@ qubits: [0]
 
 actions:
   - id: resonator punchout
-    priority: 0
+
     operation: resonator_punchout
     parameters:
         freq_width: 40_000_000

--- a/runcards/calibration_tutorial/resonator_spectroscopy_high.yaml
+++ b/runcards/calibration_tutorial/resonator_spectroscopy_high.yaml
@@ -5,7 +5,7 @@ qubits: [0]
 actions:
 
   - id: resonator_spectroscopy high power
-    priority: 0
+
     operation: resonator_spectroscopy
     parameters:
         freq_width: 60_000_000

--- a/runcards/calibration_tutorial/resonator_spectroscopy_low.yaml
+++ b/runcards/calibration_tutorial/resonator_spectroscopy_low.yaml
@@ -4,7 +4,7 @@ qubits: [0]
 
 actions:
   - id: resonator_spectroscopy low power
-    priority: 0
+
     operation: resonator_spectroscopy
     parameters:
         freq_width: 60_000_000

--- a/runcards/calibration_tutorial/t1.yaml
+++ b/runcards/calibration_tutorial/t1.yaml
@@ -5,7 +5,7 @@ qubits: [0]
 actions:
 
   - id: t1
-    priority: 0
+
     operation: t1
     parameters:
         delay_before_readout_end: 200000

--- a/runcards/monitor.yml
+++ b/runcards/monitor.yml
@@ -23,7 +23,7 @@ actions:
       nshots: 5000
 
   # - id: standard rb bootstrap
-  #   priority: 40
+
   #   operation: standard_rb
   #   parameters:
   #     depths: [10, 100, 150, 200, 250, 300]


### PR DESCRIPTION
Removing `priority`, `next` and `main` from some runcards and documentation.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
