### PR TITLE
Switch reusable workflows to v1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.9, "3.10", "3.11"]
-    uses: qiboteam/workflows/.github/workflows/deploy-pip-poetry.yml@main
+    uses: qiboteam/workflows/.github/workflows/deploy-pip-poetry.yml@v1
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
 
   deploy-docs:
     needs: [evaluate-label]
-    uses: qiboteam/workflows/.github/workflows/deploy-ghpages-latest-stable.yml@main
+    uses: qiboteam/workflows/.github/workflows/deploy-ghpages-latest-stable.yml@v1
     with:
       python-version: "3.10"
       package-manager: "poetry"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.9, "3.10", "3.11"]
-    uses: qiboteam/workflows/.github/workflows/rules-poetry.yml@main
+    uses: qiboteam/workflows/.github/workflows/rules-poetry.yml@v1
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
The main benefit of `v1` is the name itself, since I'd like to finally move towards workflows versioning.

However, there are already two improvements:
1. the cache is not present any longer, that should solve https://github.com/qiboteam/workflows/issues/64
2. I now enabled the modern installer (not sure why it was disabled, or still disabled) which may solve some installation problems experienced recently (which signature was something like `  IncompleteRead(* bytes read, * more expected)`, e.g. [this run](https://github.com/qiboteam/qibocal/actions/runs/9806408242/job/27078063843#step:7:38))