### PR TITLE
in chsh_circuits, measure qubits simultaneously

### DIFF
--- a/src/qibocal/protocols/readout_mitigation_matrix.py
+++ b/src/qibocal/protocols/readout_mitigation_matrix.py
@@ -134,7 +134,7 @@ def _acquisition(
                 for q, bit in enumerate(state):
                     if bit == "1":
                         c.add(gates.X(qubits[q]))
-                    c.add(gates.M(qubits[q]))
+                c.add(gates.M(*[qubits[i] for i in range(len(state))]))
                 _, results = execute_transpiled_circuit(
                     c, qubit_map, backend, nshots=params.nshots, transpiler=transpiler
                 )

--- a/src/qibocal/protocols/two_qubit_interaction/chsh/circuits.py
+++ b/src/qibocal/protocols/two_qubit_interaction/chsh/circuits.py
@@ -93,7 +93,6 @@ def create_chsh_circuits(
                     c.add(gates.GPI2(qubits[i], p[i] + np.pi / 2))
                 else:
                     c.add(gates.H(qubits[i]))
-        for qubit in qubits:
-            c.add(gates.M(qubit))
+        c.add(gates.M(*qubits))
         chsh_circuits[basis] = c
     return chsh_circuits


### PR DESCRIPTION
In principle, https://github.com/qiboteam/qibolab/pull/1096 should address the issue of `chsh_circuits` producing different results compared to `chsh_pulses`*, however in the definitions of experiments it is still good to explicitly have qubits measured at once/in one circuit moment.


\* The discrepancy is clearly visible in this two reports: [chsh_pulses](http://login.qrccluster.com:9000/WPLE0h22TGSJb9ynR70azg==/), [chsh_circuits](http://login.qrccluster.com:9000/6p6EaKgYRlyd1UGJXaxUwA==/)
