### PR TITLE
Hotfix for sweetspot calculation

### DIFF
--- a/src/qibocal/protocols/flux_dependence/qubit_flux_dependence.py
+++ b/src/qibocal/protocols/flux_dependence/qubit_flux_dependence.py
@@ -218,12 +218,10 @@ def _fit(data: QubitFluxData) -> QubitFluxResults:
                 "charging_energy": data.charging_energy[qubit] * HZ_TO_GHZ,
             }
             frequency[qubit] = popt[0] * GHZ_TO_HZ
-            # solution to x*popt[1] + popt[2] = k pi
+            # solution to x*popt[1] + popt[2] = k
             # such that x is close to 0
             # to avoid errors due to periodicity
-            k = np.round(popt[2] / np.pi)
-
-            sweetspot[qubit] = (k * np.pi + popt[2]) / popt[1]
+            sweetspot[qubit] = (np.round(popt[2]) - popt[2]) / popt[1]
             matrix_element[qubit] = popt[1]
         except ValueError as e:
             log.error(

--- a/src/qibocal/protocols/flux_dependence/utils.py
+++ b/src/qibocal/protocols/flux_dependence/utils.py
@@ -318,12 +318,12 @@ def qubit_flux_dependence_fit_bounds(qubit_frequency: float):
         [
             qubit_frequency * HZ_TO_GHZ - 1,
             0,
-            -np.pi,
+            -1,
         ],
         [
             qubit_frequency * HZ_TO_GHZ + 1,
             np.inf,
-            np.pi,
+            1,
         ],
     )
 


### PR DESCRIPTION
The error comes from the fact there was a redundant factor pi which is already included in 
https://github.com/qiboteam/qibocal/blob/78d4938552e46b678e4b6f10acc2bea64e039cc1/src/qibocal/protocols/flux_dependence/utils.py#L220-L221
Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
