### PR TITLE
Update in serialize.load method. 

### DIFF
--- a/src/qibocal/auto/serialize.py
+++ b/src/qibocal/auto/serialize.py
@@ -18,15 +18,15 @@ def serialize(raw: dict):
     }
 
 
+def _nested_list_to_tuples(raw):
+    """Convert nested lists to nested tuples."""
+    if isinstance(raw, list):
+        return tuple([_nested_list_to_tuples(item) for item in raw])
+    return raw
+
+
 # TODO: distinguish between tuples and strings
 def load(key):
     """Evaluate key converting string of lists to tuples."""
     raw_load = json.loads(key)
-
-    def to_tuple(raw):
-        if isinstance(raw, list):
-            return tuple([to_tuple(item) for item in raw])
-        else:
-            return raw
-
-    return to_tuple(raw_load)
+    return _nested_list_to_tuples(raw_load)

--- a/src/qibocal/auto/serialize.py
+++ b/src/qibocal/auto/serialize.py
@@ -22,10 +22,11 @@ def serialize(raw: dict):
 def load(key):
     """Evaluate key converting string of lists to tuples."""
     raw_load = json.loads(key)
+
     def to_tuple(raw):
         if isinstance(raw, list):
             return tuple([to_tuple(item) for item in raw])
         else:
             return raw
-        
+
     return to_tuple(raw_load)

--- a/src/qibocal/auto/serialize.py
+++ b/src/qibocal/auto/serialize.py
@@ -22,6 +22,10 @@ def serialize(raw: dict):
 def load(key):
     """Evaluate key converting string of lists to tuples."""
     raw_load = json.loads(key)
-    if isinstance(raw_load, list):
-        return tuple(raw_load)
-    return raw_load
+    def to_tuple(raw):
+        if isinstance(raw, list):
+            return tuple([to_tuple(item) for item in raw])
+        else:
+            return raw
+        
+    return to_tuple(raw_load)


### PR DESCRIPTION
Currently, when the data key is a tuple (for instance when a QubitPairID is used as key in the stored data) the Jason keys are stored as "[['q1','q2'], 'some_key', 'some_other_key']". This then gets converted into a tuple as (['q1','q2'], 'some_key', ...) . This immediatly generates an error since the first item, a list, is unhashable and therefore cannot be used as a key in the dictionary. Instead, any nested list in the keys need to also be converted to a tuple.