### PR TITLE
Readout optimization with QND

### DIFF
--- a/tests/platforms/mock/calibration.json
+++ b/tests/platforms/mock/calibration.json
@@ -4,7 +4,8 @@
             "resonator": {
                 "bare_frequency": 0.0,
                 "dressed_frequency": null,
-                "depletion_time": 0
+                "depletion_time": 0,
+                "bare_frequency_amplitude": null
             },
             "qubit": {
                 "frequency_01": 4000000000.0,
@@ -20,6 +21,8 @@
             },
             "readout": {
                 "fidelity": 0.0,
+                "coupling": null,
+                "effective_temperature": null,
                 "ground_state": [
                     0.0,
                     1.0
@@ -27,16 +30,20 @@
                 "excited_state": [
                     1.0,
                     0.0
-                ]
-
+                ],
+                "qudits_frequency": {}
             },
+            "t1": null,
+            "t2": null,
+            "t2_spin_echo": null,
             "rb_fidelity": null
         },
         "1": {
             "resonator": {
                 "bare_frequency": 0.0,
                 "dressed_frequency": 4900000000.0,
-                "depletion_time": 0
+                "depletion_time": 0,
+                "bare_frequency_amplitude": null
             },
             "qubit": {
                 "frequency_01": 4200000000.0,
@@ -52,6 +59,8 @@
             },
             "readout": {
                 "fidelity": 0.0,
+                "coupling": null,
+                "effective_temperature": null,
                 "ground_state": [
                     0.25,
                     0.0
@@ -64,12 +73,22 @@
                     "1": 6100000000.0
                 }
             },
+            "t1": null,
+            "t2": null,
+            "t2_spin_echo": null,
             "rb_fidelity": null
         }
     },
     "two_qubits": {
         "0-1": {
-            "rb_fidelity": [0.99, 0.01]
+            "rb_fidelity": [
+                0.99,
+                0.01
+            ],
+            "cz_fidelity": null,
+            "coupling": null
         }
-    }
+    },
+    "readout_mitigation_matrix": null,
+    "flux_crosstalk_matrix": null
 }

--- a/tests/platforms/mock/parameters.json
+++ b/tests/platforms/mock/parameters.json
@@ -1,348 +1,347 @@
 {
-  "settings": {
-    "nshots": 1024,
-    "relaxation_time": 0
-  },
-  "configs": {
-    "dummy/bounds": {
-      "kind": "bounds",
-      "waveforms": 0,
-      "readout": 0,
-      "instructions": 0
+    "settings": {
+        "nshots": 1024,
+        "relaxation_time": 0
     },
-    "0/drive": {
-      "kind": "iq",
-      "frequency": 4000000000.0
-    },
-    "1/drive": {
-      "kind": "iq",
-      "frequency": 4200000000.0
-    },
-    "0/drive12": {
-      "kind": "iq",
-      "frequency": 4700000000.0
-    },
-    "1/drive12": {
-      "kind": "iq",
-      "frequency": 4855663000.0
-    },
-    "0/flux": {
-      "kind": "dc-filter",
-      "offset": -0.1,
-      "filter": []
-    },
-    "1/flux": {
-      "kind": "dc-filter",
-      "offset": 0.0,
-      "filter": []
-    },
-
-    "0/probe": {
-      "kind": "iq",
-      "frequency": 7200000000.0
-    },
-    "1/probe": {
-      "kind": "iq",
-      "frequency": 7400000000.0
-    },
-    "0/acquisition": {
-      "kind": "acquisition",
-      "delay": 0.0,
-      "smearing": 0.0,
-      "threshold": 0.0,
-      "iq_angle": 0.0,
-      "kernel": "k05VTVBZAQB2AHsnZGVzY3InOiAnPGY4JywgJ2ZvcnRyYW5fb3JkZXInOiBGYWxzZSwgJ3NoYXBlJzogKDEwLCksIH0gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAp5sDfS7uHlP2DIMKNvnKc/gCqN8KV/pT94FQCYYJC3PzSbwfi/894/APwg6C61rj8MSN3blizAP2ha9unQYsM/+BFjHTxcwT+gXaJazvbpPw=="
-    },
-    "1/acquisition": {
-      "kind": "acquisition",
-      "delay": 0.0,
-      "smearing": 0.0,
-      "threshold": 0.0,
-      "iq_angle": 0.0,
-      "kernel": "k05VTVBZAQB2AHsnZGVzY3InOiAnPGY4JywgJ2ZvcnRyYW5fb3JkZXInOiBGYWxzZSwgJ3NoYXBlJzogKDEwLCksIH0gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAr4dT6V5tHrP1w+JhHImN8/sPePZeSUuj/4yTKrD5fRP/ysonZip98/6GJMAPV9xD/LTiJo4k7oP96aWXpxduU/6fUxETe/7z9GXEBNGebWPw=="
-    },
-    "coupler_01/flux": {
-      "kind": "dc-filter",
-      "offset": 0.0,
-      "filter": []
-    },
-    "twpa_pump": {
-      "kind": "oscillator",
-      "frequency": 1000000000.0,
-      "power": 10.0
-    },
-    "0/drive_lo": {
+    "configs": {
+        "dummy/bounds": {
+            "kind": "bounds",
+            "waveforms": 0.0,
+            "readout": 0,
+            "instructions": 0
+        },
+        "0/drive": {
+            "kind": "iq",
+            "frequency": 4000000000.0
+        },
+        "1/drive": {
+            "kind": "iq",
+            "frequency": 4200000000.0
+        },
+        "0/drive12": {
+            "kind": "iq",
+            "frequency": 4700000000.0
+        },
+        "1/drive12": {
+            "kind": "iq",
+            "frequency": 4855663000.0
+        },
+        "0/flux": {
+            "kind": "dc-filter",
+            "offset": -0.1,
+            "filter": []
+        },
+        "1/flux": {
+            "kind": "dc-filter",
+            "offset": 0.0,
+            "filter": []
+        },
+        "0/probe": {
+            "kind": "iq",
+            "frequency": 7175000000.0
+        },
+        "1/probe": {
+            "kind": "iq",
+            "frequency": 7400000000.0
+        },
+        "0/acquisition": {
+            "kind": "acquisition",
+            "delay": 0.0,
+            "smearing": 0.0,
+            "threshold": 0.0,
+            "iq_angle": 0.0,
+            "kernel": "k05VTVBZAQB2AHsnZGVzY3InOiAnPGY4JywgJ2ZvcnRyYW5fb3JkZXInOiBGYWxzZSwgJ3NoYXBlJzogKDEwLCksIH0gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAp5sDfS7uHlP2DIMKNvnKc/gCqN8KV/pT94FQCYYJC3PzSbwfi/894/APwg6C61rj8MSN3blizAP2ha9unQYsM/+BFjHTxcwT+gXaJazvbpPw=="
+        },
+        "1/acquisition": {
+            "kind": "acquisition",
+            "delay": 0.0,
+            "smearing": 0.0,
+            "threshold": 0.0,
+            "iq_angle": 0.0,
+            "kernel": "k05VTVBZAQB2AHsnZGVzY3InOiAnPGY4JywgJ2ZvcnRyYW5fb3JkZXInOiBGYWxzZSwgJ3NoYXBlJzogKDEwLCksIH0gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAr4dT6V5tHrP1w+JhHImN8/sPePZeSUuj/4yTKrD5fRP/ysonZip98/6GJMAPV9xD/LTiJo4k7oP96aWXpxduU/6fUxETe/7z9GXEBNGebWPw=="
+        },
+        "coupler_01/flux": {
+            "kind": "dc-filter",
+            "offset": 0.0,
+            "filter": []
+        },
+        "twpa_pump": {
             "kind": "oscillator",
-            "frequency": 4900000000,
-            "power": 0
-    },
-    "1/drive_lo": {
+            "frequency": 1000000000.0,
+            "power": 10.0
+        },
+        "0/drive_lo": {
             "kind": "oscillator",
-            "frequency": 4900000000,
-            "power": 0
-    },
-    "01/probe_lo": {
+            "frequency": 4900000000.0,
+            "power": 0.0
+        },
+        "1/drive_lo": {
             "kind": "oscillator",
-            "frequency": 7000000000,
-            "power": 0
-    }
-
-  },
-  "native_gates": {
-    "single_qubit": {
-      "0": {
-        "RX": [
-          [
-            "0/drive",
-            {
-              "duration": 40,
-              "amplitude": 0.1,
-              "envelope": {
-                "kind": "gaussian",
-                "rel_sigma": 0.2
-              },
-              "relative_phase": 0.0,
-              "kind": "pulse"
-            }
-          ]
-        ],
-        "RX90": [
-          [
-            "0/drive",
-            {
-              "duration": 40,
-              "amplitude": 0.05,
-              "envelope": {
-                "kind": "gaussian",
-                "rel_sigma": 0.2
-              },
-              "relative_phase": 0.0,
-              "kind": "pulse"
-            }
-          ]
-        ],
-        "RX12": [
-          [
-            "0/drive12",
-            {
-              "duration": 40.0,
-              "amplitude": 0.005,
-              "envelope": {
-                "kind": "gaussian",
-                "rel_sigma": 0.2
-              },
-              "relative_phase": 0.0,
-              "kind": "pulse"
-            }
-          ]
-        ],
-        "MZ": [
-          [
-            "0/acquisition",
-            {
-              "kind": "readout",
-              "acquisition": {
-                "kind": "acquisition",
-                "duration": 2000.0
-              },
-              "probe": {
-                "duration": 2000.0,
-                "amplitude": 0.1,
-                "envelope": {
-                  "kind": "gaussian_square",
-                  "rel_sigma": 0.2,
-                  "width": 0.75
-                },
-                "relative_phase": 0.0,
-                "kind": "pulse"
-              }
-            }
-          ]
-        ],
-        "CP": null
-      },
-      "1": {
-        "RX": [
-          [
-            "1/drive",
-            {
-              "duration": 40.0,
-              "amplitude": 0.3,
-              "envelope": {
-                "kind": "drag",
-                "rel_sigma": 0.2,
-                "beta": 0.02
-              },
-              "relative_phase": 0.0,
-              "kind": "pulse"
-            }
-          ]
-        ],
-        "RX90": [
-          [
-            "1/drive",
-            {
-              "duration": 40.0,
-              "amplitude": 0.15,
-              "envelope": {
-                "kind": "drag",
-                "rel_sigma": 0.2,
-                "beta": 0.02
-              },
-              "relative_phase": 0.0,
-              "kind": "pulse"
-            }
-          ]
-        ],
-        "RX12": [
-          [
-            "1/drive12",
-            {
-              "duration": 40.0,
-              "amplitude": 0.3,
-              "envelope": {
-                "kind": "drag",
-                "rel_sigma": 0.2,
-                "beta": 0.02
-              },
-              "relative_phase": 0.0,
-              "kind": "pulse"
-            }
-          ]
-        ],
-        "MZ": [
-          [
-            "1/acquisition",
-            {
-              "kind": "readout",
-              "acquisition": {
-                "kind": "acquisition",
-                "duration": 2000.0
-              },
-              "probe": {
-                "duration": 2000.0,
-                "amplitude": 0.1,
-                "envelope": {
-                  "kind": "gaussian_square",
-                  "rel_sigma": 0.2,
-                  "width": 0.75
-                },
-                "relative_phase": 0.0,
-                "kind": "pulse"
-              }
-            }
-          ]
-        ],
-        "CP": null
-      }
+            "frequency": 4900000000.0,
+            "power": 0.0
+        },
+        "01/probe_lo": {
+            "kind": "oscillator",
+            "frequency": 7000000000.0,
+            "power": 0.0
+        }
     },
-    "two_qubit": {
-      "0-1": {
-        "CZ": [
-          [
-            "1/flux",
-            {
-              "duration": 30.0,
-              "amplitude": 0.05,
-              "envelope": {
-                "kind": "gaussian_square",
-                "rel_sigma": 0.2,
-                "width": 0.75
-              },
-              "relative_phase": 0.0,
-              "kind": "pulse"
+    "native_gates": {
+        "single_qubit": {
+            "0": {
+                "RX": [
+                    [
+                        "0/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 40.0,
+                            "amplitude": 0.1,
+                            "envelope": {
+                                "kind": "gaussian",
+                                "rel_sigma": 0.2
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "RX90": [
+                    [
+                        "0/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 40.0,
+                            "amplitude": 0.05,
+                            "envelope": {
+                                "kind": "gaussian",
+                                "rel_sigma": 0.2
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "RX12": [
+                    [
+                        "0/drive12",
+                        {
+                            "kind": "pulse",
+                            "duration": 40.0,
+                            "amplitude": 0.005,
+                            "envelope": {
+                                "kind": "gaussian",
+                                "rel_sigma": 0.2
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "MZ": [
+                    [
+                        "0/acquisition",
+                        {
+                            "kind": "readout",
+                            "acquisition": {
+                                "kind": "acquisition",
+                                "duration": 2000.0
+                            },
+                            "probe": {
+                                "kind": "pulse",
+                                "duration": 2000.0,
+                                "amplitude": 0.2,
+                                "envelope": {
+                                    "kind": "gaussian_square",
+                                    "rel_sigma": 0.2,
+                                    "width": 0.75
+                                },
+                                "relative_phase": 0.0
+                            }
+                        }
+                    ]
+                ],
+                "CP": null
+            },
+            "1": {
+                "RX": [
+                    [
+                        "1/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 40.0,
+                            "amplitude": 0.3,
+                            "envelope": {
+                                "kind": "drag",
+                                "rel_sigma": 0.2,
+                                "beta": 0.02
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "RX90": [
+                    [
+                        "1/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 40.0,
+                            "amplitude": 0.15,
+                            "envelope": {
+                                "kind": "drag",
+                                "rel_sigma": 0.2,
+                                "beta": 0.02
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "RX12": [
+                    [
+                        "1/drive12",
+                        {
+                            "kind": "pulse",
+                            "duration": 40.0,
+                            "amplitude": 0.3,
+                            "envelope": {
+                                "kind": "drag",
+                                "rel_sigma": 0.2,
+                                "beta": 0.02
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "MZ": [
+                    [
+                        "1/acquisition",
+                        {
+                            "kind": "readout",
+                            "acquisition": {
+                                "kind": "acquisition",
+                                "duration": 2000.0
+                            },
+                            "probe": {
+                                "kind": "pulse",
+                                "duration": 2000.0,
+                                "amplitude": 0.1,
+                                "envelope": {
+                                    "kind": "gaussian_square",
+                                    "rel_sigma": 0.2,
+                                    "width": 0.75
+                                },
+                                "relative_phase": 0.0
+                            }
+                        }
+                    ]
+                ],
+                "CP": null
             }
-          ],
-          [
-            "0/drive",
-            {
-              "phase": 0.0,
-              "kind": "virtualz"
+        },
+        "coupler": {},
+        "two_qubit": {
+            "0-1": {
+                "CZ": [
+                    [
+                        "1/flux",
+                        {
+                            "kind": "pulse",
+                            "duration": 30.0,
+                            "amplitude": 0.05,
+                            "envelope": {
+                                "kind": "gaussian_square",
+                                "rel_sigma": 0.2,
+                                "width": 0.75
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ],
+                    [
+                        "0/drive",
+                        {
+                            "kind": "virtualz",
+                            "phase": 0.0
+                        }
+                    ],
+                    [
+                        "1/drive",
+                        {
+                            "kind": "virtualz",
+                            "phase": 0.0
+                        }
+                    ],
+                    [
+                        "coupler_01/flux",
+                        {
+                            "kind": "pulse",
+                            "duration": 30.0,
+                            "amplitude": 0.05,
+                            "envelope": {
+                                "kind": "gaussian_square",
+                                "rel_sigma": 0.2,
+                                "width": 0.75
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "CNOT": [
+                    [
+                        "1/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 40.0,
+                            "amplitude": 0.3,
+                            "envelope": {
+                                "kind": "drag",
+                                "rel_sigma": 0.2,
+                                "beta": 0.02
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "iSWAP": [
+                    [
+                        "1/flux",
+                        {
+                            "kind": "pulse",
+                            "duration": 30.0,
+                            "amplitude": 0.05,
+                            "envelope": {
+                                "kind": "gaussian_square",
+                                "rel_sigma": 0.2,
+                                "width": 0.75
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ],
+                    [
+                        "0/drive",
+                        {
+                            "kind": "virtualz",
+                            "phase": 0.0
+                        }
+                    ],
+                    [
+                        "1/drive",
+                        {
+                            "kind": "virtualz",
+                            "phase": 0.0
+                        }
+                    ],
+                    [
+                        "coupler_01/flux",
+                        {
+                            "kind": "pulse",
+                            "duration": 30.0,
+                            "amplitude": 0.05,
+                            "envelope": {
+                                "kind": "gaussian_square",
+                                "rel_sigma": 0.2,
+                                "width": 0.75
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ]
             }
-          ],
-          [
-            "1/drive",
-            {
-              "phase": 0.0,
-              "kind": "virtualz"
-            }
-          ],
-          [
-            "coupler_01/flux",
-            {
-              "duration": 30.0,
-              "amplitude": 0.05,
-              "envelope": {
-                "kind": "gaussian_square",
-                "rel_sigma": 0.2,
-                "width": 0.75
-              },
-              "relative_phase": 0.0,
-              "kind": "pulse"
-            }
-          ]
-        ],
-        "CNOT": [
-          [
-            "1/drive",
-            {
-              "duration": 40.0,
-              "amplitude": 0.3,
-              "envelope": {
-                "kind": "drag",
-                "rel_sigma": 0.2,
-                "beta": 0.02
-              },
-              "relative_phase": 0.0,
-              "kind": "pulse"
-            }
-          ]
-        ],
-        "iSWAP": [
-          [
-            "1/flux",
-            {
-              "duration": 30.0,
-              "amplitude": 0.05,
-              "envelope": {
-                "kind": "gaussian_square",
-                "rel_sigma": 0.2,
-                "width": 0.75
-              },
-              "relative_phase": 0.0,
-              "kind": "pulse"
-            }
-          ],
-          [
-            "0/drive",
-            {
-              "phase": 0.0,
-              "kind": "virtualz"
-            }
-          ],
-          [
-            "1/drive",
-            {
-              "phase": 0.0,
-              "kind": "virtualz"
-            }
-          ],
-          [
-            "coupler_01/flux",
-            {
-              "duration": 30.0,
-              "amplitude": 0.05,
-              "envelope": {
-                "kind": "gaussian_square",
-                "rel_sigma": 0.2,
-                "width": 0.75
-              },
-              "relative_phase": 0.0,
-              "kind": "pulse"
-            }
-          ]
-        ]
-      }
-      }
+        }
     }
 }


### PR DESCRIPTION
I decided to open a new branch pointing at `readout_optimization02` as I also made some changes to the way I save data after acquisition, in addition to the necessary modifications for adding the QND calculation.

The goal for this PR is to come up with a protocol that optimizes the readout frequency and amplitude, considering both the `assignment_fidelity` and the quantum non-demolition-ness (QND). 

Currently, the routine optimizes the frequency and amplitude of readout pulse only with respect to the assignment fidelity and computes the QND without using this quantity for the optimization.
