### PR TITLE
Fix bug in chevron fitting

### DIFF
--- a/src/qibocal/protocols/characterization/two_qubit_interaction/utils.py
+++ b/src/qibocal/protocols/characterization/two_qubit_interaction/utils.py
@@ -65,7 +65,7 @@ def fit_flux_amplitude(matrix, amps, times):
         fs.append(2 * np.pi * f)
 
     low_freq_interval = np.where(fs == np.min(fs))
-    amplitude = median_high(amps[low_freq_interval])
+    amplitude = median_high(amps[::-1][low_freq_interval])
     index = int(np.where(np.unique(amps) == amplitude)[0])
     delta = np.min(fs)
     return amplitude, index, delta


### PR DESCRIPTION
This PR fixes a bug that I saw in the fit for the chevron:
http://login.qrccluster.com:9000/PnNMnXAFT42fu83vinMgkg==

I found out that the amplitude array needed to be reversed to obtain the correct value:
http://login.qrccluster.com:9000/wlPO4jUsT1qQmgzkCDtyqg==/

Moreover, since for the Chevron with probabilities there is no point in checking what is happening to the high frequency qubit since we do not have qutrit classification I decided to remove the fit for the high frequency qubit.



Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
