### PR TITLE
Attempt to close #919

### DIFF
--- a/src/qibocal/auto/execute.py
+++ b/src/qibocal/auto/execute.py
@@ -120,12 +120,19 @@ class Executor:
         protocol: Routine,
         parameters: Action,
         mode: ExecutionMode = AUTOCALIBRATION,
+        output: Optional[Path] = None,
     ) -> Completed:
         """Run single protocol in ExecutionMode mode."""
         task = Task(action=parameters, operation=protocol)
         log.info(f"Executing mode {mode} on {task.action.id}.")
-
-        completed = task.run(platform=self.platform, targets=self.targets, mode=mode)
+        completed = task.run(
+            platform=self.platform,
+            targets=self.targets,
+            mode=mode,
+            folder=self.history.task_path(
+                self.history._pending_task_id(task.id), output
+            ),
+        )
         self.history.push(completed)
 
         # TODO: drop, as the conditions won't be necessary any longer, and then it could

--- a/src/qibocal/auto/output.py
+++ b/src/qibocal/auto/output.py
@@ -193,8 +193,7 @@ class Output:
         self._export_stats()
         (path / META).write_text(json.dumps(self.meta.dump(), indent=4))
 
-        # dump tasks
-        self.history.flush(path)
+        self.history.flush()
 
         # update platform
         if self.platform is not None:
@@ -247,13 +246,14 @@ class Output:
                 and completed.results is not None
             ):
                 raise KeyError(f"{task_id} already contains fitting results.")
-
             # TODO: this is a plain hack, to be fixed together with the task lifecycle
-            # refactor
             self.history._tasks[task_id.id][task_id.iteration] = completed.task.run(
-                platform=self.platform, mode=mode, folder=completed.path
+                platform=self.platform,
+                mode=mode,
+                folder=self.history.task_path(
+                    self.history._executed_task_id(task_id.id), output
+                ),
             )
-            self.history.flush(output)
-
+            self.history.flush()
             if update and completed.task.update:
                 completed.update_platform(platform=self.platform)

--- a/src/qibocal/auto/runcard.py
+++ b/src/qibocal/auto/runcard.py
@@ -63,6 +63,7 @@ class Runcard:
                 protocol=getattr(protocols, action.operation),
                 parameters=action,
                 mode=mode,
+                output=output,
             )
-            instance.history.flush(output)
+            history.flush()
         return instance.history

--- a/src/qibocal/protocols/resonator_spectroscopy.py
+++ b/src/qibocal/protocols/resonator_spectroscopy.py
@@ -150,14 +150,14 @@ class ResonatorSpectroscopyData(Data):
     will apply a minus to the phase data."""
     data: dict[QubitId, npt.NDArray[ResSpecType]] = field(default_factory=dict)
     """Raw data acquired."""
-    power_level: Optional[PowerLevel] = None
+    power_level: Optional[PowerLevel] = PowerLevel.low
     """Power regime of the resonator."""
 
     @classmethod
     def load(cls, path):
         obj = super().load(path)
         # Instantiate PowerLevel object
-        if obj.power_level is not None:  # pylint: disable=E1101
+        if hasattr(obj, "power_level"):  # pylint: disable=E1101
             obj.power_level = PowerLevel(obj.power_level)  # pylint: disable=E1101
         return obj
 

--- a/src/qibocal/protocols/state_tomography.py
+++ b/src/qibocal/protocols/state_tomography.py
@@ -72,10 +72,11 @@ class StateTomographyData(Data):
 
     @classmethod
     def load(cls, path):
-        circuit = Circuit.from_dict(json.loads((path / CIRCUIT_PATH).read_text()))
-        data = super().load_data(path, DATAFILE)
-        params = super().load_params(path, DATAFILE)
-        return cls(data=data, circuit=circuit, targets=params["targets"])
+        if (path / CIRCUIT_PATH).exists():
+            circuit = Circuit.from_dict(json.loads((path / CIRCUIT_PATH).read_text()))
+            data = super().load_data(path, DATAFILE)
+            params = super().load_params(path, DATAFILE)
+            return cls(data=data, circuit=circuit, targets=params["targets"])
 
 
 @dataclass

--- a/src/qibocal/protocols/two_qubit_state_tomography.py
+++ b/src/qibocal/protocols/two_qubit_state_tomography.py
@@ -60,11 +60,12 @@ class StateTomographyData(Data):
 
     @classmethod
     def load(cls, path):
-        return cls(
-            data=super().load_data(path, DATAFILE),
-            ideal=super().load_data(path, SIMULATED_DENSITY_MATRIX),
-            simulated=QuantumState.load(path / "simulated.json"),
-        )
+        if (path / "simulated.json").exists():
+            return cls(
+                data=super().load_data(path, DATAFILE),
+                ideal=super().load_data(path, SIMULATED_DENSITY_MATRIX),
+                simulated=QuantumState.load(path / "simulated.json"),
+            )
 
 
 @dataclass

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -38,7 +38,7 @@ def fake_output(tmp_path: Path) -> tuple[Output, Path]:
     executor = Executor(
         history=History(), targets=list(platform.qubits), platform=platform
     )
-    executor.run_protocol(flipping, ACTION, mode=ExecutionMode.ACQUIRE)
+    executor.run_protocol(flipping, ACTION, mode=ExecutionMode.ACQUIRE, output=tmp_path)
     meta.end()
     platform.disconnect()
     output.history = executor.history


### PR DESCRIPTION
Initial attempt to close #919.
I know that in theory this is breaking the initial proposal in which `task.run` should not directly perform the dumping, however since both acquisition and fitting are performed there in order to dump the data before performing the post-processing I didn't see another valid solution.
