### PR TITLE
Cross resonance protocol for 0.2 version

### DIFF
--- a/platforms/qutrits/calibration.json
+++ b/platforms/qutrits/calibration.json
@@ -1,0 +1,58 @@
+{
+    "single_qubits": {
+        "0": {
+            "resonator": {
+                "bare_frequency": 0.0,
+                "dressed_frequency": 5200000000.0,
+                "depletion_time": 0
+            },
+            "qubit": {
+                "frequency_01": 5000000000.0,
+                "frequency_12": 4800000000.0,
+                "maximum_frequency": 5000000000.0,
+                "asymmetry": 0.0,
+                "sweetspot": 0.0
+            },
+            "readout": {
+                "fidelity": 0.0,
+                "ground_state": [
+                    0.0,
+                    1.0
+                ],
+                "excited_state": [
+                    1.0,
+                    0.0
+                ]
+            },
+            "rb_fidelity": null
+        },
+        "1": {
+            "resonator": {
+                "bare_frequency": 0.0,
+                "dressed_frequency": 5200000000.0,
+                "depletion_time": 0
+            },
+            "qubit": {
+                "frequency_01": 4500000000.0,
+                "frequency_12": 4300000000.0,
+                "maximum_frequency": 4500000000.0,
+                "asymmetry": 0.0,
+                "sweetspot": 0.0
+            },
+            "readout": {
+                "fidelity": 0.0,
+                "ground_state": [
+                    0.0,
+                    1.0
+                ],
+                "excited_state": [
+                    1.0,
+                    0.0
+                ]
+            },
+            "rb_fidelity": null
+        }
+    },
+    "two_qubits": {
+    }
+}

--- a/platforms/qutrits/parameters.json
+++ b/platforms/qutrits/parameters.json
@@ -1,0 +1,268 @@
+{
+    "settings": {
+      "nshots": 1024,
+      "relaxation_time": 0
+    },
+    "configs": {
+      "emulator/bounds": {
+      "kind": "bounds",
+      "waveforms": 1000000,
+      "readout": 50,
+      "instructions": 200
+    },
+    "hamiltonian":{
+      "transmon_levels": 3,
+      "single_qubit": {
+        "0": {
+          "frequency": 5.0554e9,
+          "anharmonicity": -220e6,
+          "t1": {
+            "0-1": 8200
+          },
+          "t2": {
+            "0-1": 7100
+          }
+        },
+        "1": {
+          "frequency": 4.9895e9,
+          "anharmonicity": -228e6,
+          "t1": {
+            "0-1": 9700
+                    },
+          "t2": {
+            "0-1": 10030
+          }
+        }
+      },
+      "pairs":{
+        "0-1": {
+          "coupling": 7.44e6
+        }
+      },
+      "kind": "hamiltonian"
+    },
+      "0/drive": {
+        "kind": "drive-emulator",
+        "frequency": 5.0554e9,
+        "rabi_frequency": 20e6,
+        "scale_factor": 10
+      },
+      "01/drive": {
+        "kind": "drive-emulator",
+        "frequency": 4e9,
+        "rabi_frequency": 20e6,
+        "scale_factor": 10
+
+      },
+      "0/drive12": {
+        "kind": "drive-emulator",
+        "frequency": 4.8354e9,
+        "rabi_frequency": 20e6,
+        "scale_factor": 10
+      },
+      "1/drive": {
+        "kind": "drive-emulator",
+        "frequency": 4.9895e9,
+        "rabi_frequency": 20e6,
+        "scale_factor": 10
+      },
+      "1/drive12": {
+        "kind": "drive-emulator",
+        "frequency": 4.7615e9,
+        "rabi_frequency": 20e6,
+        "scale_factor": 10
+      },
+    "0/probe": {
+      "kind": "iq",
+      "frequency": 5200000000.0
+    },
+    "0/acquisition": {
+      "kind": "acquisition",
+      "delay": 0.0,
+      "smearing": 0.0,
+      "threshold": 0.0,
+      "iq_angle": 0.0,
+      "kernel": null
+    },
+    "1/probe": {
+      "kind": "iq",
+      "frequency": 5200000000.0
+    },
+    "1/acquisition": {
+      "kind": "acquisition",
+      "delay": 0.0,
+      "smearing": 0.0,
+      "threshold": 0.0,
+      "iq_angle": 0.0,
+      "kernel": null
+    }
+    },
+    "native_gates": {
+      "single_qubit": {
+        "0": {
+          "RX": [
+            [
+              "0/drive",
+              {
+                "duration": 40,
+                "amplitude": 0.105387,
+                "envelope": {
+                  "kind": "drag",
+                  "rel_sigma": 0.25,
+                  "beta": -0.1
+                },
+                "relative_phase": 0.0,
+                "kind": "pulse"
+              }
+            ]
+          ],
+          "RX90": [
+            [
+              "0/drive",
+              {
+                "duration": 40,
+                "amplitude": 0.0527,
+                "envelope": {
+                  "kind": "drag",
+                  "rel_sigma": 0.25,
+                  "beta": -0.1
+                },
+                "relative_phase": 0.0,
+                "kind": "pulse"
+              }
+            ]
+          ],
+          "RX12": [
+            [
+              "0/drive12",
+              {
+                "duration": 30.0,
+                "amplitude": 0.15,
+                "envelope": {
+                  "kind": "gaussian",
+                  "rel_sigma": 0.25
+                },
+                "relative_phase": 0.0,
+                "kind": "pulse"
+              }
+            ]
+          ],
+          "MZ": [
+            [
+              "0/acquisition",
+              {
+                "kind": "readout",
+                "acquisition": {
+                  "kind": "acquisition",
+                  "duration": 10.0
+                },
+                "probe": {
+                  "duration": 10.0,
+                  "amplitude": 0.1,
+                  "envelope": {
+                    "kind": "gaussian_square",
+                    "rel_sigma": 0.2,
+                    "width": 0.75
+                  },
+                  "relative_phase": 0.0,
+                  "kind": "pulse"
+                }
+              }
+            ]
+          ],
+          "CP": null
+        },
+        "1": {
+          "RX": [
+            [
+              "1/drive",
+              {
+                "duration": 40,
+                "amplitude": 0.10529,
+                "envelope": {
+                  "kind": "drag",
+                  "rel_sigma": 0.25,
+                  "beta": -0.1
+                },
+                "relative_phase": 0.0,
+                "kind": "pulse"
+              }
+            ]
+          ],
+          "RX90": [
+            [
+              "1/drive",
+              {
+                "duration": 40,
+                "amplitude": 0.05285,
+                "envelope": {
+                  "kind": "drag",
+                  "rel_sigma": 0.25,
+                  "beta": -0.1
+                },
+                "relative_phase": 0.0,
+                "kind": "pulse"
+              }
+            ]
+          ],
+          "RX12": [
+            [
+              "1/drive12",
+              {
+                "duration": 40.0,
+                "amplitude": 0.15,
+                "envelope": {
+                  "kind": "gaussian",
+                  "rel_sigma": 0.25
+                },
+                "relative_phase": 0.0,
+                "kind": "pulse"
+              }
+            ]
+          ],
+          "MZ": [
+            [
+              "1/acquisition",
+              {
+                "kind": "readout",
+                "acquisition": {
+                  "kind": "acquisition",
+                  "duration": 10.0
+                },
+                "probe": {
+                  "duration": 10.0,
+                  "amplitude": 0.1,
+                  "envelope": {
+                    "kind": "gaussian_square",
+                    "rel_sigma": 0.2,
+                    "width": 0.75
+                  },
+                  "relative_phase": 0.0,
+                  "kind": "pulse"
+                }
+              }
+            ]
+          ],
+          "CP": null
+        }
+      },
+      "two_qubit": {
+            "0-1": {
+                "CNOT": [
+                    [
+                        "01/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 110,
+                            "amplitude": 1,
+                            "envelope": {
+                                "kind": "rectangular"
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ]
+            }
+      }
+    }
+  }

--- a/platforms/qutrits/platform.py
+++ b/platforms/qutrits/platform.py
@@ -1,0 +1,42 @@
+import pathlib
+
+from qibolab import ConfigKinds
+from qibolab._core.components import IqChannel
+from qibolab._core.instruments.emulator.emulator import EmulatorController
+from qibolab._core.instruments.emulator.hamiltonians import (
+    DriveEmulatorConfig,
+    HamiltonianConfig,
+)
+from qibolab._core.platform import Platform
+from qibolab._core.qubits import Qubit, QubitPair
+
+FOLDER = pathlib.Path(__file__).parent
+
+ConfigKinds.extend([HamiltonianConfig, DriveEmulatorConfig])
+
+
+def create() -> Platform:
+    """Create a dummy platform using the dummy instrument."""
+    qubits = {}
+    pairs = {}
+    channels = {}
+
+    for q in range(2):
+        qubits[q] = qubit = Qubit.default(q, drive_qudits={(1, 2): f"{q}/drive12"})
+        channels |= {
+            qubit.drive: IqChannel(mixer=None, lo=None),
+            qubits[q].drive_qudits[1, 2]: IqChannel(mixer=None, lo=None),
+        }
+    pairs[(0, 1)] = pair = QubitPair(drive="01/drive")
+    channels |= {pair.drive: IqChannel(mixer=None, lo=None)}
+    # register the instruments
+    instruments = {
+        "dummy": EmulatorController(address="0.0.0.0", channels=channels),
+    }
+
+    return Platform.load(
+        path=FOLDER,
+        instruments=instruments,
+        qubits=qubits,
+        qubit_pairs=pairs,
+    )

--- a/src/qibocal/protocols/__init__.py
+++ b/src/qibocal/protocols/__init__.py
@@ -53,6 +53,7 @@ from .two_qubit_interaction import (
     chevron,
     chevron_signal,
     correct_virtual_z_phases,
+    cross_resonance,
     cryoscope,
     optimize_two_qubit_gate,
 )
@@ -114,4 +115,5 @@ __all__ = [
     "flux_amplitude_frequency",
     "cpmg",
     "drag_simple",
+    "cross_resonance",
 ]

--- a/src/qibocal/protocols/__init__.py
+++ b/src/qibocal/protocols/__init__.py
@@ -53,7 +53,7 @@ from .two_qubit_interaction import (
     chevron,
     chevron_signal,
     correct_virtual_z_phases,
-    cross_resonance,
+    cross_resonance_length,
     cryoscope,
     optimize_two_qubit_gate,
 )
@@ -115,5 +115,5 @@ __all__ = [
     "flux_amplitude_frequency",
     "cpmg",
     "drag_simple",
-    "cross_resonance",
+    "cross_resonance_length",
 ]

--- a/src/qibocal/protocols/two_qubit_interaction/__init__.py
+++ b/src/qibocal/protocols/two_qubit_interaction/__init__.py
@@ -1,6 +1,6 @@
 from .chevron import chevron as chevron
 from .chevron import chevron_signal as chevron_signal
-from .cr_rabi import cross_resonance as cross_resonance
+from .cross_resonance import cross_resonance_length as cross_resonance_length
 from .cryoscope import cryoscope as cryoscope
 from .optimize import optimize_two_qubit_gate as optimize_two_qubit_gate
 from .virtual_z_phases import correct_virtual_z_phases as correct_virtual_z_phases

--- a/src/qibocal/protocols/two_qubit_interaction/__init__.py
+++ b/src/qibocal/protocols/two_qubit_interaction/__init__.py
@@ -1,5 +1,6 @@
 from .chevron import chevron as chevron
 from .chevron import chevron_signal as chevron_signal
+from .cr_rabi import cross_resonance as cross_resonance
 from .cryoscope import cryoscope as cryoscope
 from .optimize import optimize_two_qubit_gate as optimize_two_qubit_gate
 from .virtual_z_phases import correct_virtual_z_phases as correct_virtual_z_phases

--- a/src/qibocal/protocols/two_qubit_interaction/cr_rabi.py
+++ b/src/qibocal/protocols/two_qubit_interaction/cr_rabi.py
@@ -1,0 +1,240 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+import numpy as np
+import numpy.typing as npt
+import plotly.graph_objects as go
+from qibolab import (
+    AcquisitionType,
+    AveragingMode,
+    Delay,
+    Parameter,
+    PulseSequence,
+    Sweeper,
+)
+
+from qibocal.auto.operation import (
+    Data,
+    Parameters,
+    QubitId,
+    QubitPairId,
+    Results,
+    Routine,
+)
+from qibocal.calibration import CalibrationPlatform
+from qibocal.result import probability
+from qibocal.update import replace
+
+CrossResonanceType = np.dtype(
+    [
+        ("prob_target", np.float64),
+        ("prob_control", np.float64),
+        ("length", np.int64),
+    ]
+)
+"""Custom dtype for resonator spectroscopy."""
+
+
+@dataclass
+class CrossResonanceParameters(Parameters):
+    """ResonatorSpectroscopy runcard inputs."""
+
+    pulse_duration_start: float
+    """Initial pi pulse duration [ns]."""
+    pulse_duration_end: float
+    """Final pi pulse duration [ns]."""
+    pulse_duration_step: float
+    """Step pi pulse duration [ns]."""
+
+    pulse_amplitude: Optional[float] = None
+    interpolated_sweeper: bool = False
+    """Use real-time interpolation if supported by instruments."""
+
+    @property
+    def duration_range(self):
+        return np.arange(
+            self.pulse_duration_start, self.pulse_duration_end, self.pulse_duration_step
+        )
+
+
+@dataclass
+class CrossResonanceResults(Results):
+    """ResonatorSpectroscopy outputs."""
+
+
+@dataclass
+class CrossResonanceData(Data):
+    """Data structure for resonator spectroscopy with attenuation."""
+
+    data: dict[QubitId, npt.NDArray[CrossResonanceType]] = field(default_factory=dict)
+    """Raw data acquired."""
+
+
+def _acquisition(
+    params: CrossResonanceParameters,
+    platform: CalibrationPlatform,
+    targets: list[QubitPairId],
+) -> CrossResonanceData:
+    """Data acquisition for resonator spectroscopy."""
+
+    data = CrossResonanceData()
+
+    for pair in targets:
+        control, target = pair
+        print("CONTROL", control)
+        print("TARGET", target)
+        pair = (control, target)
+        for setup in ["I", "X"]:
+            sequence = PulseSequence()
+            natives_control = platform.natives.single_qubit[control]
+            natives_target = platform.natives.single_qubit[target]
+            cr_channel, cr_drive_pulse = platform.natives.two_qubit[pair].CNOT()[0]
+            control_drive_channel, control_drive_pulse = natives_control.RX()[0]
+            target_drive_channel, target_drive_pulse = natives_target.RX()[0]
+            ro_channel, ro_pulse = natives_target.MZ()[0]
+            ro_channel_control, ro_pulse_control = natives_control.MZ()[0]
+            if setup == "X":
+                sequence.append((control_drive_channel, control_drive_pulse))
+                # sequence.append((target_drive_channel, target_drive_pulse))
+                sequence.append(
+                    (ro_channel, Delay(duration=control_drive_pulse.duration))
+                )
+                sequence.append(
+                    (ro_channel_control, Delay(duration=control_drive_pulse.duration))
+                )
+                sequence.append(
+                    (cr_channel, Delay(duration=control_drive_pulse.duration))
+                )
+
+            if params.pulse_amplitude is not None:
+                cr_drive_pulse = replace(
+                    cr_drive_pulse, amplitude=params.pulse_amplitude
+                )
+
+            sequence.append((cr_channel, cr_drive_pulse))
+
+            delay1 = Delay(duration=0)
+            delay2 = Delay(duration=0)
+            if params.interpolated_sweeper:
+                sequence.align([cr_channel, ro_channel, ro_pulse_control])
+            else:
+                sequence.append((ro_channel, delay1))
+                sequence.append((ro_channel_control, delay2))
+            sequence.append((ro_channel, ro_pulse))
+            sequence.append((ro_channel_control, ro_pulse_control))
+
+            # sequence, qd_pulses, delays, ro_pulses, amplitudes = sequence_length(
+            # [target],
+            # params,
+            # platform,
+            # use_align=params.interpolated_sweeper, cross_resonance=control if setup == "X" else None
+            # )
+
+            sweep_range = (
+                params.pulse_duration_start,
+                params.pulse_duration_end,
+                params.pulse_duration_step,
+            )
+            if params.interpolated_sweeper:
+                sweeper = Sweeper(
+                    parameter=Parameter.duration_interpolated,
+                    range=sweep_range,
+                    pulses=[cr_drive_pulse],
+                )
+            else:
+                sweeper = Sweeper(
+                    parameter=Parameter.duration,
+                    range=sweep_range,
+                    pulses=[cr_drive_pulse, delay1, delay2],
+                )
+
+            updates = []
+            updates.append(
+                {
+                    platform.qubit_pairs[pair].drive: {
+                        "frequency": platform.config(
+                            platform.qubits[target].drive
+                        ).frequency
+                    }
+                }
+            )
+            # execute the sweep
+            results = platform.execute(
+                [sequence],
+                [[sweeper]],
+                nshots=params.nshots,
+                relaxation_time=params.relaxation_time,
+                acquisition_type=AcquisitionType.DISCRIMINATION,
+                averaging_mode=AveragingMode.SINGLESHOT,
+                updates=updates,
+            )
+
+            # store the results
+            for q in [target]:
+                prob_target = probability(results[ro_pulse.id], state=1)
+                prob_control = probability(results[ro_pulse_control.id], state=1)
+                data.register_qubit(
+                    CrossResonanceType,
+                    (q, setup),
+                    dict(
+                        length=sweeper.values,
+                        prob_target=prob_target,
+                        prob_control=prob_control,
+                        # error=np.sqrt(prob * (1 - prob) / params.nshots).tolist(),
+                    ),
+                )
+    # finally, save the remaining data
+    return data
+
+
+def _fit(
+    data: CrossResonanceData,
+) -> CrossResonanceResults:
+    """Post-processing function for ResonatorSpectroscopy."""
+    return CrossResonanceResults()
+
+
+def _plot(data: CrossResonanceData, target: QubitPairId, fit: CrossResonanceResults):
+    """Plotting function for ResonatorSpectroscopy."""
+    # TODO: share colorbar
+
+    target_idle_data = data.data[target[1], "I"]
+    target_excited_data = data.data[target[1], "X"]
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scatter(
+            x=target_idle_data.length,
+            y=target_idle_data.prob_control,
+            name="Control at 0",
+        ),
+    )
+
+    fig.add_trace(
+        go.Scatter(
+            x=target_idle_data.length,
+            y=target_excited_data.prob_control,
+            name="Control at 1",
+        ),
+    )
+
+    fig.add_trace(
+        go.Scatter(
+            x=target_idle_data.length,
+            y=target_idle_data.prob_target,
+            name="Target when Control at 0",
+        ),
+    )
+
+    fig.add_trace(
+        go.Scatter(
+            x=target_excited_data.length,
+            y=target_excited_data.prob_target,
+            name="Target when Control at 1",
+        ),
+    )
+
+    return [fig], ""
+
+
+cross_resonance = Routine(_acquisition, _fit, _plot)
+"""CrossResonance Routine object."""

--- a/src/qibocal/protocols/two_qubit_interaction/cross_resonance/__init__.py
+++ b/src/qibocal/protocols/two_qubit_interaction/cross_resonance/__init__.py
@@ -1,0 +1,1 @@
+from .length import cross_resonance_length as cross_resonance_length


### PR DESCRIPTION
In this PR I'm planning to convert the protocols for cross-resonance to the 0.2 version.
Right now this PR includes only one routine where I sweep the duration of the cross-resonance pulse `cross_resonance_length`. 
I was able to verify the implementation of the protocol using https://github.com/qiboteam/qibolab/pull/1186 with the platform `qutrits` which I have uploaded in this PR (which is based on some parameters from IBM chips).
Here is a report with the protocol: http://login.qrccluster.com:9000/V_RjRIyXT66pwqcRvCdukQ==/