### PR TITLE
Update pyproject before release

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2775,4 +2775,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.13"
-content-hash = "3158884a48db7447cb58b68ac5f19d2d062b593a566dfc09caf778fd9b74e491"
+content-hash = "199935a15dc1e2518432b7aa7fcbd4e0af9d2530916f57a2d2e3dc667dcbcb98"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"
 qibolab = {git = "https://github.com/qiboteam/qibolab.git"}
-qibo = "^0.2.13"
+qibo = "^0.2.16"
 numpy = "^1.26.4"
 scipy = "^1.10.1"
 pandas = { version = "^2.2.2", extras = ["html"] }


### PR DESCRIPTION
Syncing Qibo version with https://github.com/qiboteam/qibolab/pull/1204.
As soon as we release Qibolab I will update the `pyproject` here to point to the new release and then we can release Qibocal as well.