### PR TITLE
conditional and virtual phase experiment improvements

### DIFF
--- a/src/qibocal/protocols/two_qubit_interaction/optimize.py
+++ b/src/qibocal/protocols/two_qubit_interaction/optimize.py
@@ -409,7 +409,7 @@ def _plot(
                     y=amps,
                     z=cz,
                     zmin=np.pi / 2,
-                    zmax=3 * np.pi / 2,
+                    zmax=np.pi,
                     name="{fit.native} angle",
                     colorbar_x=-0.1,
                     colorscale="RdBu",

--- a/src/qibocal/protocols/two_qubit_interaction/virtual_z_phases.py
+++ b/src/qibocal/protocols/two_qubit_interaction/virtual_z_phases.py
@@ -98,8 +98,7 @@ def create_sequence(
     native: str,
     parking: bool,
     dt: float,
-    amplitude: float = None,
-    duration: float = None,
+    flux_pulse_max_duration: float = None,
 ) -> tuple[
     PulseSequence,
     dict[QubitId, Pulse],
@@ -118,11 +117,10 @@ def create_sequence(
         start=max(Y90_pulse.finish, RX_pulse_start.finish),
     )
 
-    if amplitude is not None:
-        flux_sequence.get_qubit_pulses(ordered_pair[1])[0].amplitude = amplitude
-
-    if duration is not None:
-        flux_sequence.get_qubit_pulses(ordered_pair[1])[0].duration = duration
+    if flux_pulse_max_duration is not None:
+        flux_sequence.get_qubit_pulses(ordered_pair[1])[
+            0
+        ].duration = flux_pulse_max_duration
     theta_pulse = platform.create_RX90_pulse(
         target_qubit,
         start=flux_sequence.finish + dt,

--- a/src/qibocal/protocols/two_qubit_interaction/virtual_z_phases_signal.py
+++ b/src/qibocal/protocols/two_qubit_interaction/virtual_z_phases_signal.py
@@ -75,9 +75,8 @@ def _acquisition(
             for setup in ("I", "X"):
                 (
                     sequence,
+                    _,
                     theta_pulse,
-                    data.amplitudes[ord_pair],
-                    data.durations[ord_pair],
                 ) = create_sequence(
                     platform,
                     setup,
@@ -87,7 +86,6 @@ def _acquisition(
                     params.native,
                     params.dt,
                     params.parking,
-                    params.flux_pulse_amplitude,
                 )
                 theta = np.arange(
                     params.theta_start,

--- a/tests/runcards/protocols.yml
+++ b/tests/runcards/protocols.yml
@@ -796,8 +796,6 @@ actions:
       theta_start: 0
       theta_end: 180
       theta_step: 10
-      flux_pulse_amplitude: 0.5
-      flux_pulse_duration: 10
       dt: 0
       native: iSWAP
       parking: True
@@ -809,8 +807,6 @@ actions:
       theta_start: 0
       theta_end: 180
       theta_step: 10
-      flux_pulse_amplitude: 0.5
-      flux_pulse_duration: 10
       native: iSWAP
       dt: 0
       parking: True
@@ -822,8 +818,6 @@ actions:
       theta_start: 0
       theta_end: 180
       theta_step: 10
-      flux_pulse_amplitude: 0.5
-      flux_pulse_duration: 10
       dt: 0
       native: CZ
       parking: True
@@ -835,8 +829,6 @@ actions:
       theta_start: 0
       theta_end: 180
       theta_step: 10
-      flux_pulse_amplitude: 0.5
-      flux_pulse_duration: 10
       native: CZ
       dt: 0
       parking: True


### PR DESCRIPTION
- Remove parameters `flux_pulse_amplitude` and `flux_pulse_duration` from the experiment `correct_virtual_z_phases`. I think they are not usefull - nobody is going to manually try out various combinations of these parameters to find a good one. There is the `optimize_two_qubit_gate` for this type of task.
  - BTW, `flux_pulse_duration` was not even used, it was ignored and always the flux pulse duration from platform was used.
- Get rid of the `amplitude` argument of the `create_sequence` function (as a consequence of the change in the above point). Rename the `duration` argument to `flux_pulse_max_duration` - this is needed for the optimize routine to make sure there is enough room for the duration sweep, and the flux pulse does not overlap with readout (this is different from `dt`, which is just a constant offset, not dependent on values used for sweep). 
- Change the return content of the `create_sequence` function. Now it return the sequence, reference to the flux pulse, reference to the theta pulse.
- Move the code for fitting a sinusoid to a separate function, so that it is reused instead of duplicated.
- And, the reason all of this started, the phase difference between two sinusoids is now calculated in a manner, that it is normalized in the [0, pi] range, and does not cause large jumps because of angle fluctuations close to boundary values (0 and pi).:
  - before:  <img width="1026" alt="image" src="https://github.com/user-attachments/assets/898d0862-321e-46e5-8244-630d8c8c47fe" />
  - after: <img width="597" alt="image" src="https://github.com/user-attachments/assets/9cdab8cf-a2a5-4bf4-b813-a39258bdec62" />