### PR TITLE
Fix ramsey update

### DIFF
--- a/doc/source/protocols/ramsey/ramsey.rst
+++ b/doc/source/protocols/ramsey/ramsey.rst
@@ -56,8 +56,8 @@ The expected output is the following:
 :math:`T_2` and :math:`\Delta \omega` are determined by fitting the output signal using
 the formula presented above.
 
-If the protocols is successful the drive frequency will be updated. For updating :math:`T_2`
-the user is invited to run ``T2 experiment``.
+If the protocols is successful the drive frequency will be updated only if a non-zero
+detuning is provided. :math:`T_2` is updated only in the case where detuning is 0.
 
 Requirements
 ^^^^^^^^^^^^

--- a/doc/source/protocols/ramsey/ramsey.rst
+++ b/doc/source/protocols/ramsey/ramsey.rst
@@ -57,7 +57,7 @@ The expected output is the following:
 the formula presented above.
 
 If the protocols is successful the drive frequency will be updated only if a non-zero
-detuning is provided. :math:`T_2` is updated only in the case where detuning is 0.
+detuning is provided. :math:`T_2` is updated only in the case where detuning is not specified.
 
 Requirements
 ^^^^^^^^^^^^

--- a/src/qibocal/protocols/ramsey/ramsey.py
+++ b/src/qibocal/protocols/ramsey/ramsey.py
@@ -13,14 +13,14 @@ from qibolab.sweeper import Parameter, Sweeper, SweeperType
 from qibocal.auto.operation import Routine
 from qibocal.config import log
 
-from ..utils import GHZ_TO_HZ, chi2_reduced, table_dict, table_html
+from ..utils import table_dict, table_html
 from .ramsey_signal import (
     RamseySignalData,
     RamseySignalParameters,
     RamseySignalResults,
     _update,
 )
-from .utils import fitting, ramsey_fit, ramsey_sequence
+from .utils import fitting, process_fit, ramsey_fit, ramsey_sequence
 
 COLORBAND = "rgba(0,100,80,0.2)"
 COLORBAND_LINE = "rgba(255,255,255,0)"
@@ -191,36 +191,13 @@ def _fit(data: RamseyData) -> RamseyResults:
         probs = qubit_data["prob"]
         try:
             popt, perr = fitting(waits, probs, qubit_data.errors)
-
-            delta_fitting = popt[2] / (2 * np.pi)
-            sign = np.sign(data.detuning) if data.detuning != 0 else 1
-            delta_phys = int(sign * (delta_fitting * GHZ_TO_HZ - np.abs(data.detuning)))
-            corrected_qubit_frequency = int(qubit_freq - delta_phys)
-            t2 = 1 / popt[4]
-            # TODO: check error formula
-            freq_measure[qubit] = (
-                corrected_qubit_frequency,
-                perr[2] * GHZ_TO_HZ / (2 * np.pi),
-            )
-            t2_measure[qubit] = (t2, perr[4] * (t2**2))
-            popts[qubit] = popt
-            # TODO: check error formula
-            delta_phys_measure[qubit] = (
-                -delta_phys,
-                perr[2] * GHZ_TO_HZ / (2 * np.pi),
-            )
-            delta_fitting_measure[qubit] = (
-                -delta_fitting * GHZ_TO_HZ,
-                perr[2] * GHZ_TO_HZ / (2 * np.pi),
-            )
-            chi2[qubit] = (
-                chi2_reduced(
-                    probs,
-                    ramsey_fit(waits, *popts[qubit]),
-                    qubit_data.errors,
-                ),
-                np.sqrt(2 / len(probs)),
-            )
+            (
+                freq_measure[qubit],
+                t2_measure[qubit],
+                delta_phys_measure[qubit],
+                delta_fitting_measure[qubit],
+                popts[qubit],
+            ) = process_fit(popt, perr, qubit_freq, data.detuning)
         except Exception as e:
             log.warning(f"Ramsey fitting failed for qubit {qubit} due to {e}.")
     return RamseyResults(

--- a/src/qibocal/protocols/ramsey/ramsey.py
+++ b/src/qibocal/protocols/ramsey/ramsey.py
@@ -210,6 +210,7 @@ def _fit(data: RamseyData) -> RamseyResults:
         except Exception as e:
             log.warning(f"Ramsey fitting failed for qubit {qubit} due to {e}.")
     return RamseyResults(
+        detuning=data.detuning,
         frequency=freq_measure,
         t2=t2_measure,
         delta_phys=delta_phys_measure,

--- a/src/qibocal/protocols/ramsey/ramsey.py
+++ b/src/qibocal/protocols/ramsey/ramsey.py
@@ -13,7 +13,7 @@ from qibolab.sweeper import Parameter, Sweeper, SweeperType
 from qibocal.auto.operation import Routine
 from qibocal.config import log
 
-from ..utils import table_dict, table_html
+from ..utils import chi2_reduced, table_dict, table_html
 from .ramsey_signal import (
     RamseySignalData,
     RamseySignalParameters,
@@ -198,6 +198,15 @@ def _fit(data: RamseyData) -> RamseyResults:
                 delta_fitting_measure[qubit],
                 popts[qubit],
             ) = process_fit(popt, perr, qubit_freq, data.detuning)
+
+            chi2[qubit] = (
+                chi2_reduced(
+                    probs,
+                    ramsey_fit(waits, *popts[qubit]),
+                    qubit_data.errors,
+                ),
+                np.sqrt(2 / len(probs)),
+            )
         except Exception as e:
             log.warning(f"Ramsey fitting failed for qubit {qubit} due to {e}.")
     return RamseyResults(

--- a/src/qibocal/protocols/ramsey/ramsey_signal.py
+++ b/src/qibocal/protocols/ramsey/ramsey_signal.py
@@ -295,7 +295,10 @@ def _plot(data: RamseySignalData, target: QubitId, fit: RamseySignalResults = No
 
 
 def _update(results: RamseySignalResults, platform: Platform, target: QubitId):
-    update.drive_frequency(results.frequency[target][0], platform, target)
+    if int(results.delta_phys[target][0]) == int(results.delta_fitting[target][0]):
+        update.t2(results.t2[target][0], platform, target)
+    else:
+        update.drive_frequency(results.frequency[target][0], platform, target)
 
 
 ramsey_signal = Routine(_acquisition, _fit, _plot, _update)

--- a/src/qibocal/protocols/ramsey/utils.py
+++ b/src/qibocal/protocols/ramsey/utils.py
@@ -21,8 +21,8 @@ THRESHOLD = 0.5
 def ramsey_sequence(
     platform: Platform,
     qubit: QubitId,
-    wait: Optional[int] = 0,
-    detuning: Optional[int] = 0,
+    wait: int = 0,
+    detuning: Optional[int] = None,
 ):
     """Pulse sequence used in Ramsey (detuned) experiments.
 
@@ -41,8 +41,9 @@ def ramsey_sequence(
     )
 
     # apply detuning:
-    first_pi_half_pulse.frequency += detuning
-    second_pi_half_pulse.frequency += detuning
+    if detuning is not None:
+        first_pi_half_pulse.frequency += detuning
+        second_pi_half_pulse.frequency += detuning
     readout_pulse = platform.create_qubit_readout_pulse(
         qubit, start=second_pi_half_pulse.finish
     )


### PR DESCRIPTION
The drive frequency is now updated only when a detuning is provided, which is one of the assumption of the fit. When detuning is 0 we update T2 since we expect it to be more reliable.

Now Ramsey can be used to monitor T2 in a more stable way given that the fit will include both oscillations and an exponential decay.




Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
