### PR TITLE
Fix default executor platform

### DIFF
--- a/src/qibocal/__init__.py
+++ b/src/qibocal/__init__.py
@@ -7,7 +7,7 @@ from .version import __version__
 
 __all__ = ["Executor", "protocols", "command", "__version__"]
 
-DEFAULT_EXECUTOR = Executor.create(".routines")
+DEFAULT_EXECUTOR = Executor.create(".routines", platform="dummy")
 """Default executor, registered as a qibocal submodule.
 
 It is defined for streamlined usage of qibocal protocols in simple

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -157,13 +157,9 @@ def test_close(tmp_path: Path, executor: Executor):
     assert executor.meta.end is not None
 
 
-def test_default_executor(tmp_path: Path):
+@pytest.fixture
+def fake_platform(tmp_path):
     name = "ciao-come-va"
-    os.environ["QIBO_PLATFORM"] = name
-    reload(qibocal)
-    assert qibocal.DEFAULT_EXECUTOR.platform.name == "dummy"
-
-    path = tmp_path / "my-default-exec-folder"
     platform = tmp_path / "ciao-come-va"
     platform.mkdir()
     (platform / "platform.py").write_text(
@@ -177,6 +173,14 @@ def test_default_executor(tmp_path: Path):
         )
     )
     os.environ["QIBOLAB_PLATFORMS"] = str(tmp_path)
+    return name
 
-    qibocal.routines.init(path, platform=name)
+
+def test_default_executor(tmp_path: Path, fake_platform: str):
+    os.environ["QIBO_PLATFORM"] = fake_platform
+    reload(qibocal)
+    assert qibocal.DEFAULT_EXECUTOR.platform.name == "dummy"
+
+    path = tmp_path / "my-default-exec-folder"
+    qibocal.routines.init(path, platform=fake_platform)
     assert qibocal.DEFAULT_EXECUTOR.platform.name == 42

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,5 +1,7 @@
+import os
 from copy import deepcopy
 from dataclasses import dataclass
+from importlib import reload
 from pathlib import Path
 from typing import Optional
 
@@ -7,6 +9,7 @@ import pytest
 from qibolab import Platform, create_platform
 from qibolab.qubits import QubitId
 
+import qibocal
 import qibocal.protocols
 from qibocal import Executor
 from qibocal.auto.history import History
@@ -151,3 +154,9 @@ def test_close(tmp_path: Path, executor: Executor):
     assert executor.meta is not None
     assert executor.meta.start is not None
     assert executor.meta.end is not None
+
+
+def test_default_executor():
+    os.environ["QIBO_PLATFORM"] = "ciao-come-va"
+    reload(qibocal)
+    assert qibocal.DEFAULT_EXECUTOR.platform.name == "dummy"

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,4 +1,3 @@
-import os
 from copy import deepcopy
 from dataclasses import dataclass
 from importlib import reload
@@ -158,7 +157,7 @@ def test_close(tmp_path: Path, executor: Executor):
 
 
 @pytest.fixture
-def fake_platform(tmp_path):
+def fake_platform(tmp_path, monkeypatch):
     name = "ciao-come-va"
     platform = tmp_path / "ciao-come-va"
     platform.mkdir()
@@ -172,12 +171,12 @@ def fake_platform(tmp_path):
             """
         )
     )
-    os.environ["QIBOLAB_PLATFORMS"] = str(tmp_path)
+    monkeypatch.setenv("QIBOLAB_PLATFORMS", tmp_path)
     return name
 
 
-def test_default_executor(tmp_path: Path, fake_platform: str):
-    os.environ["QIBO_PLATFORM"] = fake_platform
+def test_default_executor(tmp_path: Path, fake_platform: str, monkeypatch):
+    monkeypatch.setenv("QIBO_PLATFORM", fake_platform)
     reload(qibocal)
     assert qibocal.DEFAULT_EXECUTOR.platform.name == "dummy"
 


### PR DESCRIPTION
Initially setting it to dummy, to avoid loading attempts from other platforms, through undesired env vars

- [ ] add a test failing in `main`, passing now
- ~~convert one of the two example scripts to `qibocal.routines`~~ done in #949
