### PR TITLE
Fix flux_gate protocol sweeper

### DIFF
--- a/src/qibocal/protocols/coherence/t1.py
+++ b/src/qibocal/protocols/coherence/t1.py
@@ -10,7 +10,7 @@ from qibocal.auto.operation import Data, QubitId, Routine
 from qibocal.calibration import CalibrationPlatform
 from qibocal.result import probability
 
-from ..utils import table_dict, table_html
+from ..utils import COLORBAND, COLORBAND_LINE, table_dict, table_html
 from . import t1_signal, utils
 
 
@@ -122,8 +122,8 @@ def _plot(data: T1Data, target: QubitId, fit: T1Results = None):
                 x=np.concatenate((waits, waits[::-1])),
                 y=np.concatenate((probs + error_bars, (probs - error_bars)[::-1])),
                 fill="toself",
-                fillcolor=utils.COLORBAND,
-                line=dict(color=utils.COLORBAND_LINE),
+                fillcolor=COLORBAND,
+                line=dict(color=COLORBAND_LINE),
                 showlegend=True,
                 name="Errors",
             ),

--- a/src/qibocal/protocols/coherence/utils.py
+++ b/src/qibocal/protocols/coherence/utils.py
@@ -6,15 +6,12 @@ from scipy.optimize import curve_fit
 from qibocal.auto.operation import QubitId
 from qibocal.config import log
 
-from ..utils import chi2_reduced, table_dict, table_html
+from ..utils import COLORBAND, COLORBAND_LINE, chi2_reduced, table_dict, table_html
 
 CoherenceType = np.dtype(
     [("wait", np.float64), ("signal", np.float64), ("phase", np.float64)]
 )
 """Custom dtype for coherence routines."""
-
-COLORBAND = "rgba(0,100,80,0.2)"
-COLORBAND_LINE = "rgba(255,255,255,0)"
 
 
 def average_single_shots(data_type, single_shots):

--- a/src/qibocal/protocols/flux_gate.py
+++ b/src/qibocal/protocols/flux_gate.py
@@ -19,6 +19,7 @@ from qibolab import (
 
 from qibocal.auto.operation import Data, Parameters, QubitId, Results, Routine
 
+from ..result import probability
 from .ramsey.utils import fitting, ramsey_fit
 from .utils import GHZ_TO_HZ, table_dict, table_html
 
@@ -92,7 +93,7 @@ def _acquisition(
             envelope=Rectangular(),
         )
         drive_delay = Delay(duration=flux_pulses[qubit].duration)
-        ro_delay = Delay(duration=flux_pulses[qubit].duration + 2 * rx90.duration)
+        ro_delay = Delay(duration=flux_pulses[qubit].duration)
         qubit_sequence.extend(
             [
                 (drive_channel, rx90),
@@ -100,10 +101,8 @@ def _acquisition(
                 (flux_channel, flux_pulses[qubit]),
                 (drive_channel, drive_delay),
                 (drive_channel, rx90),
-                (
-                    ro_channel,
-                    ro_delay,
-                ),
+                (ro_channel, ro_delay),
+                (ro_channel, Delay(duration=2 * rx90.duration)),
                 (ro_channel, ro_pulse),
             ]
         )
@@ -118,7 +117,7 @@ def _acquisition(
     options = dict(
         nshots=params.nshots,
         acquisition_type=AcquisitionType.DISCRIMINATION,
-        averaging_mode=AveragingMode.CYCLIC,
+        averaging_mode=AveragingMode.SINGLESHOT,
     )
 
     results = platform.execute([sequence], [[sweeper]], **options)
@@ -130,7 +129,7 @@ def _acquisition(
             (qubit),
             dict(
                 duration=duration_range,
-                prob_1=results[ro_pulse.id],
+                prob_1=probability(results[ro_pulse.id], state=1),
             ),
         )
 

--- a/src/qibocal/protocols/rabi/utils.py
+++ b/src/qibocal/protocols/rabi/utils.py
@@ -125,7 +125,7 @@ def plot_probabilities(data, qubit, fit, rx90):
     qubit_data = data[qubit]
     probs = qubit_data.prob
     error_bars = qubit_data.error
-
+    print(error_bars)
     rabi_parameters = getattr(qubit_data, quantity)
     fig = go.Figure(
         [

--- a/src/qibocal/protocols/rabi/utils.py
+++ b/src/qibocal/protocols/rabi/utils.py
@@ -125,7 +125,6 @@ def plot_probabilities(data, qubit, fit, rx90):
     qubit_data = data[qubit]
     probs = qubit_data.prob
     error_bars = qubit_data.error
-    print(error_bars)
     rabi_parameters = getattr(qubit_data, quantity)
     fig = go.Figure(
         [

--- a/src/qibocal/protocols/ramsey/ramsey.py
+++ b/src/qibocal/protocols/ramsey/ramsey.py
@@ -11,7 +11,7 @@ from qibocal.calibration import CalibrationPlatform
 from qibocal.config import log
 from qibocal.result import probability
 
-from ..utils import chi2_reduced, table_dict, table_html
+from ..utils import COLORBAND, COLORBAND_LINE, chi2_reduced, table_dict, table_html
 from .ramsey_signal import (
     RamseySignalData,
     RamseySignalParameters,
@@ -19,9 +19,6 @@ from .ramsey_signal import (
     _update,
 )
 from .utils import fitting, process_fit, ramsey_fit, ramsey_sequence
-
-COLORBAND = "rgba(0,100,80,0.2)"
-COLORBAND_LINE = "rgba(255,255,255,0)"
 
 
 @dataclass

--- a/src/qibocal/protocols/ramsey/ramsey_zz.py
+++ b/src/qibocal/protocols/ramsey/ramsey_zz.py
@@ -11,10 +11,8 @@ from qibocal.calibration import CalibrationPlatform
 from ...auto.operation import QubitId, Routine
 from ...config import log
 from ...result import probability
-from ..utils import table_dict, table_html
+from ..utils import COLORBAND, COLORBAND_LINE, table_dict, table_html
 from .ramsey import (
-    COLORBAND,
-    COLORBAND_LINE,
     RamseySignalData,
     RamseySignalParameters,
     RamseySignalResults,


### PR DESCRIPTION
This PR addresses an error in the duration sweeper of the flux_gate protocol.
I've also decided to add error bars to the plot and I've removed some duplicate variables `COLORBAND` and `COLORBANDLINE`.

Here is the updated protocol: http://login.qrccluster.com:9000/_YxzqVClTsSys8iO4ap53w==/ 