### PR TITLE
Small fixes for qutrits protocols

### DIFF
--- a/src/qibocal/protocols/qubit_spectroscopy_ef.py
+++ b/src/qibocal/protocols/qubit_spectroscopy_ef.py
@@ -84,9 +84,9 @@ def _acquisition(
         qd12_channel, qd12_pulse = natives.RX12()[0]
         ro_channel, ro_pulse = natives.MZ()[0]
 
-        qd_pulse = replace(qd_pulse, duration=params.drive_duration)
+        qd12_pulse = replace(qd12_pulse, duration=params.drive_duration)
         if params.drive_amplitude is not None:
-            qd_pulse = replace(qd_pulse, amplitude=params.drive_amplitude)
+            qd12_pulse = replace(qd12_pulse, amplitude=params.drive_amplitude)
 
         amplitudes[qubit] = qd12_pulse.amplitude
         ro_pulses[qubit] = ro_pulse
@@ -104,7 +104,7 @@ def _acquisition(
             Sweeper(
                 parameter=Parameter.frequency,
                 values=platform.config(qd12_channel).frequency + delta_frequency_range,
-                channels=[qd_channel],
+                channels=[qd12_channel],
             )
         )
 

--- a/src/qibocal/protocols/qutrit_classification.py
+++ b/src/qibocal/protocols/qutrit_classification.py
@@ -168,7 +168,7 @@ def _plot(
     target: QubitId,
     fit: QutritClassificationResults,
 ):
-    figures = plot_results(data, target, 3, fit)
+    figures = plot_results(data, target, 3, None)
     fitting_report = ""
     return figures, fitting_report
 


### PR DESCRIPTION
In this PR I'm adjusting a few issues which I found in some qutrits related protocols.

- Adjusting the amplitude and the duration of the drive12 pulse in `qubit_spectroscopy_ef`
- Sweeping over the correct channel in the same protocol
- Putting `None` as fit in the plotting method for the qubit spectroscopy

Here is a report with the corrected protocols http://login.qrccluster.com:9000/IpYZZKreQ3C4fObr4W68Mg==/