### PR TITLE
fix incorrect handeling of dimensions in data  processing

### DIFF
--- a/src/qibocal/protocols/readout_optimization/resonator_frequency.py
+++ b/src/qibocal/protocols/readout_optimization/resonator_frequency.py
@@ -141,9 +141,9 @@ def _acquisition(
             states = []
             for i, results in enumerate([results_0, results_1]):
                 result = results[ro_pulses[qubit].serial]
-                i_values.extend(result.voltage_i[k])
-                q_values.extend(result.voltage_q[k])
-                states.extend([i] * len(result.voltage_i[k]))
+                i_values.extend(result.voltage_i[:, k])
+                q_values.extend(result.voltage_q[:, k])
+                states.extend([i] * len(result.voltage_i[:, k]))
 
             model = QubitFit()
             model.fit(np.stack((i_values, q_values), axis=-1), np.array(states))


### PR DESCRIPTION
We fixed the incorrect handling of the dimensions in the data processing of the readout frequency optimization experiment.
Before fix: http://login.qrccluster.com:9000/fm9khE2vSOe4PD3Az8uywQ==
After fix: http://login.qrccluster.com:9000/viE48NXFS6ySplY9syja9Q==

