### PR TITLE
Extend interactive workflow instructions for multinetwork systems

### DIFF
--- a/doc/source/tutorials/connect-to-queue.bash
+++ b/doc/source/tutorials/connect-to-queue.bash
@@ -9,7 +9,15 @@ print(s.getsockname()[1])
 s.close()
 EOF
 
-IP=$(hostname -I | cut -d ' ' -f 1)
+read -rd '' getip <<EOF
+import sys
+
+ips = sys.stdin.read().split(" ")
+print([ip for ip in ips if ip.startswith(sys.argv[1])][0])
+EOF
+
+SUBNET=""
+IP=$(hostname -I | python -c "$getip" "$SUBNET")
 PORT=$(python -c "$getport")
 
 echo "Forward your local port with:"

--- a/doc/source/tutorials/interactive.rst
+++ b/doc/source/tutorials/interactive.rst
@@ -33,3 +33,15 @@ the following script should help automating the process.
 
 Once the required server is dispatched as queue job with the script, the instructions to
 connect will appear in the output (usually redirected by the queue system on a file).
+
+.. note::
+
+   If the system you are targeting, the *remote computing node*, is actually part of
+   multiple networks, and you need to discriminate the correct one to use, just add the
+   subnetwork as a string in the former
+
+   E.g. you could use::
+
+       SUBNET="192.168.XXX"
+
+   to specify a local network whose 3rd byte is ``XXX`` (e.g. ``0``, ``1``, ..., ``255``)


### PR DESCRIPTION
The workflow proposed in #1184 was flawed for systems part of multiple networks, since a single one was assumed.

This is actually the case of TII's quantum computing lab, for which `SUBNET` should be set to `"192.168.2"`.