### PR TITLE
Missing `platform.connect()` in README?

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,13 @@ params = rabi_amplitude.parameters_type.load(dict(
         ))
 
 # acquire
+platform.connect()
 data, acquisition_time = rabi_amplitude.acquisition(
                                                     params=params,
                                                     platform=platform,
                                                     targets=targets
                                                     )
+platform.disconnect()
 
 # post-processing
 results, fit_time = rabi_amplitude.fit(data=data)


### PR DESCRIPTION
I am not sure if I did something wrong, however while playing around with #1181 using the README example, I found that `platform.connect()` is needed before doing the acquisition. If that's actually true, we should correct the README.