### PR TITLE
Fix Rabi length signal fit

### DIFF
--- a/src/qibocal/protocols/rabi/utils.py
+++ b/src/qibocal/protocols/rabi/utils.py
@@ -284,6 +284,7 @@ def guess_frequency(x, y):
 def fit_length_function(
     x, y, guess, sigma=None, signal=True, x_limits=(None, None), y_limits=(None, None)
 ):
+    inf_bounds = [0, -1, 0, -np.pi, 0] if signal else [0, 0, 0, -np.pi, 0]
     popt, perr = curve_fit(
         rabi_length_function,
         x,
@@ -291,7 +292,7 @@ def fit_length_function(
         p0=guess,
         maxfev=100000,
         bounds=(
-            [0, 0, 0, -np.pi, 0],
+            inf_bounds,
             [1, 1, np.inf, np.pi, np.inf],
         ),
         sigma=sigma,


### PR DESCRIPTION
Closes #879.

I guess that the "problem" arises from the fact that in rabi length we expect to see oscillations given by detuning (potential at least) spanning along a large duration. While for rabi amplitude the length is usually kept small -> we do not fit oscillation and we don't have the same problem.

I'm not sure that I like the asymmetry, but it doesn't probably matter

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
