### PR TITLE
Save random_indexes for the RB

### DIFF
--- a/src/qibocal/protocols/characterization/randomized_benchmarking/circuit_tools.py
+++ b/src/qibocal/protocols/characterization/randomized_benchmarking/circuit_tools.py
@@ -8,7 +8,7 @@ from qibo.gates.abstract import Gate
 from qibo.models import Circuit
 
 
-def layer_circuit(layer_gen: Callable, depth: int, qubit, seed) -> tuple[Circuit, dict]:
+def layer_circuit(rb_gen: Callable, depth: int, qubit) -> tuple[Circuit, dict]:
     """Creates a circuit of `depth` layers from a generator `layer_gen` yielding `Circuit` or `Gate`.
 
     Args:
@@ -26,7 +26,8 @@ def layer_circuit(layer_gen: Callable, depth: int, qubit, seed) -> tuple[Circuit
 
     for _ in range(depth):
         # Generate a layer.
-        new_layer, random_index = layer_gen(1, seed)
+        # new_layer, random_index = layer_gen(1, seed)
+        new_layer, random_index = rb_gen.layer_gen()
         # Ensure new_layer is a circuit
         if isinstance(new_layer, Gate):
             new_circuit = Circuit(1, wire_names=qubits_str)

--- a/src/qibocal/protocols/characterization/randomized_benchmarking/circuit_tools.py
+++ b/src/qibocal/protocols/characterization/randomized_benchmarking/circuit_tools.py
@@ -9,7 +9,8 @@ from qibo.models import Circuit
 
 
 def layer_circuit(rb_gen: Callable, depth: int, qubit) -> tuple[Circuit, dict]:
-    """Creates a circuit of `depth` layers from a generator `layer_gen` yielding `Circuit` or `Gate`.
+    """Creates a circuit of `depth` layers from a generator `layer_gen` yielding `Circuit` or `Gate`
+    and a dictionary with random indexes used to select the clifford gates.
 
     Args:
         layer_gen (Callable): Should return gates or a full circuit specifying a layer.

--- a/src/qibocal/protocols/characterization/randomized_benchmarking/circuit_tools.py
+++ b/src/qibocal/protocols/characterization/randomized_benchmarking/circuit_tools.py
@@ -8,7 +8,7 @@ from qibo.gates.abstract import Gate
 from qibo.models import Circuit
 
 
-def layer_circuit(layer_gen: Callable, depth: int, qubit, seed) -> Circuit:
+def layer_circuit(layer_gen: Callable, depth: int, qubit, seed) -> tuple[Circuit, dict]:
     """Creates a circuit of `depth` layers from a generator `layer_gen` yielding `Circuit` or `Gate`.
 
     Args:
@@ -20,21 +20,24 @@ def layer_circuit(layer_gen: Callable, depth: int, qubit, seed) -> Circuit:
     """
 
     full_circuit = None
+    random_indexes = {qubit: []}
     # Build each layer, there will be depth many in the final circuit.
     qubits_str = [str(qubit)]
+
     for _ in range(depth):
         # Generate a layer.
-        new_layer, random_indexes = layer_gen(
-            1, seed
-        )  # TODO: find better implementation
+        new_layer, random_index = layer_gen(1, seed)
         # Ensure new_layer is a circuit
         if isinstance(new_layer, Gate):
             new_circuit = Circuit(1, wire_names=qubits_str)
             new_circuit.add(new_layer)
+
+        # We are only using this for the RB we have right now
         elif all(isinstance(gate, Gate) for gate in new_layer):
             new_circuit = Circuit(1, wire_names=qubits_str)
-
             new_circuit.add(new_layer)
+            random_indexes[qubit].extend([r for r in random_index])
+
         elif isinstance(new_layer, Circuit):
             new_circuit = new_layer
         else:

--- a/src/qibocal/protocols/characterization/randomized_benchmarking/circuit_tools.py
+++ b/src/qibocal/protocols/characterization/randomized_benchmarking/circuit_tools.py
@@ -24,7 +24,9 @@ def layer_circuit(layer_gen: Callable, depth: int, qubit, seed) -> Circuit:
     qubits_str = [str(qubit)]
     for _ in range(depth):
         # Generate a layer.
-        new_layer = layer_gen(1, seed)  # TODO: find better implementation
+        new_layer, random_indexes = layer_gen(
+            1, seed
+        )  # TODO: find better implementation
         # Ensure new_layer is a circuit
         if isinstance(new_layer, Gate):
             new_circuit = Circuit(1, wire_names=qubits_str)
@@ -43,7 +45,7 @@ def layer_circuit(layer_gen: Callable, depth: int, qubit, seed) -> Circuit:
         if full_circuit is None:  # instantiate in first loop
             full_circuit = Circuit(new_circuit.nqubits, wire_names=qubits_str)
         full_circuit = full_circuit + new_circuit
-    return full_circuit
+    return full_circuit, random_indexes
 
 
 def add_inverse_layer(circuit: Circuit, single_qubit=True):

--- a/src/qibocal/protocols/characterization/randomized_benchmarking/circuit_tools.py
+++ b/src/qibocal/protocols/characterization/randomized_benchmarking/circuit_tools.py
@@ -26,7 +26,6 @@ def layer_circuit(rb_gen: Callable, depth: int, qubit) -> tuple[Circuit, dict]:
 
     for _ in range(depth):
         # Generate a layer.
-        # new_layer, random_index = layer_gen(1, seed)
         new_layer, random_index = rb_gen.layer_gen()
         # Ensure new_layer is a circuit
         if isinstance(new_layer, Gate):

--- a/src/qibocal/protocols/characterization/randomized_benchmarking/circuit_tools.py
+++ b/src/qibocal/protocols/characterization/randomized_benchmarking/circuit_tools.py
@@ -20,7 +20,7 @@ def layer_circuit(rb_gen: Callable, depth: int, qubit) -> tuple[Circuit, dict]:
     """
 
     full_circuit = None
-    random_indexes = {qubit: []}
+    random_indexes = []
     # Build each layer, there will be depth many in the final circuit.
     qubits_str = [str(qubit)]
 
@@ -31,12 +31,13 @@ def layer_circuit(rb_gen: Callable, depth: int, qubit) -> tuple[Circuit, dict]:
         if isinstance(new_layer, Gate):
             new_circuit = Circuit(1, wire_names=qubits_str)
             new_circuit.add(new_layer)
+            random_indexes.append(random_index)
 
         # We are only using this for the RB we have right now
         elif all(isinstance(gate, Gate) for gate in new_layer):
             new_circuit = Circuit(1, wire_names=qubits_str)
             new_circuit.add(new_layer)
-            random_indexes[qubit].extend([r for r in random_index])
+            random_indexes.append(random_index)
 
         elif isinstance(new_layer, Circuit):
             new_circuit = new_layer

--- a/src/qibocal/protocols/characterization/randomized_benchmarking/standard_rb.py
+++ b/src/qibocal/protocols/characterization/randomized_benchmarking/standard_rb.py
@@ -1,5 +1,7 @@
+import json
 from collections import defaultdict
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Iterable, Optional, TypedDict, Union
 
 import numpy as np
@@ -10,6 +12,7 @@ from qibolab.platform import Platform
 from qibolab.qubits import QubitId
 
 from qibocal.auto.operation import Data, Parameters, Results, Routine
+from qibocal.auto.serialize import serialize
 from qibocal.config import raise_error
 from qibocal.protocols.characterization.randomized_benchmarking import noisemodels
 
@@ -96,6 +99,17 @@ class RBData(Data):
             data_list = data_list.reshape((-1, self.nshots))
             probs.append(np.count_nonzero(1 - data_list, axis=1) / data_list.shape[1])
         return probs
+
+    def _to_json(self, path: Path, filename: str):
+        """Helper function to dump to json."""
+        if self.circuits:
+            (path / f"{filename}.json").write_text(
+                json.dumps(serialize(self.circuts), indent=4)
+            )
+        if self.params:
+            (path / f"{filename}.json").write_text(
+                json.dumps(serialize(self.params), indent=4)
+            )
 
 
 @dataclass

--- a/src/qibocal/protocols/characterization/randomized_benchmarking/standard_rb.py
+++ b/src/qibocal/protocols/characterization/randomized_benchmarking/standard_rb.py
@@ -120,21 +120,20 @@ class StandardRBResult(Results):
 
 class RB_Generator:
 
-    def __init__(self, seed, nqubits):
+    def __init__(self, seed):
         self.seed = seed
         self.local_state = (
             np.random.default_rng(seed)
             if seed is None or isinstance(seed, int)
             else seed
         )
-        self.nqubits = nqubits
 
     def random_index(self, gate_list):
         return self.local_state.integers(0, len(gate_list), 1)
 
     def layer_gen(self):
         """Returns a circuit with a random single-qubit clifford unitary."""
-        return random_clifford(self.nqubits, self.random_index)
+        return random_clifford(self.random_index)
 
 
 def random_circuits(
@@ -218,7 +217,7 @@ def _acquisition(
     indexes = {}
     samples = []
     qubits_ids = targets
-    rb_gen = RB_Generator(params.seed, nqubits)
+    rb_gen = RB_Generator(params.seed)
     for depth in params.depths:
         # TODO: This does not generate multi qubit circuits
         circuits_depth, random_indexes = random_circuits(

--- a/src/qibocal/protocols/characterization/randomized_benchmarking/standard_rb.py
+++ b/src/qibocal/protocols/characterization/randomized_benchmarking/standard_rb.py
@@ -1,7 +1,5 @@
-import json
 from collections import defaultdict
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Iterable, Optional, TypedDict, Union
 
 import numpy as np
@@ -12,7 +10,6 @@ from qibolab.platform import Platform
 from qibolab.qubits import QubitId
 
 from qibocal.auto.operation import Data, Parameters, Results, Routine
-from qibocal.auto.serialize import serialize
 from qibocal.config import raise_error
 from qibocal.protocols.characterization.randomized_benchmarking import noisemodels
 
@@ -67,7 +64,6 @@ class StandardRBParameters(Parameters):
 RBType = np.dtype(
     [
         ("samples", np.int32),
-        ("random_indexes", np.int32),
     ]
 )
 """Custom dtype for RB."""
@@ -99,17 +95,6 @@ class RBData(Data):
             data_list = data_list.reshape((-1, self.nshots))
             probs.append(np.count_nonzero(1 - data_list, axis=1) / data_list.shape[1])
         return probs
-
-    def _to_json(self, path: Path, filename: str):
-        """Helper function to dump to json."""
-        if self.circuits:
-            (path / f"{filename}.json").write_text(
-                json.dumps(serialize(self.circuts), indent=4)
-            )
-        if self.params:
-            (path / f"{filename}.json").write_text(
-                json.dumps(serialize(self.params), indent=4)
-            )
 
 
 @dataclass

--- a/src/qibocal/protocols/characterization/randomized_benchmarking/standard_rb.py
+++ b/src/qibocal/protocols/characterization/randomized_benchmarking/standard_rb.py
@@ -129,12 +129,12 @@ class RB_Generator:
         )
         self.nqubits = nqubits
 
-    def random_indexes(self, gate_list, qubits):
-        return self.local_state.integers(0, len(gate_list), len(qubits))
+    def random_index(self, gate_list):
+        return self.local_state.integers(0, len(gate_list), 1)
 
     def layer_gen(self):
         """Returns a circuit with a random single-qubit clifford unitary."""
-        return random_clifford(self.nqubits, self.random_indexes)
+        return random_clifford(self.nqubits, self.random_index)
 
 
 def random_circuits(
@@ -161,14 +161,13 @@ def random_circuits(
     indexes = defaultdict(list)
     for _ in range(niter):
         for target in targets:
-            circuit, random_indexes = layer_circuit(rb_gen, depth, target)
+            circuit, random_index = layer_circuit(rb_gen, depth, target)
             add_inverse_layer(circuit)
             add_measurement_layer(circuit)
             if noise_model is not None:
                 circuit = noise_model.apply(circuit)
             circuits.append(circuit)
-            for qubit in random_indexes.keys():
-                indexes[qubit].append(random_indexes[qubit])
+            indexes[target].append(random_index)
 
     return circuits, indexes
 

--- a/src/qibocal/protocols/characterization/randomized_benchmarking/standard_rb.py
+++ b/src/qibocal/protocols/characterization/randomized_benchmarking/standard_rb.py
@@ -84,7 +84,7 @@ class RBData(Data):
     """Number of iterations for each depth."""
     data: dict[QubitId, npt.NDArray[RBType]] = field(default_factory=dict)
     """Raw data acquired."""
-    circuits: dict[QubitId, int] = field(default_factory=dict)
+    circuits: dict[QubitId, list[list[int]]] = field(default_factory=dict)
     """Clifford gate indexes executed."""
 
     def extract_probabilities(self, qubit):
@@ -118,6 +118,9 @@ class StandardRBResult(Results):
 
 
 class RB_Generator:
+    """
+    This class generates random single qubit cliffords for randomized benchmarking.
+    """
 
     def __init__(self, seed):
         self.seed = seed
@@ -128,10 +131,22 @@ class RB_Generator:
         )
 
     def random_index(self, gate_list):
+        """
+        Generates a random index within the range of the given gate list.
+
+        Parameters:
+        - gate_list (list): Dict of gates.
+
+        Returns:
+        - int: Random index.
+        """
         return self.local_state.integers(0, len(gate_list), 1)
 
     def layer_gen(self):
-        """Returns a circuit with a random single-qubit clifford unitary."""
+        """
+        Returns:
+        - Gate: Random single-qubit clifford .
+        """
         return random_clifford(self.random_index)
 
 

--- a/src/qibocal/protocols/characterization/randomized_benchmarking/utils.py
+++ b/src/qibocal/protocols/characterization/randomized_benchmarking/utils.py
@@ -56,9 +56,9 @@ def random_clifford(random_index_gen):
     """
 
     random_index = int(random_index_gen(SINGLE_QUBIT_CLIFFORDS))
-    clifford_gates = SINGLE_QUBIT_CLIFFORDS[random_index](0)
+    clifford_gate = SINGLE_QUBIT_CLIFFORDS[random_index](0)
 
-    return clifford_gates, random_index
+    return clifford_gate, random_index
 
 
 def number_to_str(

--- a/src/qibocal/protocols/characterization/randomized_benchmarking/utils.py
+++ b/src/qibocal/protocols/characterization/randomized_benchmarking/utils.py
@@ -83,7 +83,7 @@ def random_clifford(qubits, seed=None):
         SINGLE_QUBIT_CLIFFORDS[p](q) for p, q in zip(random_indexes, qubits)
     ]
 
-    return clifford_gates
+    return clifford_gates, random_indexes
 
 
 def number_to_str(

--- a/src/qibocal/protocols/characterization/randomized_benchmarking/utils.py
+++ b/src/qibocal/protocols/characterization/randomized_benchmarking/utils.py
@@ -42,7 +42,7 @@ SINGLE_QUBIT_CLIFFORDS = {
 }
 
 
-def random_clifford(qubits, random_indexes_gen):
+def random_clifford(qubits, random_index_gen):
     """Generates random Clifford operator(s).
 
     Args:
@@ -74,14 +74,10 @@ def random_clifford(qubits, random_indexes_gen):
     if isinstance(qubits, int):
         qubits = list(range(qubits))
 
-    random_indexes = random_indexes_gen(SINGLE_QUBIT_CLIFFORDS, qubits)
+    random_index = int(random_index_gen(SINGLE_QUBIT_CLIFFORDS))
+    clifford_gates = SINGLE_QUBIT_CLIFFORDS[random_index](0)
 
-    clifford_gates = [SINGLE_QUBIT_CLIFFORDS[p](0) for p in random_indexes]
-
-    # To allow json serialization
-    random_indexes = [float(r) for r in random_indexes]
-
-    return clifford_gates, random_indexes
+    return clifford_gates, random_index
 
 
 def number_to_str(

--- a/src/qibocal/protocols/characterization/randomized_benchmarking/utils.py
+++ b/src/qibocal/protocols/characterization/randomized_benchmarking/utils.py
@@ -42,7 +42,7 @@ SINGLE_QUBIT_CLIFFORDS = {
 }
 
 
-def random_clifford(qubits, seed=None):
+def random_clifford(qubits, random_indexes_gen):
     """Generates random Clifford operator(s).
 
     Args:
@@ -71,14 +71,11 @@ def random_clifford(qubits, seed=None):
     if isinstance(qubits, (list, np.ndarray)) and any(q < 0 for q in qubits):
         raise_error(ValueError, "qubit indexes must be non-negative integers.")
 
-    local_state = (
-        np.random.default_rng(seed) if seed is None or isinstance(seed, int) else seed
-    )
-
     if isinstance(qubits, int):
         qubits = list(range(qubits))
 
-    random_indexes = local_state.integers(0, len(SINGLE_QUBIT_CLIFFORDS), len(qubits))
+    random_indexes = random_indexes_gen(SINGLE_QUBIT_CLIFFORDS, qubits)
+
     clifford_gates = [
         SINGLE_QUBIT_CLIFFORDS[p](q) for p, q in zip(random_indexes, qubits)
     ]

--- a/src/qibocal/protocols/characterization/randomized_benchmarking/utils.py
+++ b/src/qibocal/protocols/characterization/randomized_benchmarking/utils.py
@@ -83,6 +83,9 @@ def random_clifford(qubits, seed=None):
         SINGLE_QUBIT_CLIFFORDS[p](q) for p, q in zip(random_indexes, qubits)
     ]
 
+    # To allow json serialization
+    random_indexes = [float(r) for r in random_indexes]
+
     return clifford_gates, random_indexes
 
 

--- a/src/qibocal/protocols/characterization/randomized_benchmarking/utils.py
+++ b/src/qibocal/protocols/characterization/randomized_benchmarking/utils.py
@@ -75,9 +75,9 @@ def random_clifford(qubits, random_indexes_gen):
         qubits = list(range(qubits))
 
     random_indexes = random_indexes_gen(SINGLE_QUBIT_CLIFFORDS, qubits)
-
+    
     clifford_gates = [
-        SINGLE_QUBIT_CLIFFORDS[p](q) for p, q in zip(random_indexes, qubits)
+        SINGLE_QUBIT_CLIFFORDS[p](0) for p in random_indexes
     ]
 
     # To allow json serialization

--- a/src/qibocal/protocols/characterization/randomized_benchmarking/utils.py
+++ b/src/qibocal/protocols/characterization/randomized_benchmarking/utils.py
@@ -4,7 +4,6 @@ from typing import Optional, Union
 import numpy as np
 from qibo import gates
 
-from qibocal.config import raise_error
 from qibocal.protocols.characterization.utils import significant_digit
 
 SINGLE_QUBIT_CLIFFORDS = {
@@ -42,8 +41,8 @@ SINGLE_QUBIT_CLIFFORDS = {
 }
 
 
-def random_clifford(qubits, random_index_gen):
-    """Generates random Clifford operator(s).
+def random_clifford(random_index_gen):
+    """Generates random Clifford operator.
 
     Args:
         qubits (int or list or ndarray): if ``int``, the number of qubits for the Clifford.
@@ -55,24 +54,6 @@ def random_clifford(qubits, random_index_gen):
     Returns:
         (list of :class:`qibo.gates.Gate`): Random Clifford operator(s).
     """
-
-    if (
-        not isinstance(qubits, int)
-        and not isinstance(qubits, list)
-        and not isinstance(qubits, np.ndarray)
-    ):
-        raise_error(
-            TypeError,
-            f"qubits must be either type int, list or ndarray, but it is type {type(qubits)}.",
-        )
-    if isinstance(qubits, int) and qubits <= 0:
-        raise_error(ValueError, "qubits must be a positive integer.")
-
-    if isinstance(qubits, (list, np.ndarray)) and any(q < 0 for q in qubits):
-        raise_error(ValueError, "qubit indexes must be non-negative integers.")
-
-    if isinstance(qubits, int):
-        qubits = list(range(qubits))
 
     random_index = int(random_index_gen(SINGLE_QUBIT_CLIFFORDS))
     clifford_gates = SINGLE_QUBIT_CLIFFORDS[random_index](0)

--- a/src/qibocal/protocols/characterization/randomized_benchmarking/utils.py
+++ b/src/qibocal/protocols/characterization/randomized_benchmarking/utils.py
@@ -75,10 +75,8 @@ def random_clifford(qubits, random_indexes_gen):
         qubits = list(range(qubits))
 
     random_indexes = random_indexes_gen(SINGLE_QUBIT_CLIFFORDS, qubits)
-    
-    clifford_gates = [
-        SINGLE_QUBIT_CLIFFORDS[p](0) for p in random_indexes
-    ]
+
+    clifford_gates = [SINGLE_QUBIT_CLIFFORDS[p](0) for p in random_indexes]
 
     # To allow json serialization
     random_indexes = [float(r) for r in random_indexes]


### PR DESCRIPTION
>[!CAUTION]
> It requieres https://github.com/qiboteam/qibolab/pull/864 to fix RB completely.

This will save the random indexes in the data.json from the reports. And fix the RB random number generation.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
