### PR TITLE
Use native_gate_virtualz to handle iSWAP or CZ

### DIFF
--- a/src/qibocal/protocols/characterization/__init__.py
+++ b/src/qibocal/protocols/characterization/__init__.py
@@ -55,7 +55,12 @@ from .signal_experiments.calibrate_state_discrimination import (
     calibrate_state_discrimination,
 )
 from .signal_experiments.time_of_flight_readout import time_of_flight_readout
-from .two_qubit_interaction import chevron, chsh_circuits, chsh_pulses, cz_virtualz
+from .two_qubit_interaction import (
+    chevron,
+    chsh_circuits,
+    chsh_pulses,
+    native_gate_virtualz,
+)
 
 
 class Operation(Enum):
@@ -91,7 +96,7 @@ class Operation(Enum):
     flipping = flipping
     dispersive_shift = dispersive_shift
     chevron = chevron
-    cz_virtualz = cz_virtualz
+    native_gate_virtualz = native_gate_virtualz
     standard_rb = standard_rb
     readout_characterization = readout_characterization
     resonator_frequency = resonator_frequency

--- a/src/qibocal/protocols/characterization/two_qubit_interaction/__init__.py
+++ b/src/qibocal/protocols/characterization/two_qubit_interaction/__init__.py
@@ -1,3 +1,3 @@
 from .chevron import chevron
 from .chsh import chsh_circuits, chsh_pulses
-from .cz_virtualz import cz_virtualz
+from .native_gate_virtualz import native_gate_virtualz

--- a/src/qibocal/protocols/characterization/two_qubit_interaction/native_gate_virtualz.py
+++ b/src/qibocal/protocols/characterization/two_qubit_interaction/native_gate_virtualz.py
@@ -32,7 +32,7 @@ class VirtualZParameters(Parameters):
     theta_step: float
     """Step size for the theta sweep in radians."""
     flux_pulse_amplitude: Optional[float] = None
-    """Amplitude of flux pulse implementing CZ."""
+    """Amplitude of flux pulse implementing native gate."""
     native_gate: Optional[str] = "CZ"
     """Native gate to implement, CZ or iSWAP."""
     dt: Optional[float] = 20
@@ -43,7 +43,7 @@ class VirtualZParameters(Parameters):
 
 @dataclass
 class VirtualZResults(Results):
-    """CzVirtualZ outputs when fitting will be done."""
+    """VirtualZ outputs when fitting will be done."""
 
     fitted_parameters: dict[tuple[str, QubitId],]
     """Fitted parameters"""
@@ -154,7 +154,6 @@ def create_sequence(
                 pulse.duration = theta_pulse.finish
                 sequence.add(pulse)
 
-    # TODO: Do we need an independent amplitude similar for coupler amplitude ?
     return (
         sequence,
         virtual_z_phase,

--- a/tests/runcards/protocols.yml
+++ b/tests/runcards/protocols.yml
@@ -655,16 +655,32 @@ actions:
       nshots: 1000
       parking: True
 
-  - id: tune landscape
-    operation: cz_virtualz
+
+  - id: CZ tune landscape
+    operation: native_gate_virtualz
     targets: [[0, 2],[1,2],[3,2]]
     parameters:
       theta_start: 0
       theta_end: 180
       theta_step: 10
       flux_pulse_amplitude: 0.5
+      native_gate: "CZ"
       dt: 0
       parking: True
+
+  - id: iSWAP tune landscape
+    priority: 0
+    operation: native_gate_virtualz
+    targets: [[0, 2],[1,2],[3,2]]
+    parameters:
+      theta_start: 0
+      theta_end: 180
+      theta_step: 10
+      flux_pulse_amplitude: 0.5
+      native_gate: "iSWAP"
+      dt: 0
+      parking: False
+
 
   - id : resonator_frequency
     operation: resonator_frequency


### PR DESCRIPTION
It makes the virtualz calibration routine able to take both iSWAP and CZ. It comes from #568. I just separed them to ease the review. It comes from an old routine so I will update it if you think this is interesting.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
