### PR TITLE
unify execution pars for dispersive shift

### DIFF
--- a/src/qibocal/protocols/dispersive_shift.py
+++ b/src/qibocal/protocols/dispersive_shift.py
@@ -125,20 +125,21 @@ def _acquisition(
         type=SweeperType.OFFSET,
     )
 
+    execution_pars = ExecutionParameters(
+        nshots=params.nshots,
+        relaxation_time=params.relaxation_time,
+        acquisition_type=AcquisitionType.INTEGRATION,
+        averaging_mode=AveragingMode.CYCLIC,
+    )
     results_0 = platform.sweep(
         sequence_0,
-        ExecutionParameters(
-            nshots=params.nshots,
-            relaxation_time=params.relaxation_time,
-            acquisition_type=AcquisitionType.INTEGRATION,
-            averaging_mode=AveragingMode.CYCLIC,
-        ),
+        execution_pars,
         sweeper,
     )
 
     results_1 = platform.sweep(
         sequence_1,
-        params.execution_parameters,
+        execution_pars,
         sweeper,
     )
 


### PR DESCRIPTION
Closes #887, but does not take care at all of #890.

How could we use `params.execution_parameters` and also pass standard values?

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
