### PR TITLE
added flux pulse to the sequence

### DIFF
--- a/src/qibocal/protocols/characterization/qubit_spectroscopy.py
+++ b/src/qibocal/protocols/characterization/qubit_spectroscopy.py
@@ -32,6 +32,7 @@ class QubitSpectroscopyParameters(Parameters):
     flux_duration: Optional[float] = None
     """Flux pulse duration (optional). Same for all qubits."""
 
+
 @dataclass
 class QubitSpectroscopyResults(Results):
     """QubitSpectroscopy outputs."""
@@ -85,8 +86,14 @@ def _acquisition(
 
         if params.flux_amplitude is not None or params.flux_duration is not None:
             # Define default values if parameters are None
-            flux_amplitude = params.flux_amplitude if params.flux_amplitude is not None else 0
-            flux_duration = params.flux_duration if params.flux_duration is not None else sequence.duration
+            flux_amplitude = (
+                params.flux_amplitude if params.flux_amplitude is not None else 0
+            )
+            flux_duration = (
+                params.flux_duration
+                if params.flux_duration is not None
+                else sequence.duration
+            )
 
             # Create the flux pulse with the specified or default parameters
             flux_pulses[qubit] = platform.create_qubit_flux_pulse(
@@ -96,7 +103,6 @@ def _acquisition(
                 amplitude=flux_amplitude,
             )
             sequence.add(flux_pulses[qubit])
-
 
     # define the parameter to sweep and its range:
     delta_frequency_range = np.arange(

--- a/src/qibocal/protocols/characterization/qubit_spectroscopy.py
+++ b/src/qibocal/protocols/characterization/qubit_spectroscopy.py
@@ -84,7 +84,10 @@ def _acquisition(
 
         if params.flux_amplitude is not None:
             flux_pulses[qubit] = platform.create_qubit_flux_pulse(
-                qubit, start=0, duration=sequence.duration, amplitude=params.flux_amplitude
+                qubit,
+                start=0,
+                duration=sequence.duration,
+                amplitude=params.flux_amplitude,
             )
             sequence.add(flux_pulses[qubit])
 

--- a/src/qibocal/protocols/characterization/qubit_spectroscopy.py
+++ b/src/qibocal/protocols/characterization/qubit_spectroscopy.py
@@ -29,7 +29,8 @@ class QubitSpectroscopyParameters(Parameters):
     """Drive pulse amplitude (optional). Same for all qubits."""
     flux_amplitude: Optional[float] = None
     """Flux pulse amplitude (optional). Same for all qubits."""
-
+    flux_duration: Optional[float] = None
+    """Flux pulse duration (optional). Same for all qubits."""
 
 @dataclass
 class QubitSpectroscopyResults(Results):
@@ -82,14 +83,20 @@ def _acquisition(
         sequence.add(qd_pulses[qubit])
         sequence.add(ro_pulses[qubit])
 
-        if params.flux_amplitude is not None:
+        if params.flux_amplitude is not None or params.flux_duration is not None:
+            # Define default values if parameters are None
+            flux_amplitude = params.flux_amplitude if params.flux_amplitude is not None else 0
+            flux_duration = params.flux_duration if params.flux_duration is not None else sequence.duration
+
+            # Create the flux pulse with the specified or default parameters
             flux_pulses[qubit] = platform.create_qubit_flux_pulse(
                 qubit,
                 start=0,
-                duration=sequence.duration,
-                amplitude=params.flux_amplitude,
+                duration=flux_duration,
+                amplitude=flux_amplitude,
             )
             sequence.add(flux_pulses[qubit])
+
 
     # define the parameter to sweep and its range:
     delta_frequency_range = np.arange(


### PR DESCRIPTION
This PR allows the user to add a flux pulse into the qubit spectroscopy sequence (optional) in order to adjust/check the shift produced in the drive frequency when applying a flux pulse to the qubit. 

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
- [x] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [x] Qibo: `master`
    - [x] Qibolab: `main`
    - [x] Qibolab_platforms_qrc: `main`
