### PR TITLE
Script to measure RB fidelity with flux induced noise and recalibration

### DIFF
--- a/runcards/rb_noise.py
+++ b/runcards/rb_noise.py
@@ -1,0 +1,124 @@
+import argparse
+
+from qibolab.qubits import QubitId
+
+from qibocal.auto.execute import Executor
+from qibocal.cli.report import report
+
+# Change bias points here
+# in this case I am addressing D1 and I am modifying the bias
+# point of the D2 and D3
+NEW_BIAS = {
+    "D2": -0.419,
+    "D3": -0.2074,
+}
+
+
+def main(targets: list[QubitId], platform_name: str, output: str):
+
+    with Executor.open(
+        "myexec",
+        path=output,
+        platform=platform_name,
+        targets=targets,
+        update=False,
+        force=True,
+    ) as e:
+        platform = e.platform
+
+        # changing bias of neighbor qubit
+        for qubit, new_bias in NEW_BIAS.items():
+            e.platform.qubits[qubit].flux.offset = new_bias
+
+        rb_output = e.rb_ondevice(
+            apply_inverse=True,
+            delta_clifford=10,
+            max_circuit_depth=500,
+            n_avg=1,
+            num_of_sequences=10000,
+            save_sequences=True,
+            state_discrimination=True,
+        )
+
+        qubit_spectroscopy_output = e.qubit_spectroscopy(
+            freq_width=40_000_000,
+            freq_step=500_000,
+            drive_duration=2000,
+            drive_amplitude=0.01,
+            relaxation_time=5000,
+            nshots=1024,
+        )
+
+        qubit_spectroscopy_output.update_platform(platform)
+
+        rabi_output = e.rabi_amplitude_signal(
+            min_amp_factor=0.1,
+            max_amp_factor=2,
+            step_amp_factor=0.03,
+            pulse_length=40,
+        )
+
+        rabi_output.update_platform(platform)
+
+        classification_output = e.single_shot_classification(
+            nshots=5000,
+        )
+
+        classification_output.update_platform(platform)
+
+        rabi_output = e.rabi_amplitude(
+            min_amp_factor=0.1,
+            max_amp_factor=2,
+            step_amp_factor=0.03,
+            pulse_length=40,
+        )
+
+        rabi_output.update_platform(platform)
+
+        ramsey = e.ramsey(
+            delay_between_pulses_start=10,
+            delay_between_pulses_end=1_000,
+            delay_between_pulses_step=20,
+            detuning=10_000_000,
+        )
+
+        ramsey.update_platform(platform)
+
+        ramsey = e.ramsey(
+            delay_between_pulses_start=10,
+            delay_between_pulses_end=1_000,
+            delay_between_pulses_step=20,
+            detuning=10_000_000,
+        )
+
+        ramsey.update_platform(platform)
+
+        classification_output = e.single_shot_classification(
+            nshots=5000,
+        )
+
+        classification_output.update_platform(platform)
+
+        rb_output = e.rb_ondevice(
+            apply_inverse=True,
+            delta_clifford=10,
+            max_circuit_depth=500,
+            n_avg=1,
+            num_of_sequences=10000,
+            save_sequences=True,
+            state_discrimination=True,
+        )
+
+        report(e.path, e.history)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser("Qubit recalibration")
+    parser.add_argument("--platform", type=str, help="Qibo platform")
+    parser.add_argument("--output", type=str, help="Output folder")
+    parser.add_argument(
+        "--targets", nargs="+", help="Target qubit to recalibrate", required=True
+    )
+
+    args = parser.parse_args()
+    main(targets=args.targets, platform_name=args.platform, output=args.output)


### PR DESCRIPTION
This PR adds a script to monitor how the RB fidelity changes by modifying the offest of some
of the neighboring qubits.
The code works only for QM since it using qua for a fast evaluation of RB.
Here is how to run the code
```python
srun -p qw11q python runcards/rb_noise.py --platform qw11q --targets D1 --output <qibocal_report_folder>
```
In the current example I am changing the offset of D2 and D3.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
