### PR TITLE
Add possibility to dump and load `History`

### DIFF
--- a/src/qibocal/auto/execute.py
+++ b/src/qibocal/auto/execute.py
@@ -3,7 +3,7 @@
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterator, Union
+from typing import Union
 
 from qibolab import create_platform
 from qibolab.platform import Platform
@@ -14,7 +14,7 @@ from qibocal.config import log
 from .history import History
 from .mode import ExecutionMode
 from .operation import Routine
-from .runcard import Action, Id, Runcard, Targets
+from .runcard import Action, Runcard, Targets
 from .task import Completed, Task
 
 
@@ -22,8 +22,6 @@ from .task import Completed, Task
 class Executor:
     """Execute a tasks' graph and tracks its history."""
 
-    actions: list[Action]
-    """List of actions."""
     history: History
     """The execution history, with results and exit states."""
     output: Path
@@ -34,32 +32,6 @@ class Executor:
     """Qubits' platform."""
     update: bool = True
     """Runcard update mechanism."""
-
-    # TODO: find a more elegant way to pass everything
-    @classmethod
-    def load(
-        cls,
-        card: Runcard,
-        output: Path,
-        platform: Platform,
-        targets: Targets,
-        update: bool = True,
-    ):
-        """Load execution graph and associated executor from a runcard."""
-
-        return cls(
-            actions=card.actions,
-            history=History({}),
-            output=output,
-            platform=platform,
-            targets=targets,
-            update=update,
-        )
-
-    @property
-    def _actions_dict(self):
-        """Helper dict to find protocol."""
-        return {action.id: action for action in self.actions}
 
     @classmethod
     def create(
@@ -72,8 +44,7 @@ class Executor:
             platform if isinstance(platform, Platform) else create_platform(platform)
         )
         return cls(
-            actions=[],
-            history=History({}),
+            history=History(),
             output=Path(output),
             platform=platform,
             targets=list(platform.qubits),
@@ -95,7 +66,7 @@ class Executor:
         task = Task(action, protocol)
         if isinstance(mode, ExecutionMode):
             log.info(
-                f"Executing mode {mode.name if mode.name is not None else 'AUTOCALIBRATION'} on {id}."
+                f"Executing mode {mode.name if mode.name is not None else 'AUTOCALIBRATION'} on {task.id}."
             )
         completed = task.run(
             platform=self.platform,
@@ -108,20 +79,34 @@ class Executor:
             completed.update_platform(platform=self.platform, update=self.update)
 
         self.history.push(completed)
+        completed.dump(self.output)
 
         return completed
 
-    def run(self, mode: ExecutionMode) -> Iterator[Id]:
+    @classmethod
+    def run(cls, runcard: Runcard, output: Path, mode: ExecutionMode):
         """Actual execution.
 
         The platform's update method is called if:
         - self.update is True and task.update is None
         - task.update is True
         """
-        for id, params in self._actions_dict.items():
-            completed = self.run_protocol(
-                protocol=getattr(protocols, params.operation),
-                parameters=params,
+        platform = runcard.platform_obj
+        targets = (
+            runcard.targets if runcard.targets is not None else list(platform.qubits)
+        )
+        instance = cls(
+            history=History.load(output),
+            platform=platform,
+            targets=targets,
+            output=output,
+            update=runcard.update,
+        )
+
+        for action in runcard.actions:
+            _ = instance.run_protocol(
+                protocol=getattr(protocols, action.operation),
+                parameters=action,
                 mode=mode,
             )
-            yield completed.task.id
+        return instance

--- a/src/qibocal/auto/history.py
+++ b/src/qibocal/auto/history.py
@@ -1,5 +1,7 @@
 """Track execution history."""
 
+from pathlib import Path
+
 from .runcard import Id
 from .task import Completed
 
@@ -22,7 +24,7 @@ def add_timings_to_meta(meta, history):
     return meta
 
 
-class History(dict[tuple[Id, int], Completed]):
+class History(dict[Id, Completed]):
     """Execution history.
 
     This is not only used for logging and debugging, but it is an actual part
@@ -30,6 +32,14 @@ class History(dict[tuple[Id, int], Completed]):
     former ones from here.
 
     """
+
+    @classmethod
+    def load(cls, path: Path):
+        """To be defined"""
+        instance = cls()
+        for protocol in path.glob("data/*"):
+            instance.push(Completed.load(protocol))
+        return instance
 
     def push(self, completed: Completed):
         """Adding completed task to history."""

--- a/src/qibocal/auto/runcard.py
+++ b/src/qibocal/auto/runcard.py
@@ -1,8 +1,10 @@
 """Specify runcard layout, handles (de)serialization."""
 
 import os
+from dataclasses import asdict
 from typing import Any, NewType, Optional, Union
 
+import yaml
 from pydantic.dataclasses import dataclass
 from qibo.backends import Backend, GlobalBackend
 from qibolab.platform import Platform
@@ -15,6 +17,11 @@ Id = NewType("Id", str)
 
 Targets = Union[list[QubitId], list[QubitPairId], list[tuple[QubitId, ...]]]
 """Elements to be calibrated by a single protocol."""
+
+RUNCARD = "runcard.yml"
+"""Runcard filename."""
+
+SINGLE_ACTION = "action.yml"
 
 
 @dataclass(config=dict(smart_union=True))
@@ -36,6 +43,15 @@ class Action:
         """Each action is uniquely identified by its id."""
         return hash(self.id)
 
+    def dump(self, path):
+        """Dump single action to yaml"""
+        (path / SINGLE_ACTION).write_text(yaml.safe_dump(asdict(self)))
+
+    @classmethod
+    def load(cls, path):
+        """Load action from yaml."""
+        return cls(**yaml.safe_load((path / SINGLE_ACTION).read_text(encoding="utf-8")))
+
 
 @dataclass(config=dict(smart_union=True))
 class Runcard:
@@ -51,15 +67,11 @@ class Runcard:
     """Qibo backend."""
     platform: str = os.environ.get("QIBO_PLATFORM", "dummy")
     """Qibolab platform."""
-
-    def __post_init__(self):
-        if self.targets is None and self.platform_obj is not None:
-            self.targets = list(self.platform_obj.qubits)
+    update: bool = True
 
     @property
     def backend_obj(self) -> Backend:
         """Allocate backend."""
-        GlobalBackend.set_backend(self.backend, platform=self.platform)
         return GlobalBackend()
 
     @property
@@ -68,6 +80,14 @@ class Runcard:
         return self.backend_obj.platform
 
     @classmethod
-    def load(cls, params: dict):
-        """Load a runcard (dict)."""
-        return cls(**params)
+    def load(cls, runcard: Union[dict, os.PathLike]):
+        """Load a runcard dict or path."""
+        if not isinstance(runcard, dict):
+            runcard = cls.load(
+                yaml.safe_load((runcard / RUNCARD).read_text(encoding="utf-8"))
+            )
+        return cls(**runcard)
+
+    def dump(self, path):
+        """Dump runcard object to yaml."""
+        (path / RUNCARD).write_text(yaml.safe_dump(asdict(self)))

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -9,6 +9,8 @@ from typing import Optional
 from qibolab.platform import Platform
 from qibolab.serialize import dump_platform
 
+from qibocal import protocols
+
 from ..config import log
 from .mode import ExecutionMode
 from .operation import Data, DummyPars, Results, Routine, dummy_operation
@@ -29,6 +31,14 @@ class Task:
     action: Action
     """Action object parsed from Runcard."""
     operation: Routine
+
+    @classmethod
+    def load(cls, path):
+        action = Action.load(path)
+        return cls(action=action, operation=getattr(protocols, action.operation))
+
+    def dump(self, path):
+        self.action.dump(path)
 
     @property
     def targets(self) -> Targets:
@@ -161,6 +171,17 @@ class Completed:
         """Set and store data."""
         self._data = data
         self._data.save(self.datapath)
+
+    def dump(self, path):
+        """test"""
+        self.task.dump(self.datapath)
+
+    @classmethod
+    def load(cls, folder: Path):
+        """Loading completed from path."""
+
+        task = Task.load(folder)
+        return cls(task=task, folder=folder.parent.parent)
 
     def update_platform(self, platform: Platform, update: bool):
         """Perform update on platform' parameters by looping over qubits or pairs."""

--- a/src/qibocal/cli/autocalibration.py
+++ b/src/qibocal/cli/autocalibration.py
@@ -1,8 +1,7 @@
 import datetime
 import json
-from dataclasses import asdict
 
-import yaml
+from qibo.backends import set_backend
 from qibolab.serialize import dump_platform
 
 from ..auto.execute import Executor
@@ -12,7 +11,6 @@ from .report import report
 from .utils import (
     META,
     PLATFORM,
-    RUNCARD,
     UPDATED_PLATFORM,
     generate_meta,
     generate_output_folder,
@@ -26,7 +24,7 @@ def autocalibrate(runcard, folder, force, update):
 
      - RUNCARD: runcard with declarative inputs.
     """
-
+    set_backend(backend=runcard.backend, platform=runcard.platform)
     # rename for brevity
     backend = runcard.backend_obj
     platform = runcard.platform_obj
@@ -34,37 +32,36 @@ def autocalibrate(runcard, folder, force, update):
     path = generate_output_folder(folder, force)
 
     # generate meta
-    meta = generate_meta(backend, platform, path)
+    meta = generate_meta(runcard.backend_obj, runcard.platform_obj, path)
     # dump platform
     if backend.name == "qibolab":
         (path / PLATFORM).mkdir(parents=True, exist_ok=True)
         dump_platform(platform, path / PLATFORM)
 
     # dump action runcard
-    (path / RUNCARD).write_text(yaml.safe_dump(asdict(runcard)))
+    runcard.dump(folder)
     # dump meta
     (path / META).write_text(json.dumps(meta, indent=4))
-
-    # allocate executor
-    executor = Executor.load(runcard, path, platform, runcard.targets, update)
 
     # connect and initialize platform
     if platform is not None:
         platform.connect()
 
-    # run protocols
-    for _ in executor.run(mode=AUTOCALIBRATION):
-        # meta needs to be updated before each report to show correct end-time
-        e = datetime.datetime.now(datetime.timezone.utc)
-        meta["end-time"] = e.strftime("%H:%M:%S")
-        # dump updated meta
-        meta = add_timings_to_meta(meta, executor.history)
-        (path / META).write_text(json.dumps(meta, indent=4))
-        report(path, executor)
+    # run
+    executor = Executor.run(output=path, runcard=runcard, mode=AUTOCALIBRATION)
+
+    # TODO: implement iterative dump of report...
 
     # stop and disconnect platform
     if platform is not None:
         platform.disconnect()
+
+    e = datetime.datetime.now(datetime.timezone.utc)
+    meta["end-time"] = e.strftime("%H:%M:%S")
+    meta = add_timings_to_meta(meta, executor.history)
+    (path / META).write_text(json.dumps(meta, indent=4))
+
+    report(path, executor.history)
 
     # dump updated runcard
     if platform is not None:

--- a/src/qibocal/cli/report.py
+++ b/src/qibocal/cli/report.py
@@ -1,15 +1,14 @@
 import io
 import json
 import pathlib
-from typing import Optional, Union
+from typing import Union
 
 import plotly.graph_objects as go
 import yaml
 from jinja2 import Environment, FileSystemLoader
-from qibo.backends import GlobalBackend
 from qibolab.qubits import QubitId, QubitPairId
 
-from qibocal.auto.execute import Executor
+from qibocal.auto.history import History
 from qibocal.auto.runcard import Runcard
 from qibocal.auto.task import Completed
 from qibocal.cli.utils import META, RUNCARD
@@ -61,31 +60,22 @@ def plotter(
     return all_html, fitting_report
 
 
-def report(path: pathlib.Path, executor: Optional[Executor] = None):
+def report(path: pathlib.Path, history: History = None):
     """Report generation.
 
     Generates the report for protocol dumped in `path`.
     Executor can be passed to generate report on the fly.
     """
 
-    if path.exists():
+    if (path / "index.html").exists():
         log.warning(f"Regenerating {path}/index.html")
     # load meta
     meta = json.loads((path / META).read_text())
     # load runcard
     runcard = Runcard.load(yaml.safe_load((path / RUNCARD).read_text()))
 
-    # set backend, platform and qubits
-    GlobalBackend.set_backend(backend=meta["backend"], platform=meta["platform"])
-
-    # load executor
-    if executor is None:
-        executor = Executor.load(
-            runcard, path, targets=runcard.targets, platform=GlobalBackend().platform
-        )
-        # produce html
-        # TODO: skip report in a proper way
-        list(executor.run(mode=[]))
+    if history is None:
+        history = History.load(path)
 
     css_styles = f"<style>\n{pathlib.Path(STYLES).read_text()}\n</style>"
 
@@ -98,8 +88,8 @@ def report(path: pathlib.Path, executor: Optional[Executor] = None):
         title=path.name,
         report=Report(
             path=path,
-            targets=executor.targets,
-            history=executor.history,
+            targets=runcard.targets,
+            history=history,
             meta=meta,
             plotter=plotter,
         ),

--- a/tests/test_task_options.py
+++ b/tests/test_task_options.py
@@ -101,15 +101,14 @@ def test_update_argument(global_update, local_update, tmp_path):
     NEW_CARD = modify_card(
         UPDATE_CARD, local_update=local_update, global_update=global_update
     )
-    platform = GlobalBackend().platform
+    platform = deepcopy(GlobalBackend().platform)
+    old_readout_frequency = platform.qubits[0].readout_frequency
+    old_iq_angle = platform.qubits[1].iq_angle
     executor = Executor.run(
         Runcard.load(NEW_CARD),
         tmp_path,
         mode=AUTOCALIBRATION,
     )
-
-    old_readout_frequency = platform.qubits[0].readout_frequency
-    old_iq_angle = platform.qubits[1].iq_angle
 
     if local_update and global_update:
         assert old_readout_frequency != executor.platform.qubits[0].readout_frequency

--- a/tests/test_task_options.py
+++ b/tests/test_task_options.py
@@ -3,7 +3,7 @@
 from copy import deepcopy
 
 import pytest
-from qibolab import create_platform
+from qibo.backends import GlobalBackend, set_backend
 
 from qibocal import protocols
 from qibocal.auto.execute import Executor
@@ -15,6 +15,8 @@ from qibocal.protocols.classification import SingleShotClassificationParameters
 from qibocal.protocols.readout_mitigation_matrix import (
     ReadoutMitigationMatrixParameters,
 )
+
+set_backend(backend="qibolab", platform="dummy")
 
 TARGETS = [0, 1, 2]
 DUMMY_CARD = {
@@ -33,14 +35,20 @@ DUMMY_CARD = {
 }
 
 
-def modify_card(card, targets=None, update=None, backend="qibolab"):
+def modify_card(
+    card, targets=None, local_update=None, global_update=None, backend="qibolab"
+):
     """Modify runcard to change local targets or update."""
     card["backend"] = backend
+
+    if global_update is not None:
+        card["update"] = global_update
+
     for action in card["actions"]:
         if targets is not None:
             action["targets"] = targets
-        elif update is not None:
-            action["update"] = update
+        elif local_update is not None:
+            action["update"] = local_update
     return card
 
 
@@ -90,20 +98,18 @@ UPDATE_CARD = {
 @pytest.mark.parametrize("local_update", [True, False])
 def test_update_argument(global_update, local_update, tmp_path):
     """Test possible update combinations between global and local."""
-    platform = create_platform("dummy")
-    NEW_CARD = modify_card(UPDATE_CARD, update=local_update)
-    executor = Executor.load(
+    NEW_CARD = modify_card(
+        UPDATE_CARD, local_update=local_update, global_update=global_update
+    )
+    platform = GlobalBackend().platform
+    executor = Executor.run(
         Runcard.load(NEW_CARD),
         tmp_path,
-        platform,
-        list(platform.qubits),
-        update=global_update,
+        mode=AUTOCALIBRATION,
     )
 
-    old_readout_frequency = executor.platform.qubits[0].readout_frequency
-    old_iq_angle = executor.platform.qubits[1].iq_angle
-
-    list(executor.run(mode=AUTOCALIBRATION))
+    old_readout_frequency = platform.qubits[0].readout_frequency
+    old_iq_angle = platform.qubits[1].iq_angle
 
     if local_update and global_update:
         assert old_readout_frequency != executor.platform.qubits[0].readout_frequency


### PR DESCRIPTION
In this PR I address some of the comments raised in #865, given that the changes were substantial I decided to open a separate PR.
 
- [x] (de)serialize `History`
- [x] drop `load` from Executor
- [ ] restore iterative dumping when running autocalibration mode 

There might be a better way to (de)serialize `History`, the current implementation should be acceptable.
The only annoying object left to deal with seems to be `meta.json`, we could think about a way of moving its content somewhere else.