### PR TITLE
Removing virtual phase from CZ routine, as it might interfere with the calibration of the virtual phase

### DIFF
--- a/src/qibocal/protocols/two_qubit_interaction/optimize.py
+++ b/src/qibocal/protocols/two_qubit_interaction/optimize.py
@@ -164,7 +164,6 @@ def _acquisition(
             for setup in ("I", "X"):
                 (
                     sequence,
-                    virtual_z_phase,
                     theta_pulse,
                     amplitude,
                     data.durations[ord_pair],

--- a/src/qibocal/protocols/two_qubit_interaction/optimize.py
+++ b/src/qibocal/protocols/two_qubit_interaction/optimize.py
@@ -112,8 +112,6 @@ class OptimizeTwoQubitGateData(Data):
     """Angles swept."""
     native: str = "CZ"
     """Native two qubit gate."""
-    vphases: dict[QubitPairId, dict[QubitId, float]] = field(default_factory=dict)
-    """Virtual phases for each qubit."""
     amplitudes: dict[tuple[QubitId, QubitId], float] = field(default_factory=dict)
     """"Amplitudes swept."""
     durations: dict[tuple[QubitId, QubitId], float] = field(default_factory=dict)
@@ -181,7 +179,6 @@ def _acquisition(
                     params.parking,
                     params.flux_pulse_amplitude_min,
                 )
-                data.vphases[ord_pair] = dict(virtual_z_phase)
                 theta = np.arange(
                     params.theta_start,
                     params.theta_end,
@@ -208,7 +205,7 @@ def _acquisition(
 
                 sweeper_theta = Sweeper(
                     Parameter.relative_phase,
-                    theta - data.vphases[ord_pair][target_q],
+                    theta,
                     pulses=[theta_pulse],
                     type=SweeperType.ABSOLUTE,
                 )
@@ -246,7 +243,7 @@ def _acquisition(
                     target_q,
                     control_q,
                     setup,
-                    theta - data.vphases[ord_pair][target_q],
+                    theta,
                     data.amplitudes[ord_pair],
                     data.durations[ord_pair],
                     result_control,
@@ -293,7 +290,7 @@ def _fit(
                     try:
                         popt, _ = curve_fit(
                             fit_function,
-                            np.array(data.thetas) - data.vphases[ord_pair][target],
+                            np.array(data.thetas),
                             target_data,
                             p0=pguess,
                             bounds=(

--- a/src/qibocal/protocols/two_qubit_interaction/virtual_z_phases.py
+++ b/src/qibocal/protocols/two_qubit_interaction/virtual_z_phases.py
@@ -143,12 +143,12 @@ def create_sequence(
     theta_pulse = platform.create_RX90_pulse(
         target_qubit,
         start=flux_sequence.finish + dt,
-        relative_phase=virtual_z_phase[target_qubit],
+        relative_phase=0,
     )
     RX_pulse_end = platform.create_RX_pulse(
         control_qubit,
         start=flux_sequence.finish + dt,
-        relative_phase=virtual_z_phase[control_qubit],
+        relative_phase=0,
     )
     measure_target = platform.create_qubit_readout_pulse(
         target_qubit, start=theta_pulse.finish

--- a/src/qibocal/protocols/two_qubit_interaction/virtual_z_phases_signal.py
+++ b/src/qibocal/protocols/two_qubit_interaction/virtual_z_phases_signal.py
@@ -75,7 +75,6 @@ def _acquisition(
             for setup in ("I", "X"):
                 (
                     sequence,
-                    virtual_z_phase,
                     theta_pulse,
                     data.amplitudes[ord_pair],
                     data.durations[ord_pair],
@@ -90,7 +89,6 @@ def _acquisition(
                     params.parking,
                     params.flux_pulse_amplitude,
                 )
-                data.vphases[ord_pair] = dict(virtual_z_phase)
                 theta = np.arange(
                     params.theta_start,
                     params.theta_end,


### PR DESCRIPTION
Just removing the virtual phases set in the creation of the CZ gate from the routine. 

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Compatibility with Qibo modules (Please edit this section if the current pull request is not compatible with the following branches).
    - [ ] Qibo: `master`
    - [ ] Qibolab: `main`
    - [ ] Qibolab_platforms_qrc: `main`
