### PR TITLE
Delay on readout characterization

### DIFF
--- a/src/qibocal/protocols/characterization/readout_characterization.py
+++ b/src/qibocal/protocols/characterization/readout_characterization.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field
 import numpy as np
 import numpy.typing as npt
 import plotly.graph_objects as go
+from plotly.subplots import make_subplots
 from qibolab import AcquisitionType, ExecutionParameters
 from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
@@ -241,26 +242,59 @@ def _plot(
                     marker=dict(size=3),
                 )
             )
+    fig.update_layout(
+        title={
+            "text": "IQ Plane",
+            "y": 0.9,
+            "x": 0.5,
+            "xanchor": "center",
+            "yanchor": "top",
+        },
+        xaxis_title="I",
+        yaxis_title="Q",
+    )
+
     figures.append(fig)
     if fit is not None:
-        fig2 = go.Figure()
-        fig2.add_trace(
+
+        fig = make_subplots(
+            rows=1,
+            cols=2,
+            subplot_titles=(
+                "1st measurement statistics",
+                "2nd measurement statistics",
+            ),
+        )
+
+        fig.add_trace(
             go.Heatmap(
                 z=fit.Lambda_M[target],
-            )
+                x=["0", "1"],
+                y=["0", "1"],
+                coloraxis="coloraxis",
+            ),
+            row=1,
+            col=1,
         )
-        fig2.update_layout(title="1st measurement statistics")
-        figures.append(fig2)
 
-        fig3 = go.Figure()
-        fig3.add_trace(
+        fig.add_trace(
             go.Heatmap(
                 z=fit.Lambda_M2[target],
-            )
+                x=["0", "1"],
+                y=["0", "1"],
+                coloraxis="coloraxis",
+            ),
+            row=1,
+            col=2,
         )
-        fig3.update_layout(title="2nd measurement statistics")
 
-        figures.append(fig3)
+        fig.update_xaxes(title_text="Measured state", row=1, col=1)
+        fig.update_xaxes(title_text="Measured state", row=1, col=2)
+        fig.update_yaxes(title_text="Prepared state", row=1, col=1)
+        fig.update_yaxes(title_text="Prepared state", row=1, col=2)
+
+        figures.append(fig)
+
         fitting_report = table_html(
             table_dict(
                 target,

--- a/src/qibocal/protocols/characterization/readout_characterization.py
+++ b/src/qibocal/protocols/characterization/readout_characterization.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass, field
-from typing import Optional
 
 import numpy as np
 import numpy.typing as npt
@@ -24,7 +23,7 @@ from qibocal.protocols.characterization.utils import (
 class ReadoutCharacterizationParameters(Parameters):
     """ReadoutCharacterization runcard inputs."""
 
-    delay: Optional[float] = None
+    delay: float = 0
     """Delay between readouts, could account for resonator deplation or not [ns]."""
 
 
@@ -60,7 +59,7 @@ class ReadoutCharacterizationData(Data):
     qubit_frequencies: dict[QubitId, float] = field(default_factory=dict)
     """Qubit frequencies."""
 
-    delay: Optional[float] = None
+    delay: float
     """Delay between readouts [ns]."""
     data: dict[tuple, npt.NDArray[ReadoutCharacterizationType]] = field(
         default_factory=dict

--- a/src/qibocal/protocols/characterization/readout_characterization.py
+++ b/src/qibocal/protocols/characterization/readout_characterization.py
@@ -235,7 +235,7 @@ def _plot(
                 go.Scatter(
                     x=shots.i,
                     y=shots.q,
-                    name=f"state {state} measure {measure}",
+                    name=f"state {state} measurent number {measure}",
                     mode="markers",
                     showlegend=True,
                     opacity=0.7,

--- a/src/qibocal/protocols/characterization/readout_characterization.py
+++ b/src/qibocal/protocols/characterization/readout_characterization.py
@@ -59,7 +59,7 @@ class ReadoutCharacterizationData(Data):
     qubit_frequencies: dict[QubitId, float] = field(default_factory=dict)
     """Qubit frequencies."""
 
-    delay: float
+    delay: float = 0
     """Delay between readouts [ns]."""
     data: dict[tuple, npt.NDArray[ReadoutCharacterizationType]] = field(
         default_factory=dict

--- a/src/qibocal/protocols/characterization/readout_characterization.py
+++ b/src/qibocal/protocols/characterization/readout_characterization.py
@@ -235,7 +235,7 @@ def _plot(
                 go.Scatter(
                     x=shots.i,
                     y=shots.q,
-                    name=f"Prepared state {state} measurent {measure}",
+                    name=f"Prepared state {state} measurement {measure}",
                     mode="markers",
                     showlegend=True,
                     opacity=0.7,

--- a/src/qibocal/protocols/characterization/readout_characterization.py
+++ b/src/qibocal/protocols/characterization/readout_characterization.py
@@ -235,7 +235,7 @@ def _plot(
                 go.Scatter(
                     x=shots.i,
                     y=shots.q,
-                    name=f"state {state} measurent number {measure}",
+                    name=f"Prepared state {state} measurent {measure}",
                     mode="markers",
                     showlegend=True,
                     opacity=0.7,

--- a/tests/runcards/protocols.yml
+++ b/tests/runcards/protocols.yml
@@ -475,6 +475,7 @@ actions:
   - id: readout characterization
     operation: readout_characterization
     parameters:
+      delay: 1000
       nshots: 10
 
   - id: allXY
@@ -489,7 +490,6 @@ actions:
       beta_param: null
       unrolling: True
       nshots: 10
-
 
   - id: drag_pulse_tuning
     operation: drag_tuning

--- a/tests/runcards/protocols.yml
+++ b/tests/runcards/protocols.yml
@@ -478,6 +478,12 @@ actions:
       delay: 1000
       nshots: 10
 
+  - id: readout characterization delay 0
+    operation: readout_characterization
+    parameters:
+      delay: 0
+      nshots: 10
+
   - id: allXY
     operation: allxy
     parameters:


### PR DESCRIPTION
The fidelity and QND do not seem affected when neglecting the resonator delation time as we are not applying qubit pulses during the measurements. However, there is some anomalous shift on the iq plane that goes away if you wait the resonator depletion time.

![imagen](https://github.com/qiboteam/qibocal/assets/19141117/38b63999-9e93-4426-a5b8-f6bfd3301aac)

![imagen](https://github.com/qiboteam/qibocal/assets/19141117/d7fd554b-4e3d-4a88-bd61-a55ddca85568)


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
