### PR TITLE
Generalizing Mermin to n qubits and adding theta angles for plot

### DIFF
--- a/src/qibocal/protocols/two_qubit_interaction/mermin/circuits.py
+++ b/src/qibocal/protocols/two_qubit_interaction/mermin/circuits.py
@@ -12,7 +12,7 @@ def create_mermin_circuit(qubits, native=True, theta=None):
     Native defaults to only using GPI2 and GPI gates.
     """
     if not theta:
-        theta = ((n-1)*0.25*np.pi)%(2*np.pi)
+        theta = ((n - 1) * 0.25 * np.pi) % (2 * np.pi)
     # TODO: implement condition better
     # if qubits[1] != 2:
     #     raise ValueError('The center qubit should be in qubits[1]!')

--- a/src/qibocal/protocols/two_qubit_interaction/mermin/protocol.py
+++ b/src/qibocal/protocols/two_qubit_interaction/mermin/protocol.py
@@ -11,15 +11,17 @@ from ...readout_mitigation_matrix import readout_mitigation_matrix
 from ...utils import calculate_frequencies
 from .circuits import create_mermin_circuits
 from .pulses import create_mermin_sequences
-from .utils import compute_mermin
+from .utils import compute_mermin, get_mermin_polynomial, get_readout_basis, get_mermin_coefficients
 
-READOUT_BASIS = [["X", "X", "Y"], ["X", "Y", "X"], ["Y", "X", "X"], ["Y", "Y", "Y"]]
-
+MITIGATION_MATRIX_FILE = "mitigation_matrix"
+"""File where readout mitigation matrix is stored."""
 
 @dataclass
 class MerminParameters(Parameters):
     """Mermin experiment input parameters."""
 
+    ntheta: int
+    """Number of angles probed linearly between 0 and 2 pi."""
     native: Optional[bool] = False
     """If True a circuit will be created using only GPI2 and CZ gates."""
     apply_error_mitigation: Optional[bool] = False
@@ -28,12 +30,107 @@ class MerminParameters(Parameters):
 
 @dataclass
 class MerminData(Data):
-    """Mermin acquisition data."""
+    """Mermin Data structure."""
+
+    thetas: list
+    """Angles probed."""
+    data: dict[list, list, str] = field(default_factory=dict)
+    """Raw data acquired."""
+    mitigation_matrix: dict[tuple[QubitId, ...], npt.NDArray] = field(
+        default_factory=dict
+    )
+    """Mitigation matrix computed using the readout_mitigation_matrix protocol."""
+
+    def save(self, path: Path):
+        """Saving data including mitigation matrix."""
+
+        np.savez(
+            path / f"{MITIGATION_MATRIX_FILE}.npz",
+            **{
+                json.dumps((control, target)): self.mitigation_matrix[control, target]
+                for control, target, _, _, _ in self.data
+            },
+        )
+        super().save(path=path)
+
+    @classmethod
+    def load(cls, path: Path):
+        """Custom loading to acco   modate mitigation matrix"""
+        instance = super().load(path=path)
+        # load readout mitigation matrix
+        mitigation_matrix = super().load_data(
+            path=path, filename=MITIGATION_MATRIX_FILE
+        )
+        instance.mitigation_matrix = mitigation_matrix
+        return instance
+
+    def register_basis(self, targets, basis, frequencies):
+        """Store output for single qubit."""
+        n = len(targets)
+        computational_basis = [format(i, f"0{n}b") for i in range(2**n)]
+
+        # Add zero if state do not appear in state
+        # could be removed by using high number of shots
+        for i in computational_basis:
+            if i not in frequencies:
+                frequencies[i] = 0
+
+        for state, freq in frequencies.items():
+            if (targets, basis, state) in self.data:
+                self.data[targets, basis, state] = np.concatenate(
+                    (
+                        self.data[targets, basis, state],
+                        np.array([freq]),
+                    )
+                )
+            else:
+                self.data[targets, basis, state] = np.array([freq])
+
+    def merge_frequencies(self, targets, readout_basis):
+        """Merge frequencies with different measurement basis."""
+        freqs = []
+        mermin_data = {
+            (index[1], index[2]): value
+            for index, value in self.data.items()
+            if index[0] == targets
+        }
+
+        freqs = []
+        for i in readout_basis:
+            freqs.append(
+                {state[1]: value for state, value in mermin_data.items() if state[0] == i}
+            )
+
+        return freqs
+
+    @property
+    def params(self):
+        """Convert non-arrays attributes into dict."""
+        data_dict = super().params
+        data_dict.pop("mitigation_matrix")
+
+        return data_dict
 
 
 @dataclass
 class MerminResults(Results):
-    """Mermin results."""
+    """Mermin Results class."""
+
+    mermin: dict[list, float] = field(default_factory=dict)
+    """Raw Mermin value."""
+    mermin_mitigated: dict[list, float] = field(default_factory=dict)
+    """Mitigated Mermin value."""
+
+    def __contains__(self, key: list):
+        """Check if key is in class.
+
+        While key is a QubitPairId both chsh and chsh_mitigated contain
+        an additional key which represents the basis chosen.
+
+        """
+
+        return key in [(target, control) for target, control, _ in self.mermin]
+
 
 
 def _acquisition_pulses(
@@ -42,6 +139,14 @@ def _acquisition_pulses(
     targets: list[QubitId],
 ) -> MerminData:
     r"""Data acquisition for CHSH protocol using pulse sequences."""
+    
+    thetas = np.linspace(0, 2 * np.pi, params.ntheta)
+    data = CHSHData(thetas=thetas.tolist())
+
+    n = len(targets)
+    mermin_polynomial = get_mermin_polynomial(n)
+    readout_basis = get_readout_basis(mermin_polynomial)
+    mermin_coefficients = get_mermin_coefficients(mermin_polynomial)
 
     if params.apply_error_mitigation:
         mitigation_data, _ = readout_mitigation_matrix.acquisition(
@@ -53,22 +158,20 @@ def _acquisition_pulses(
         )
 
         mitigation_results, _ = readout_mitigation_matrix.fit(mitigation_data)
+        
+    for theta in thetas:
+        mermin_sequences = create_mermin_sequences(
+            platform, targets, readout_basis=readout_basis, theta=theta
+        )
+        options = ExecutionParameters(nshots=params.nshots)
 
-    mermin_sequences = create_mermin_sequences(
-        platform, targets, readout_basis=READOUT_BASIS
-    )
-    options = ExecutionParameters(nshots=params.nshots)
+        mermin_frequencies = []
+        for basis, sequence in mermin_sequences.items():
+            results = platform.execute_pulse_sequence(sequence, options=options)
+            frequencies = calculate_frequencies(results, targets)
+            data.register_basis(targets, basis, frequencies)
 
-    mermin_frequencies = []
-    for sequence in mermin_sequences:
-        results = platform.execute_pulse_sequence(sequence, options=options)
-        frequencies = calculate_frequencies(results, targets)
-        mermin_frequencies.append(frequencies)
-
-    mermin_bare = compute_mermin(frequencies=mermin_frequencies)
-    print(mermin_bare)
-
-    return MerminData()
+    return data
 
 
 def _acquisition_circuits(
@@ -77,6 +180,14 @@ def _acquisition_circuits(
     targets: list[tuple[QubitId]],
 ) -> MerminData:
     r"""Data acquisition for CHSH protocol using pulse sequences."""
+
+    thetas = np.linspace(0, 2 * np.pi, params.ntheta)
+    data = CHSHData(thetas=thetas.tolist())
+
+    n = len(targets)
+    mermin_polynomial = get_mermin_polynomial(n)
+    readout_basis = get_readout_basis(mermin_polynomial)
+    mermin_coefficients = get_mermin_coefficients(mermin_polynomial)
 
     if params.apply_error_mitigation:
         mitigation_data, _ = readout_mitigation_matrix.acquisition(
@@ -90,28 +201,133 @@ def _acquisition_circuits(
         mitigation_results, _ = readout_mitigation_matrix.fit(mitigation_data)
 
     mermin_circuits = create_mermin_circuits(
-        targets, native=params.native, readout_basis=READOUT_BASIS
+        targets, native=params.native, readout_basis=readout_basis
     )
 
-    mermin_frequencies = []
-    for circuit in mermin_circuits:
+    for basis, circuit in mermin_circuits.items():
         results = circuit(nshots=params.nshots)
-        mermin_frequencies.append(results.frequencies())
+        data.register_basis(targets, basis, results.frequencies())
+        
 
-    mermin_bare = compute_mermin(frequencies=mermin_frequencies)
+    # mermin_bare = compute_mermin(frequencies=mermin_frequencies, mermin_coefficients)
 
-    return MerminData()
-
-
-def _fit(data: MerminData) -> MerminResults:
-    return MerminResults()
+    return data
 
 
-def _plot(
-    data: MerminData, fit: MerminResults, target: tuple[QubitId, QubitId, QubitId]
-):
+def _plot(data: MerminData, fit: MerminResults, targets: list[QubitId]):
+    """Plotting function for Mermin protocol."""
+    figures = []
 
-    return [], ""
+    n = len(target)
+    classical_bound = 2**(n//2)
+    quantum_bound = 2**((n-1)/2)*(2**(n//2))
+
+    fig = go.Figure(layout_yaxis_range=[-3, 3])
+    if fit is not None:
+        fig.add_trace(
+            go.Scatter(
+                x=data.thetas,
+                y=fit.mermin[*targets], #TODO: FIX
+                name="Bare",
+            )
+        )
+        if fit.mermin_mitigated:
+            fig.add_trace(
+                go.Scatter(
+                    x=data.thetas,
+                    y=fit.mermin_mitigated[*targets], #TODO: FIX
+                    name="Mitigated",
+                )
+            )
+
+    fig.add_trace(
+        go.Scatter(
+            mode="lines",
+            x=data.thetas,
+            y=[+classical_bound] * len(data.thetas),
+            line_color="gray",
+            name="Classical limit",
+            line_dash="dash",
+            legendgroup="classic",
+        )
+    )
+
+    fig.add_trace(
+        go.Scatter(
+            mode="lines",
+            x=data.thetas,
+            y=[-classical_bound] * len(data.thetas),
+            line_color="gray",
+            name="Classical limit",
+            legendgroup="classic",
+            line_dash="dash",
+            showlegend=False,
+        )
+    )
+
+    fig.add_trace(
+        go.Scatter(
+            mode="lines",
+            x=data.thetas,
+            y=[+quantum_bound] * len(data.thetas),
+            line_color="gray",
+            name="Quantum limit",
+            legendgroup="quantum",
+        )
+    )
+
+    fig.add_trace(
+        go.Scatter(
+            mode="lines",
+            x=data.thetas,
+            y=[-quantum_bound] * len(data.thetas),
+            line_color="gray",
+            name="Quantum limit",
+            legendgroup="quantum",
+            showlegend=False,
+        )
+    )
+
+    fig.update_layout(
+        xaxis_title="Theta [rad]",
+        yaxis_title="Mermin polynomial value",
+        xaxis=dict(range=[min(data.thetas), max(data.thetas)]),
+    )
+    figures.append(fig)
+
+    return figures, ""
+
+
+def _fit(data: CHSHData) -> CHSHResults:
+    """Fitting for CHSH protocol."""
+    results = {}
+    mitigated_results = {}
+    freq = data.merge_frequencies(data.targets)
+    n = len(data.targets)
+
+    if data.mitigation_matrix:
+        matrix = data.mitigation_matrix[pair]
+        mitigated_freq_list = []
+        for freq_basis in freq:
+            mitigated_freq = {format(i, f"0{n}b"): [] for i in range(2**n)}
+            for i in range(len(data.thetas)):
+                freq_array = np.zeros(2**n)
+                for k, v in freq_basis.items():
+                    freq_array[int(k, 2)] = v[i]
+                freq_array = freq_array.reshape(-1, 1)
+                for j, val in enumerate(matrix @ freq_array):
+                    mitigated_freq[format(j, f"0{n}b")].append(float(val))
+            mitigated_freq_list.append(mitigated_freq)
+    results[data.targets] = [
+        compute_mermin(freq, mermin_coefficients, l) for l in range(len(data.thetas))
+    ]
+
+    if data.mitigation_matrix:
+        mitigated_results[data.targets] = [
+            compute_mermin(mitigated_freq_list, mermin_coefficients, l)
+            for l in range(len(data.thetas))
+        ]
+    return MerminResults(mermin=results, mermin_mitigated=mitigated_results)
 
 
 mermin_pulses = Routine(_acquisition_pulses, _fit, _plot)

--- a/src/qibocal/protocols/two_qubit_interaction/mermin/protocol.py
+++ b/src/qibocal/protocols/two_qubit_interaction/mermin/protocol.py
@@ -11,10 +11,16 @@ from ...readout_mitigation_matrix import readout_mitigation_matrix
 from ...utils import calculate_frequencies
 from .circuits import create_mermin_circuits
 from .pulses import create_mermin_sequences
-from .utils import compute_mermin, get_mermin_polynomial, get_readout_basis, get_mermin_coefficients
+from .utils import (
+    compute_mermin,
+    get_mermin_coefficients,
+    get_mermin_polynomial,
+    get_readout_basis,
+)
 
 MITIGATION_MATRIX_FILE = "mitigation_matrix"
 """File where readout mitigation matrix is stored."""
+
 
 @dataclass
 class MerminParameters(Parameters):
@@ -98,7 +104,11 @@ class MerminData(Data):
         freqs = []
         for i in readout_basis:
             freqs.append(
-                {state[1]: value for state, value in mermin_data.items() if state[0] == i}
+                {
+                    state[1]: value
+                    for state, value in mermin_data.items()
+                    if state[0] == i
+                }
             )
 
         return freqs
@@ -132,14 +142,13 @@ class MerminResults(Results):
         return key in [(target, control) for target, control, _ in self.mermin]
 
 
-
 def _acquisition_pulses(
     params: MerminParameters,
     platform: Platform,
     targets: list[QubitId],
 ) -> MerminData:
     r"""Data acquisition for CHSH protocol using pulse sequences."""
-    
+
     thetas = np.linspace(0, 2 * np.pi, params.ntheta)
     data = CHSHData(thetas=thetas.tolist())
 
@@ -158,7 +167,7 @@ def _acquisition_pulses(
         )
 
         mitigation_results, _ = readout_mitigation_matrix.fit(mitigation_data)
-        
+
     for theta in thetas:
         mermin_sequences = create_mermin_sequences(
             platform, targets, readout_basis=readout_basis, theta=theta
@@ -207,7 +216,6 @@ def _acquisition_circuits(
     for basis, circuit in mermin_circuits.items():
         results = circuit(nshots=params.nshots)
         data.register_basis(targets, basis, results.frequencies())
-        
 
     # mermin_bare = compute_mermin(frequencies=mermin_frequencies, mermin_coefficients)
 
@@ -219,15 +227,15 @@ def _plot(data: MerminData, fit: MerminResults, targets: list[QubitId]):
     figures = []
 
     n = len(target)
-    classical_bound = 2**(n//2)
-    quantum_bound = 2**((n-1)/2)*(2**(n//2))
+    classical_bound = 2 ** (n // 2)
+    quantum_bound = 2 ** ((n - 1) / 2) * (2 ** (n // 2))
 
     fig = go.Figure(layout_yaxis_range=[-3, 3])
     if fit is not None:
         fig.add_trace(
             go.Scatter(
                 x=data.thetas,
-                y=fit.mermin[*targets], #TODO: FIX
+                y=fit.mermin[*targets],  # TODO: FIX
                 name="Bare",
             )
         )
@@ -235,7 +243,7 @@ def _plot(data: MerminData, fit: MerminResults, targets: list[QubitId]):
             fig.add_trace(
                 go.Scatter(
                     x=data.thetas,
-                    y=fit.mermin_mitigated[*targets], #TODO: FIX
+                    y=fit.mermin_mitigated[*targets],  # TODO: FIX
                     name="Mitigated",
                 )
             )

--- a/src/qibocal/protocols/two_qubit_interaction/mermin/protocol.py
+++ b/src/qibocal/protocols/two_qubit_interaction/mermin/protocol.py
@@ -1,4 +1,3 @@
-import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
@@ -6,20 +5,11 @@ from typing import Optional
 import numpy as np
 import numpy.typing as npt
 import plotly.graph_objects as go
-from qibo.backends import GlobalBackend
 from qibolab import ExecutionParameters
 from qibolab.platform import Platform
-from qibolab.qubits import QubitId, QubitPairId
+from qibolab.qubits import QubitId
 
 from qibocal.auto.operation import Data, Parameters, Results, Routine
-from qibocal.auto.transpile import dummy_transpiler, execute_transpiled_circuit
-from qibocal.config import log
-
-from ...readout_mitigation_matrix import (
-    ReadoutMitigationMatrixParameters as mitigation_params,
-)
-from ...readout_mitigation_matrix import _acquisition as mitigation_acquisition
-from ...readout_mitigation_matrix import _fit as mitigation_fit
 
 from ...readout_mitigation_matrix import readout_mitigation_matrix
 from ...utils import calculate_frequencies
@@ -59,7 +49,7 @@ class MerminData(Data):
     mitigation_matrix: dict[tuple[QubitId, ...], npt.NDArray] = field(
         default_factory=dict
     )
-    targets=None
+    targets = None
     """Mitigation matrix computed using the readout_mitigation_matrix protocol."""
 
     def save(self, path: Path):
@@ -74,7 +64,6 @@ class MerminData(Data):
         #     },
         # )
         # super().save(path=path)
-    
 
     @classmethod
     def load(cls, path: Path):
@@ -338,13 +327,12 @@ def _fit(data: MerminData) -> MerminResults:
     """Fitting for CHSH protocol."""
     results = {}
     mitigated_results = {}
-    
+
     n = len(data.targets)
     mermin_polynomial = get_mermin_polynomial(n)
     readout_basis = get_readout_basis(mermin_polynomial)
     mermin_coefficients = get_mermin_coefficients(mermin_polynomial)
     freq = data.merge_frequencies(data.targets, readout_basis)
-
 
     if data.mitigation_matrix:
         matrix = data.mitigation_matrix[pair]

--- a/src/qibocal/protocols/two_qubit_interaction/mermin/pulses.py
+++ b/src/qibocal/protocols/two_qubit_interaction/mermin/pulses.py
@@ -17,11 +17,12 @@ def create_mermin_sequence(platform, qubits, theta=None):
     for qubit in qubits:
         sequence.add(
             platform.create_RX90_pulse(
-                qubit[0], start=0, relative_phase=virtual_z_phases[qubit] + np.pi / 2
+                qubit, start=0, relative_phase=virtual_z_phases[qubit] + np.pi / 2
             )
         )
 
     # TODO: Not hardcode topology
+    # print(qubits)
 
     # qubits[0] needs to be the center qubit where everything is connected
     for i in range(1, len(qubits)):
@@ -58,6 +59,7 @@ def create_mermin_sequences(platform, qubits, readout_basis, theta):
             platform, qubits, theta=theta
         )
         t = sequence.finish
+        # print(basis)
         for i, base in enumerate(basis):
             if base == "X":
                 sequence.add(

--- a/src/qibocal/protocols/two_qubit_interaction/mermin/pulses.py
+++ b/src/qibocal/protocols/two_qubit_interaction/mermin/pulses.py
@@ -4,66 +4,55 @@ import numpy as np
 from qibolab.pulses import PulseSequence
 
 
-def create_mermin_sequence(platform, qubits):
+def create_mermin_sequence(platform, qubits, theta=None):
     """Creates the pulse sequence to generate the bell states and with a theta-measurement"""
+    
+    n = len(qubits)
+    if not theta:
+        theta = ((n-1)*0.25*np.pi)%(2*np.pi)
 
     virtual_z_phases = defaultdict(int)
     sequence = PulseSequence()
 
-    sequence.add(
-        platform.create_RX90_pulse(qubits[0], start=0, relative_phase=np.pi / 2)
-    )
-    sequence.add(
-        platform.create_RX90_pulse(qubits[1], start=0, relative_phase=np.pi / 2)
-    )
-    sequence.add(
-        platform.create_RX90_pulse(qubits[2], start=0, relative_phase=np.pi / 2)
-    )
-
-    (cz_sequence1, cz_virtual_z_phases) = platform.create_CZ_pulse_sequence(
-        qubits[0:2], sequence.finish
-    )
-    sequence.add(cz_sequence1)
-    for qubit in cz_virtual_z_phases:
-        virtual_z_phases[qubit] += cz_virtual_z_phases[qubit]
-
-    (cz_sequence2, cz_virtual_z_phases) = platform.create_CZ_pulse_sequence(
-        qubits[1:3], sequence.finish + 16  # why 16
-    )
-    sequence.add(cz_sequence2)
-    for qubit in cz_virtual_z_phases:
-        virtual_z_phases[qubit] += cz_virtual_z_phases[qubit]
-
-    t = sequence.finish + 16
-
-    sequence.add(
-        platform.create_RX90_pulse(
-            qubits[0],
-            start=t,
-            relative_phase=virtual_z_phases[qubits[0]] - np.pi / 2,
+    for qubit in qubits:
+        sequence.add(
+            platform.create_RX90_pulse(qubit[0], start=0, relative_phase=virtual_z_phases[qubit]+np.pi / 2)
         )
-    )
 
-    sequence.add(
-        platform.create_RX90_pulse(
-            qubits[2],
-            start=t,
-            relative_phase=virtual_z_phases[qubits[2]] - np.pi / 2,
+    # TODO: Not hardcode topology
+
+    # qubits[0] needs to be the center qubit where everything is connected
+    for i in range(1, len(qubits)):
+        (cz_sequence1, cz_virtual_z_phases) = platform.create_CZ_pulse_sequence(
+            [qubits[0]]+[qubits[i]], sequence.finish+8
         )
-    )
+        sequence.add(cz_sequence1)
+        for qubit in cz_virtual_z_phases:
+            virtual_z_phases[qubit] += cz_virtual_z_phases[qubit]
 
-    virtual_z_phases[qubits[0]] -= np.pi / 2
+    t = sequence.finish + 8
+
+    for i in range(1, len(qubits)):
+        sequence.add(
+            platform.create_RX90_pulse(
+                qubits[i],
+                start=t,
+                relative_phase=virtual_z_phases[qubits[i]] - np.pi / 2,
+            )
+        )
+
+    virtual_z_phases[qubits[0]] -= theta
 
     return sequence, virtual_z_phases
 
 
-def create_mermin_sequences(platform, qubits, readout_basis):
+def create_mermin_sequences(platform, qubits, readout_basis, theta):
     """Creates the pulse sequences needed for the 4 measurement settings for chsh."""
 
-    mermin_sequences = []
+    mermin_sequences = {}
 
     for basis in readout_basis:
-        sequence, virtual_z_phases = create_mermin_sequence(platform, qubits)
+        sequence, virtual_z_phases = create_mermin_sequence(platform, qubits, theta=theta)
         t = sequence.finish
         for i, base in enumerate(basis):
             if base == "X":
@@ -87,6 +76,6 @@ def create_mermin_sequences(platform, qubits, readout_basis):
         for qubit in qubits:
             MZ_pulse = platform.create_MZ_pulse(qubit, start=measurement_start)
             sequence.add(MZ_pulse)
-        mermin_sequences.append(sequence)
+        mermin_sequences[basis] = sequence
 
     return mermin_sequences

--- a/src/qibocal/protocols/two_qubit_interaction/mermin/pulses.py
+++ b/src/qibocal/protocols/two_qubit_interaction/mermin/pulses.py
@@ -6,17 +6,19 @@ from qibolab.pulses import PulseSequence
 
 def create_mermin_sequence(platform, qubits, theta=None):
     """Creates the pulse sequence to generate the bell states and with a theta-measurement"""
-    
+
     n = len(qubits)
     if not theta:
-        theta = ((n-1)*0.25*np.pi)%(2*np.pi)
+        theta = ((n - 1) * 0.25 * np.pi) % (2 * np.pi)
 
     virtual_z_phases = defaultdict(int)
     sequence = PulseSequence()
 
     for qubit in qubits:
         sequence.add(
-            platform.create_RX90_pulse(qubit[0], start=0, relative_phase=virtual_z_phases[qubit]+np.pi / 2)
+            platform.create_RX90_pulse(
+                qubit[0], start=0, relative_phase=virtual_z_phases[qubit] + np.pi / 2
+            )
         )
 
     # TODO: Not hardcode topology
@@ -24,7 +26,7 @@ def create_mermin_sequence(platform, qubits, theta=None):
     # qubits[0] needs to be the center qubit where everything is connected
     for i in range(1, len(qubits)):
         (cz_sequence1, cz_virtual_z_phases) = platform.create_CZ_pulse_sequence(
-            [qubits[0]]+[qubits[i]], sequence.finish+8
+            [qubits[0]] + [qubits[i]], sequence.finish + 8
         )
         sequence.add(cz_sequence1)
         for qubit in cz_virtual_z_phases:
@@ -52,7 +54,9 @@ def create_mermin_sequences(platform, qubits, readout_basis, theta):
     mermin_sequences = {}
 
     for basis in readout_basis:
-        sequence, virtual_z_phases = create_mermin_sequence(platform, qubits, theta=theta)
+        sequence, virtual_z_phases = create_mermin_sequence(
+            platform, qubits, theta=theta
+        )
         t = sequence.finish
         for i, base in enumerate(basis):
             if base == "X":

--- a/src/qibocal/protocols/two_qubit_interaction/mermin/utils.py
+++ b/src/qibocal/protocols/two_qubit_interaction/mermin/utils.py
@@ -36,7 +36,8 @@ def get_mermin_polynomial(n):
 
 def get_readout_basis(mermin_polynomial):
     return [
-        "".join([factor.name[0] for factor in term.factors]) for term in mermin_polynomial.terms
+        "".join([factor.name[0] for factor in term.factors])
+        for term in mermin_polynomial.terms
     ]
 
 

--- a/src/qibocal/protocols/two_qubit_interaction/mermin/utils.py
+++ b/src/qibocal/protocols/two_qubit_interaction/mermin/utils.py
@@ -1,13 +1,18 @@
-from qibo.symbols import X, Y
 from qibo.hamiltonians import SymbolicHamiltonian
+from qibo.symbols import X, Y
+
 
 def compute_mermin(frequencies, mermin_coefficients, i):
     """Computes the chsh inequality out of the frequencies of the 4 circuits executed."""
-    assert len(frequencies)==len(mermin_coefficients)
+    assert len(frequencies) == len(mermin_coefficients)
     m = 0
     for j, freq in enumerate(frequencies):
         for key in freq.keys():
-            m += mermin_coefficients[j] * freq[key][i] * (-1) ** (sum([int(key[k]) for k in range(len(key))]))
+            m += (
+                mermin_coefficients[j]
+                * freq[key][i]
+                * (-1) ** (sum([int(key[k]) for k in range(len(key))]))
+            )
     nshots = sum(freq[x] for x in freq)
     try:
         return m / nshots
@@ -17,20 +22,22 @@ def compute_mermin(frequencies, mermin_coefficients, i):
 
 
 def get_mermin_polynomial(n):
-    assert n>1
+    assert n > 1
     m0 = X(0)
     m0p = Y(0)
     for i in range(1, n):
-        mn = m0*(X(i)+Y(i))+m0p*(X(i)-Y(i))
-        mnp = m0*(Y(i)-X(i))+m0p*(X(i)+Y(i))
+        mn = m0 * (X(i) + Y(i)) + m0p * (X(i) - Y(i))
+        mnp = m0 * (Y(i) - X(i)) + m0p * (X(i) + Y(i))
         m0 = mn.expand()
         m0p = mnp.expand()
-    m = m0/2**((n-1)//2)
+    m = m0 / 2 ** ((n - 1) // 2)
     return SymbolicHamiltonian(m.expand())
 
 
 def get_readout_basis(mermin_polynomial):
-    return [[factor.name[0] for factor in term.factors] for term in mermin_polynomial.terms]            
+    return [
+        [factor.name[0] for factor in term.factors] for term in mermin_polynomial.terms
+    ]
 
 
 def get_mermin_coefficients(mermin_polynomial):

--- a/src/qibocal/protocols/two_qubit_interaction/mermin/utils.py
+++ b/src/qibocal/protocols/two_qubit_interaction/mermin/utils.py
@@ -13,7 +13,7 @@ def compute_mermin(frequencies, mermin_coefficients, i):
                 * freq[key][i]
                 * (-1) ** (sum([int(key[k]) for k in range(len(key))]))
             )
-    nshots = sum(freq[x] for x in freq)
+    nshots = sum(freq[x][i] for x in freq)
     try:
         return m / nshots
     except ZeroDivisionError:
@@ -36,7 +36,7 @@ def get_mermin_polynomial(n):
 
 def get_readout_basis(mermin_polynomial):
     return [
-        [factor.name[0] for factor in term.factors] for term in mermin_polynomial.terms
+        "".join([factor.name[0] for factor in term.factors]) for term in mermin_polynomial.terms
     ]
 
 


### PR DESCRIPTION
Push for the generalization of Mermin to any number of qubits and adding an angle theta that controls the violation.

This will override the other Mermin pull request (#770) when it is completed.

The model for this experiment is the CHSH protocol, as the output should be very similar: a plot with the Mermin value at different angles to track the violation.

I have based myself on those functions for this Mermin generalization, but I am sure there are things to be polished regarding pure qibocal code. Please @Edoardo-Pedicillo and @andrea-pasquale lend me a hand with that.