### PR TITLE
Hotfix for drag protocol

### DIFF
--- a/src/qibocal/protocols/drag.py
+++ b/src/qibocal/protocols/drag.py
@@ -283,7 +283,7 @@ def _plot(data: DragTuningData, target: QubitId, fit: DragTuningResults):
 def _update(results: DragTuningResults, platform: Platform, target: QubitId):
     try:
         update.drag_pulse_beta(
-            results.betas[target] / platform.qubits[target].anharmonicity,
+            results.betas[target] / platform.qubits[target].anharmonicity / HZ_TO_GHZ,
             platform,
             target,
         )


### PR DESCRIPTION
I missed a `HZ_TO_GHZ` conversion in #927.

Here is an example: http://login.qrccluster.com:9000/2_PXMY2xQBSV1w9CC1yezQ==



Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
