### PR TITLE
Fix `qq upload` from dalma server

### DIFF
--- a/src/qibocal/cli/upload.py
+++ b/src/qibocal/cli/upload.py
@@ -15,8 +15,8 @@ from qibocal.auto.output import META, Metadata
 
 # options for report upload
 UPLOAD_HOST = (
-    "qibocal@localhost"
-    if socket.gethostname() == "saadiyat"
+    "qibocal@saadiyat"
+    if socket.gethostname() in ("saadiyat", "dalma")
     else "qibocal@login.qrccluster.com"
 )
 TARGET_DIR = "qibocal-reports/"


### PR DESCRIPTION
`qq upload` does not work when executed from the new QRC workspace server, dalma. After discussing with @scarrazza, this should fix it. I tested and it now works for me, but it would be good if someone else confirms.