### PR TITLE
Rabi and chevron fixes

### DIFF
--- a/src/qibocal/protocols/coherence/spin_echo.py
+++ b/src/qibocal/protocols/coherence/spin_echo.py
@@ -87,8 +87,8 @@ def _acquisition(
         # save data as often as defined by points
 
         for qubit in targets:
-            RX_pulses[qubit].start = RX90_pulses1[qubit].finish + wait / 2
-            RX90_pulses2[qubit].start = RX_pulses[qubit].finish + wait / 2
+            RX_pulses[qubit].start = RX90_pulses1[qubit].finish + wait // 2
+            RX90_pulses2[qubit].start = RX_pulses[qubit].finish + wait // 2
             ro_pulses[qubit].start = RX90_pulses2[qubit].finish
 
         sequences.append(deepcopy(sequence))

--- a/src/qibocal/protocols/rabi/amplitude.py
+++ b/src/qibocal/protocols/rabi/amplitude.py
@@ -113,7 +113,7 @@ def _fit(data: RabiAmplitudeData) -> RabiAmplitudeResults:
         y = qubit_data.prob
 
         period = fallback_period(guess_period(x, y))
-        pguess = [0.5, 0.5, period, 0]
+        pguess = [0.5, 0.5, period, np.pi]
         try:
             popt, perr, pi_pulse_parameter = utils.fit_amplitude_function(
                 x,

--- a/src/qibocal/protocols/rabi/amplitude_signal.py
+++ b/src/qibocal/protocols/rabi/amplitude_signal.py
@@ -134,7 +134,7 @@ def _fit(data: RabiAmplitudeSignalData) -> RabiAmplitudeSignalResults:
         y = (voltages - y_min) / (y_max - y_min)
 
         period = fallback_period(guess_period(x, y))
-        pguess = [0.5, 1, period, 0]
+        pguess = [0.5, 0.5, period, np.pi]
         try:
             popt, _, pi_pulse_parameter = utils.fit_amplitude_function(
                 x,

--- a/src/qibocal/protocols/rabi/utils.py
+++ b/src/qibocal/protocols/rabi/utils.py
@@ -321,8 +321,8 @@ def fit_amplitude_function(
         p0=guess,
         maxfev=100000,
         bounds=(
-            [0, 0, 0, -np.pi],
-            [1, 1, np.inf, np.pi],
+            [0, 0, 0, 0],
+            [1, 1, np.inf, 2 * np.pi],
         ),
         sigma=sigma,
     )

--- a/src/qibocal/protocols/two_qubit_interaction/chevron/chevron.py
+++ b/src/qibocal/protocols/two_qubit_interaction/chevron/chevron.py
@@ -203,12 +203,17 @@ def _fit(data: ChevronData) -> ChevronResults:
         amplitude, index, delta = fit_flux_amplitude(signal_matrix, amps, times)
         # estimate duration by rabi curve at amplitude previously estimated
         y = signal_matrix[index, :].ravel()
-
         try:
             popt, _ = curve_fit(
-                chevron_fit, times, y, p0=[delta, 0, np.mean(y), np.mean(y)]
+                chevron_fit,
+                times,
+                y,
+                p0=[delta * 2 * np.pi, np.pi, np.mean(y), np.mean(y)],
+                bounds=(
+                    [0, -2 * np.pi, np.min(y), np.min(y)],
+                    [np.inf, 2 * np.pi, np.max(y), np.max(y)],
+                ),
             )
-
             # duration can be estimated as the period of the oscillation
             duration = 1 / (popt[0] / 2 / np.pi)
             amplitudes[pair] = amplitude


### PR DESCRIPTION
Closes #957 and https://github.com/qiboteam/qibocal/issues/956#issuecomment-2262771447
For Rabis I just made the bounds a bit larger and change some initial conditions.
For Chevron I did a small refactor of the fit in order to take no longer the FFT but the row where there are more oscillations.
![image](https://github.com/user-attachments/assets/2d6622a9-4862-423e-b907-0439eb636cce)

I've tested both and they seems to work as expected.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
