### PR TITLE
`platform.connect()` when running CHSH with error mitigation

### DIFF
--- a/src/qibocal/protocols/two_qubit_interaction/chsh/protocol.py
+++ b/src/qibocal/protocols/two_qubit_interaction/chsh/protocol.py
@@ -180,6 +180,7 @@ def _acquisition_pulses(
         )
         mitigation_results = mitigation_fit(mitigation_data)
 
+    platform.connect()
     for pair in targets:
         if params.apply_error_mitigation:
             try:


### PR DESCRIPTION
Ports the fix of https://github.com/qiboteam/qibocal/blob/293e2a9105568026bb2ee2a94062b381aa8c34bc/src/qibocal/protocols/two_qubit_interaction/mermin/protocol.py#L99
in CHSH, because the platform is disconnected after the error mitigation routine (due to circuit execution).