### PR TITLE
Minor fixes for iSWAP chevron protocol

### DIFF
--- a/src/qibocal/protocols/two_qubit_interaction/chevron/chevron.py
+++ b/src/qibocal/protocols/two_qubit_interaction/chevron/chevron.py
@@ -211,8 +211,8 @@ def _fit(data: ChevronData) -> ChevronResults:
                     [np.inf, 2 * np.pi, np.max(y), np.max(y)],
                 ),
             )
-            # duration can be estimated as the period of the oscillation
-            duration = 1 / (popt[0] / 2 / np.pi)
+            period = 1 / (popt[0] / 2 / np.pi)
+            duration = period if data.native == "CZ" else period / 2
             amplitudes[pair] = amplitude
             durations[pair] = int(duration)
         except Exception as e:

--- a/src/qibocal/protocols/two_qubit_interaction/chevron/utils.py
+++ b/src/qibocal/protocols/two_qubit_interaction/chevron/utils.py
@@ -71,10 +71,14 @@ def chevron_sequence(
         (ro_high_channel, dt_delay),
         (drive_channel, drive_delay),
         (drive_channel, dt_delay),
-        (ro_low_channel, Delay(duration=second_rx.duration)),
-        (ro_high_channel, Delay(duration=second_rx.duration)),
-        (drive_channel, second_rx),
     ]
+
+    if native == "CZ":
+        sequence += [
+            (ro_low_channel, Delay(duration=second_rx.duration)),
+            (ro_high_channel, Delay(duration=second_rx.duration)),
+            (drive_channel, second_rx),
+        ]
 
     # add readout
     sequence += low_natives.MZ() + high_natives.MZ()


### PR DESCRIPTION
The fitting procedure for the chevron protocol with an `iSWAP` was incorrect because we were just using the same procedure used for the `CZ`, while for the `iSWAP` the duration of the gate should be half the oscillation period.
<img width="1332" alt="Screenshot 2025-06-17 at 15 34 13" src="https://github.com/user-attachments/assets/77cc3ee3-75f7-4b54-abdb-668576561082" />

I've also removed an additional X pulse for the chevron sequence that was added to improve the plot for the `CZ` case which is not necessary for the `iSWAP`.