### PR TITLE
Show end time correctly in HTML report

### DIFF
--- a/src/qibocal/cli/autocalibration.py
+++ b/src/qibocal/cli/autocalibration.py
@@ -54,13 +54,13 @@ def autocalibrate(runcard, folder, force, update):
 
     # run protocols
     for _ in executor.run(mode=ExecutionMode.autocalibration):
-        report = ReportBuilder(path, runcard.targets, executor, meta, executor.history)
-        report.run(path)
-        # meta needs to be updated after each report to show correct end-time
+        # meta needs to be updated before each report to show correct end-time
         e = datetime.datetime.now(datetime.timezone.utc)
         meta["end-time"] = e.strftime("%H:%M:%S")
         # dump updated meta
         meta = add_timings_to_meta(meta, executor.history)
+        report = ReportBuilder(path, runcard.targets, executor, meta, executor.history)
+        report.run(path)
         (path / META).write_text(json.dumps(meta, indent=4))
 
     # stop and disconnect platform


### PR DESCRIPTION
Currently in the report start time and end time were the same due to a small bug.
This PR fixes the issue.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
- [x] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [x] Qibo: `master`
    - [x] Qibolab: `main`
    - [x] Qibolab_platforms_qrc: `main`
