### PR TITLE
Circuit serialization as parameters of the tomography

### DIFF
--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -46,9 +46,10 @@ class Action:
         if self.parameters is not None:
             for param, value in self.parameters.items():
                 if type(value) is Circuit:
-                    circuit_file = open(CIRCUIT, "w")
+                    circuit_path = path / CIRCUIT
+                    circuit_file = open(circuit_path, "w")
                     json.dump(value.raw, circuit_file)
-                    self.parameters[param] = str(CIRCUIT)
+                    self.parameters[param] = str(circuit_path)
         (path / SINGLE_ACTION).write_text(yaml.safe_dump(asdict(self)))
 
     @classmethod

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -47,8 +47,7 @@ class Action:
             for param, value in self.parameters.items():
                 if type(value) is Circuit:
                     circuit_path = path / CIRCUIT
-                    circuit_file = open(circuit_path, "w")
-                    json.dump(value.raw, circuit_file)
+                    circuit_path.write_text(json.dumps(value.raw))
                     self.parameters[param] = str(circuit_path)
         (path / SINGLE_ACTION).write_text(yaml.safe_dump(asdict(self)))
 

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -1,11 +1,13 @@
 """Action execution tracker."""
 
 import copy
+import json
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, NewType, Optional, Union
 
 import yaml
+from qibo import Circuit
 from qibolab.platform import Platform
 from qibolab.qubits import QubitId, QubitPairId
 
@@ -21,6 +23,7 @@ Targets = Union[list[QubitId], list[QubitPairId], list[tuple[QubitId, ...]]]
 """Elements to be calibrated by a single protocol."""
 
 SINGLE_ACTION = "action.yml"
+CIRCUIT = "circuit.json"
 
 
 @dataclass
@@ -40,6 +43,12 @@ class Action:
 
     def dump(self, path: Path):
         """Dump single action to yaml."""
+        if self.parameters is not None:
+            for param, value in self.parameters.items():
+                if type(value) is Circuit:
+                    circuit_file = open(CIRCUIT, "w")
+                    json.dump(value.raw, circuit_file)
+                    self.parameters[param] = str(CIRCUIT)
         (path / SINGLE_ACTION).write_text(yaml.safe_dump(asdict(self)))
 
     @classmethod


### PR DESCRIPTION
This PR is a patch to solve the serialization of Circuit parameters, like in state tomographies (this happens with the scripts). Maybe a better solution would be to define a dump method specific for each parameter class and call it directly in the action dump method.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [x] Qibolab: `0.1.9`
    - [x] Qibolab_platforms_qrc: `main`
