### PR TITLE
Small fixes for TWPA calibration routines

### DIFF
--- a/src/qibocal/protocols/readout_optimization/twpa_calibration/frequency_SNR.py
+++ b/src/qibocal/protocols/readout_optimization/twpa_calibration/frequency_SNR.py
@@ -128,6 +128,7 @@ def _acquisition(
                     "freq_width": params.freq_width,
                     "freq_step": params.freq_step,
                     "power_level": params.power_level,
+                    "relaxation_time": params.relaxation_time,
                     "nshots": params.nshots,
                 }
             ),

--- a/src/qibocal/protocols/readout_optimization/twpa_calibration/frequency_power.py
+++ b/src/qibocal/protocols/readout_optimization/twpa_calibration/frequency_power.py
@@ -100,46 +100,46 @@ def _acquisition(
         ].twpa.local_oscillator.frequency
         initial_twpa_power[qubit] = platform.qubits[qubit].twpa.local_oscillator.power
 
-    for freq in freq_range:
-        platform.qubits[qubit].twpa.local_oscillator.frequency = (
-            initial_twpa_freq[qubit] + freq
-        )
+        for freq in freq_range:
+            platform.qubits[qubit].twpa.local_oscillator.frequency = (
+                initial_twpa_freq[qubit] + freq
+            )
 
-        for power in power_range:
-            for qubit in targets:
-                platform.qubits[qubit].twpa.local_oscillator.power = (
-                    initial_twpa_power[qubit] + power
+            for power in power_range:
+                for qubit in targets:
+                    platform.qubits[qubit].twpa.local_oscillator.power = (
+                        initial_twpa_power[qubit] + power
+                    )
+
+                classification_data = classification._acquisition(
+                    classification.SingleShotClassificationParameters.load(
+                        {"nshots": params.nshots}
+                    ),
+                    platform,
+                    targets,
                 )
 
-            classification_data = classification._acquisition(
-                classification.SingleShotClassificationParameters.load(
-                    {"nshots": params.nshots}
-                ),
-                platform,
-                targets,
-            )
+                classification_result = classification._fit(classification_data)
 
-            classification_result = classification._fit(classification_data)
-
-            data.register_qubit(
-                TwpaFrequencyPowerType,
-                (qubit),
-                dict(
-                    freq=np.array(
-                        [platform.qubits[qubit].twpa.local_oscillator.frequency],
-                        dtype=np.float64,
+                data.register_qubit(
+                    TwpaFrequencyPowerType,
+                    (qubit),
+                    dict(
+                        freq=np.array(
+                            [platform.qubits[qubit].twpa.local_oscillator.frequency],
+                            dtype=np.float64,
+                        ),
+                        power=np.array(
+                            [platform.qubits[qubit].twpa.local_oscillator.power],
+                            dtype=np.float64,
+                        ),
+                        assignment_fidelity=np.array(
+                            [classification_result.assignment_fidelity[qubit]],
+                        ),
+                        angle=np.array([classification_result.rotation_angle[qubit]]),
+                        threshold=np.array([classification_result.threshold[qubit]]),
                     ),
-                    power=np.array(
-                        [platform.qubits[qubit].twpa.local_oscillator.power],
-                        dtype=np.float64,
-                    ),
-                    assignment_fidelity=np.array(
-                        [classification_result.assignment_fidelity[qubit]],
-                    ),
-                    angle=np.array([classification_result.rotation_angle[qubit]]),
-                    threshold=np.array([classification_result.threshold[qubit]]),
-                ),
-            )
+                )
     return data
 
 

--- a/src/qibocal/protocols/readout_optimization/twpa_calibration/frequency_power.py
+++ b/src/qibocal/protocols/readout_optimization/twpa_calibration/frequency_power.py
@@ -100,46 +100,46 @@ def _acquisition(
         ].twpa.local_oscillator.frequency
         initial_twpa_power[qubit] = platform.qubits[qubit].twpa.local_oscillator.power
 
-        for freq in freq_range:
-            platform.qubits[qubit].twpa.local_oscillator.frequency = (
-                initial_twpa_freq[qubit] + freq
+    for freq in freq_range:
+        platform.qubits[qubit].twpa.local_oscillator.frequency = (
+            initial_twpa_freq[qubit] + freq
+        )
+
+        for power in power_range:
+            for qubit in targets:
+                platform.qubits[qubit].twpa.local_oscillator.power = (
+                    initial_twpa_power[qubit] + power
+                )
+
+            classification_data = classification._acquisition(
+                classification.SingleShotClassificationParameters.load(
+                    {"nshots": params.nshots}
+                ),
+                platform,
+                targets,
             )
 
-            for power in power_range:
-                for qubit in targets:
-                    platform.qubits[qubit].twpa.local_oscillator.power = (
-                        initial_twpa_power[qubit] + power
-                    )
+            classification_result = classification._fit(classification_data)
 
-                classification_data = classification._acquisition(
-                    classification.SingleShotClassificationParameters.load(
-                        {"nshots": params.nshots}
+            data.register_qubit(
+                TwpaFrequencyPowerType,
+                (qubit),
+                dict(
+                    freq=np.array(
+                        [platform.qubits[qubit].twpa.local_oscillator.frequency],
+                        dtype=np.float64,
                     ),
-                    platform,
-                    targets,
-                )
-
-                classification_result = classification._fit(classification_data)
-
-                data.register_qubit(
-                    TwpaFrequencyPowerType,
-                    (qubit),
-                    dict(
-                        freq=np.array(
-                            [platform.qubits[qubit].twpa.local_oscillator.frequency],
-                            dtype=np.float64,
-                        ),
-                        power=np.array(
-                            [platform.qubits[qubit].twpa.local_oscillator.power],
-                            dtype=np.float64,
-                        ),
-                        assignment_fidelity=np.array(
-                            [classification_result.assignment_fidelity[qubit]],
-                        ),
-                        angle=np.array([classification_result.rotation_angle[qubit]]),
-                        threshold=np.array([classification_result.threshold[qubit]]),
+                    power=np.array(
+                        [platform.qubits[qubit].twpa.local_oscillator.power],
+                        dtype=np.float64,
                     ),
-                )
+                    assignment_fidelity=np.array(
+                        [classification_result.assignment_fidelity[qubit]],
+                    ),
+                    angle=np.array([classification_result.rotation_angle[qubit]]),
+                    threshold=np.array([classification_result.threshold[qubit]]),
+                ),
+            )
     return data
 
 

--- a/src/qibocal/protocols/readout_optimization/twpa_calibration/frequency_power.py
+++ b/src/qibocal/protocols/readout_optimization/twpa_calibration/frequency_power.py
@@ -106,10 +106,9 @@ def _acquisition(
             )
 
             for power in power_range:
-                for qubit in targets:
-                    platform.qubits[qubit].twpa.local_oscillator.power = (
-                        initial_twpa_power[qubit] + power
-                    )
+                platform.qubits[qubit].twpa.local_oscillator.power = (
+                    initial_twpa_power[qubit] + power
+                )
 
                 classification_data = classification._acquisition(
                     classification.SingleShotClassificationParameters.load(

--- a/src/qibocal/protocols/readout_optimization/twpa_calibration/power_SNR.py
+++ b/src/qibocal/protocols/readout_optimization/twpa_calibration/power_SNR.py
@@ -128,6 +128,7 @@ def _acquisition(
                     "freq_width": params.freq_width,
                     "freq_step": params.freq_step,
                     "power_level": params.power_level,
+                    "relaxation_time": params.relaxation_time,
                     "nshots": params.nshots,
                 }
             ),


### PR DESCRIPTION
Some issues I realized while trying to use these routines:

1. `frequency_power` was giving some `KeyError`s with `qubit`s missing from the `initial_twpa_freq` and `initial_twpa_power` dictionaries. I believe these are because the execution part of the routine is nested in the loop that initializates these dictionaries, while I think it should be a separate loop.
2. It seems that `relaxation_time` is ignored for both SNR routines as it is not passed in the `resonator_spectroscopy` call. This ends up using the default `relaxation_time` from the platform runcard, which is usually much higher than what we need for spectroscopy, thus making execution slower.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
- [x] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [x] Qibo: `master`
    - [x] Qibolab: `main`
    - [x] Qibolab_platforms_qrc: `main`
