### PR TITLE
coupler_chevron improvements

### DIFF
--- a/src/qibocal/protocols/couplers/coupler_chevron.py
+++ b/src/qibocal/protocols/couplers/coupler_chevron.py
@@ -129,7 +129,7 @@ def _aquisition(
 
 
 def _fit(data: ChevronData) -> Results:
-    """ "Results for ChevronCouplers."""
+    """Results for ChevronCouplers."""
     return Results()
 
 

--- a/src/qibocal/protocols/couplers/coupler_chevron.py
+++ b/src/qibocal/protocols/couplers/coupler_chevron.py
@@ -112,6 +112,7 @@ def _aquisition(
             results[ordered_pair[0]].probability(state=1),
             results[ordered_pair[1]].probability(state=1),
         )
+    data.label = "Probability of state |1>"
 
     return data
 

--- a/src/qibocal/protocols/couplers/coupler_chevron.py
+++ b/src/qibocal/protocols/couplers/coupler_chevron.py
@@ -15,7 +15,7 @@ from ..two_qubit_interaction.chevron.chevron import (
 from ..two_qubit_interaction.utils import order_pair
 
 
-def _aquisition(
+def _acquisition(
     params: ChevronParameters,
     platform: Platform,
     targets: list[QubitPairId],
@@ -137,5 +137,5 @@ def plot(data: ChevronData, fit: Results, target):
     return _plot(data, None, target)
 
 
-coupler_chevron = Routine(_aquisition, _fit, plot, two_qubit_gates=True)
+coupler_chevron = Routine(_acquisition, _fit, plot, two_qubit_gates=True)
 """Coupler cz/swap flux routine."""

--- a/src/qibocal/protocols/two_qubit_interaction/chevron/chevron.py
+++ b/src/qibocal/protocols/two_qubit_interaction/chevron/chevron.py
@@ -109,6 +109,9 @@ class ChevronData(Data):
     """Sweetspot value for high frequency qubit."""
     data: dict[QubitPairId, npt.NDArray[ChevronType]] = field(default_factory=dict)
 
+    label: Optional[str] = None
+    """Label for the data."""
+
     def register_qubit(self, low_qubit, high_qubit, length, amp, prob_low, prob_high):
         """Store output for single qubit."""
         size = len(length) * len(amp)
@@ -308,7 +311,7 @@ def _plot(data: ChevronData, fit: ChevronResults, target: QubitPairId):
     fig.update_layout(
         xaxis_title="Duration [ns]",
         xaxis2_title="Duration [ns]",
-        yaxis_title="Amplitude [a.u.]",
+        yaxis_title=data.label or "Amplitude [a.u.]",
         legend=dict(orientation="h"),
     )
     fig.update_layout(

--- a/tests/runcards/protocols_couplers.yml
+++ b/tests/runcards/protocols_couplers.yml
@@ -66,7 +66,7 @@ actions:
       duration_min: 50
       duration_max: 100
       duration_step: 10
-      native_gate: "CZ"
+      native: "CZ"
       dt: 5
       nshots: 10
 
@@ -81,6 +81,6 @@ actions:
       duration_min: 50
       duration_max: 100
       duration_step: 10
-      native_gate: "iSWAP"
+      native: "iSWAP"
       dt: 5
       nshots: 10


### PR DESCRIPTION
- Run acquisition in DISCRIMINATION mode. This makes it easier to interpret the results of the experiment.
- Sweeps the qubit flux pulse duration as well (in tandem with coupler flux pulse duration).


<img width="991" alt="image" src="https://github.com/user-attachments/assets/da9ff46b-afe6-44be-b9bc-8dc4242b0072">
