### PR TITLE
Remove unused pulse in tof

### DIFF
--- a/src/qibocal/protocols/signal_experiments/time_of_flight_readout.py
+++ b/src/qibocal/protocols/signal_experiments/time_of_flight_readout.py
@@ -52,13 +52,9 @@ def _acquisition(
 
     sequence = PulseSequence()
 
-    RX_pulses = {}
     ro_pulses = {}
     for qubit in targets:
-        RX_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
-        ro_pulses[qubit] = platform.create_qubit_readout_pulse(
-            qubit, start=RX_pulses[qubit].finish
-        )
+        ro_pulses[qubit] = platform.create_qubit_readout_pulse(qubit, start=0)
         if params.readout_amplitude is not None:
             ro_pulses[qubit].amplitude = params.readout_amplitude
         sequence.add(ro_pulses[qubit])


### PR DESCRIPTION
Remove unused pulse in time of flight experiment

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
