### PR TITLE
Enforce utf-8 encoding on all write operations

### DIFF
--- a/src/qibocal/auto/history.py
+++ b/src/qibocal/auto/history.py
@@ -126,7 +126,9 @@ class History:
             if output is not None:
                 completed.path = self.route(task_id, output)
             completed.flush()
-        (output / HISTORY).write_text(json.dumps(self._serialized_order, indent=4))
+        (output / HISTORY).write_text(
+            json.dumps(self._serialized_order, indent=4), encoding="utf-8"
+        )
 
     # TODO: implement time_travel()
 

--- a/src/qibocal/auto/operation.py
+++ b/src/qibocal/auto/operation.py
@@ -156,7 +156,7 @@ class AbstractData:
         """Helper function to dump to json."""
         if self.params:
             (path / f"{filename}.json").write_text(
-                json.dumps(serialize(self.params), indent=4)
+                json.dumps(serialize(self.params), indent=4), encoding="utf-8"
             )
 
     @classmethod

--- a/src/qibocal/auto/output.py
+++ b/src/qibocal/auto/output.py
@@ -191,7 +191,9 @@ class Output:
         """Dump output content to an output folder."""
         # dump metadata
         self._export_stats()
-        (path / META).write_text(json.dumps(self.meta.dump(), indent=4))
+        (path / META).write_text(
+            json.dumps(self.meta.dump(), indent=4), encoding="utf-8"
+        )
 
         # dump tasks
         self.history.flush(path)

--- a/src/qibocal/auto/runcard.py
+++ b/src/qibocal/auto/runcard.py
@@ -45,7 +45,7 @@ class Runcard:
 
     def dump(self, path):
         """Dump runcard object to yaml."""
-        (path / RUNCARD).write_text(yaml.safe_dump(asdict(self)))
+        (path / RUNCARD).write_text(yaml.safe_dump(asdict(self)), encoding="utf-8")
 
     def run(
         self, output: Path, platform: Platform, mode: ExecutionMode, update: bool = True

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -49,9 +49,11 @@ class Action:
             for param, value in self.parameters.items():
                 if type(value) is Circuit:
                     circuit_path = path / CIRCUIT
-                    circuit_path.write_text(json.dumps(value.raw))
+                    circuit_path.write_text(json.dumps(value.raw), encoding="utf-8")
                     self.parameters[param] = str(circuit_path)
-        (path / SINGLE_ACTION).write_text(yaml.safe_dump(asdict(self)))
+        (path / SINGLE_ACTION).write_text(
+            yaml.safe_dump(asdict(self)), encoding="utf-8"
+        )
 
     @classmethod
     def load(cls, path):

--- a/src/qibocal/calibration/calibration.py
+++ b/src/qibocal/calibration/calibration.py
@@ -164,7 +164,9 @@ class Calibration(Model):
 
     def dump(self, path: Path):
         """Dump calibration model."""
-        (path / CALIBRATION).write_text(self.model_dump_json(indent=4))
+        (path / CALIBRATION).write_text(
+            self.model_dump_json(indent=4), encoding="utf-8"
+        )
 
     @property
     def qubits(self) -> list:

--- a/src/qibocal/cli/compare.py
+++ b/src/qibocal/cli/compare.py
@@ -62,4 +62,4 @@ def compare_reports(folder: Path, path_1: Path, path_2: Path, force: bool):
         ),
     )
     combined_report.dump(combined_report_path)
-    (combined_report_path / "index.html").write_text(html)
+    (combined_report_path / "index.html").write_text(html, encoding="utf-8")

--- a/src/qibocal/cli/report.py
+++ b/src/qibocal/cli/report.py
@@ -93,4 +93,4 @@ def report(path: pathlib.Path, history: Optional[History] = None):
         ),
     )
 
-    (path / "index.html").write_text(html)
+    (path / "index.html").write_text(html, encoding="utf-8")

--- a/src/qibocal/cli/upload.py
+++ b/src/qibocal/cli/upload.py
@@ -28,7 +28,7 @@ def upload_report(path: pathlib.Path, tag: str, author: str):
     meta = Metadata.load(path)
     meta.author = author
     meta.tag = tag
-    (path / META).write_text(json.dumps(meta.dump(), indent=4))
+    (path / META).write_text(json.dumps(meta.dump(), indent=4), encoding="utf-8")
 
     # check the rsync command exists.
     if not shutil.which("rsync"):

--- a/src/qibocal/protocols/classification/classification.py
+++ b/src/qibocal/protocols/classification/classification.py
@@ -175,7 +175,9 @@ class SingleShotClassificationResults(Results):
         asdict_class = asdict(self)
         asdict_class.pop("models")
         asdict_class.pop("classifiers_hpars")
-        (path / f"{RESULTSFILE}.json").write_text(json.dumps(serialize(asdict_class)))
+        (path / f"{RESULTSFILE}.json").write_text(
+            json.dumps(serialize(asdict_class)), encoding="utf-8"
+        )
 
 
 def _acquisition(

--- a/src/qibocal/protocols/tomographies/state_tomography.py
+++ b/src/qibocal/protocols/tomographies/state_tomography.py
@@ -70,7 +70,7 @@ class StateTomographyData(Data):
 
     def save(self, path):
         super().save(path)
-        (path / CIRCUIT_PATH).write_text(json.dumps(self.circuit.raw))
+        (path / CIRCUIT_PATH).write_text(json.dumps(self.circuit.raw), encoding="utf-8")
 
     @classmethod
     def load(cls, path):


### PR DESCRIPTION
Apparently, UTF-8 has been accepted by Python as the default encoding, but it will only happen on py3.15
https://peps.python.org/pep-0686/

Currently, there is no reason why people may expect to be using anything differently on Linux and MacOS. But Windows users may experience some troubles in the meanwhile.

> Developers using macOS or Linux may forget that the default encoding is not always UTF-8.
> For example, using long_description = open("README.md").read() in setup.py is a common mistake. Many Windows users cannot install such packages if there is at least one non-ASCII character (e.g. emoji, author names, copyright symbols, and the like) in their UTF-8-encoded README.md file.
>
> Of the 4000 most downloaded packages from PyPI, 489 use non-ASCII characters in their README, and 82 fail to install from source on non-UTF-8 locales due to not specifying an encoding for a non-ASCII file. [[1]](https://peps.python.org/pep-0597/#id10)

https://peps.python.org/pep-0597/

@sorewachigauyo