### PR TITLE
Add missing default value

### DIFF
--- a/src/qibocal/protocols/rabi/amplitude_signal.py
+++ b/src/qibocal/protocols/rabi/amplitude_signal.py
@@ -26,7 +26,7 @@ class RabiAmplitudeSignalParameters(Parameters):
     """Maximum amplitude multiplicative factor."""
     step_amp_factor: float
     """Step amplitude multiplicative factor."""
-    pulse_length: Optional[float]
+    pulse_length: Optional[float] = None
     """RX pulse duration [ns]."""
 
 


### PR DESCRIPTION
I guess this was just an oversight, because of the asymmetry with the length signal.