### PR TITLE
Hotfix for `extract_feature` function

### DIFF
--- a/src/qibocal/protocols/characterization/flux_dependence/qubit_crosstalk.py
+++ b/src/qibocal/protocols/characterization/flux_dependence/qubit_crosstalk.py
@@ -251,18 +251,12 @@ def _fit(data: QubitCrosstalkData) -> QubitCrosstalkResults:
 
     for target_flux_qubit, qubit_data in data.data.items():
 
-        if data.resonator_type == "3D":
-            frequencies, biases = utils.extract_min_feature(
-                qubit_data.freq,
-                qubit_data.bias,
-                qubit_data.signal,
-            )
-        else:
-            frequencies, biases = utils.extract_max_feature(
-                qubit_data.freq,
-                qubit_data.bias,
-                qubit_data.signal,
-            )
+        frequencies, biases = utils.extract_feature(
+            qubit_data.freq,
+            qubit_data.bias,
+            qubit_data.signal,
+            "max",
+        )
         target_qubit, flux_qubit = target_flux_qubit
 
         if target_qubit != flux_qubit:

--- a/src/qibocal/protocols/characterization/flux_dependence/resonator_crosstalk.py
+++ b/src/qibocal/protocols/characterization/flux_dependence/resonator_crosstalk.py
@@ -263,18 +263,9 @@ def _fit(data: ResCrosstalkData) -> ResCrosstalkResults:
     for target_flux_qubit, qubit_data in data.data.items():
         target_qubit, flux_qubit = target_flux_qubit
 
-        if data.resonator_type == "3D":
-            frequencies, biases = utils.extract_max_feature(
-                qubit_data.freq,
-                qubit_data.bias,
-                qubit_data.signal,
-            )
-        else:
-            frequencies, biases = utils.extract_min_feature(
-                qubit_data.freq,
-                qubit_data.bias,
-                qubit_data.signal,
-            )
+        frequencies, biases = utils.extract_feature(
+            qubit_data.freq, qubit_data.bias, qubit_data.signal, "min"
+        )
 
         if target_qubit != flux_qubit:
             # fit function needs to be defined here to pass correct parameters


### PR DESCRIPTION
Closes #798.

I removed the `resonator_type` check since it is not needed given that we will use just 2D resonators with flux tunable qubits. If someone can confirm this I can also drop the `resonator_type` from the data structure.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
