### PR TITLE
Update emulator platforms

### DIFF
--- a/platforms/qubit/parameters.json
+++ b/platforms/qubit/parameters.json
@@ -27,12 +27,16 @@
     "kind": "hamiltonian"
   },
     "0/drive": {
-      "kind": "iq",
-      "frequency": 5e9
+      "kind": "drive-emulator",
+      "frequency": 5e9,
+      "rabi_frequency": 20e6,
+      "scale_factor": 10
     },
     "0/drive12": {
-      "kind": "iq",
-      "frequency": 4.8e9
+      "kind": "drive-emulator",
+      "frequency": 4.8e9,
+      "rabi_frequency": 20e6,
+      "scale_factor": 10
     },
   "0/probe": {
     "kind": "iq",
@@ -55,7 +59,7 @@
             "0/drive",
             {
               "duration": 40,
-              "amplitude": 0.1594,
+              "amplitude": 0.12698,
               "envelope": {
                 "kind": "gaussian",
                 "rel_sigma": 0.2

--- a/platforms/qubit/platform.py
+++ b/platforms/qubit/platform.py
@@ -3,13 +3,16 @@ import pathlib
 from qibolab import ConfigKinds
 from qibolab._core.components import IqChannel
 from qibolab._core.instruments.emulator.emulator import EmulatorController
-from qibolab._core.instruments.emulator.hamiltonians import HamiltonianConfig
+from qibolab._core.instruments.emulator.hamiltonians import (
+    DriveEmulatorConfig,
+    HamiltonianConfig,
+)
 from qibolab._core.platform import Platform
 from qibolab._core.qubits import Qubit
 
 FOLDER = pathlib.Path(__file__).parent
 
-ConfigKinds.extend([HamiltonianConfig])
+ConfigKinds.extend([HamiltonianConfig, DriveEmulatorConfig])
 
 
 def create() -> Platform:

--- a/platforms/qutrit/parameters.json
+++ b/platforms/qutrit/parameters.json
@@ -28,12 +28,16 @@
       "kind": "hamiltonian"
     },
       "0/drive": {
-        "kind": "iq",
-        "frequency": 5e9
+        "kind": "drive-emulator",
+        "frequency": 5e9,
+        "rabi_frequency": 20e6,
+        "scale_factor": 10
       },
       "0/drive12": {
-        "kind": "iq",
-        "frequency": 4.8e9
+        "kind": "drive-emulator",
+        "frequency": 4.8e9,
+        "rabi_frequency": 20e6,
+        "scale_factor": 10
       },
     "0/probe": {
       "kind": "iq",
@@ -56,7 +60,7 @@
               "0/drive",
               {
                 "duration": 30,
-                "amplitude": 0.212,
+                "amplitude": 0.169,
                 "envelope": {
                   "kind": "gaussian",
                   "rel_sigma": 0.2
@@ -66,27 +70,13 @@
               }
             ]
           ],
-          "RX90": [
-            [
-              "0/drive",
-              {
-                "duration": 30,
-                "amplitude": 0.106,
-                "envelope": {
-                  "kind": "gaussian",
-                  "rel_sigma": 0.2
-                },
-                "relative_phase": 0.0,
-                "kind": "pulse"
-              }
-            ]
-          ],
+          "RX90": null,
           "RX12": [
             [
               "0/drive12",
               {
                 "duration": 30.0,
-                "amplitude": 0.15,
+                "amplitude": 0.1201,
                 "envelope": {
                   "kind": "gaussian",
                   "rel_sigma": 0.2

--- a/platforms/qutrit/platform.py
+++ b/platforms/qutrit/platform.py
@@ -3,13 +3,16 @@ import pathlib
 from qibolab import ConfigKinds
 from qibolab._core.components import IqChannel
 from qibolab._core.instruments.emulator.emulator import EmulatorController
-from qibolab._core.instruments.emulator.hamiltonians import HamiltonianConfig
+from qibolab._core.instruments.emulator.hamiltonians import (
+    DriveEmulatorConfig,
+    HamiltonianConfig,
+)
 from qibolab._core.platform import Platform
 from qibolab._core.qubits import Qubit
 
 FOLDER = pathlib.Path(__file__).parent
 
-ConfigKinds.extend([HamiltonianConfig])
+ConfigKinds.extend([HamiltonianConfig, DriveEmulatorConfig])
 
 
 def create() -> Platform:
@@ -18,10 +21,10 @@ def create() -> Platform:
     channels = {}
 
     for q in range(1):
-        qubits[q] = qubit = Qubit.default(q, drive_qudits={(1, 2): f"{q}/drive12"})
+        qubits[q] = qubit = Qubit.default(q, drive_extra={(1, 2): f"{q}/drive12"})
         channels |= {
             qubit.drive: IqChannel(mixer=None, lo=None),
-            qubits[q].drive_qudits[1, 2]: IqChannel(mixer=None, lo=None),
+            qubits[q].drive_extra[1, 2]: IqChannel(mixer=None, lo=None),
         }
 
     # register the instruments


### PR DESCRIPTION
After merging https://github.com/qiboteam/qibolab/pull/1186, the platforms here needed to be updated.