### PR TITLE
Fix update in resonator spectroscopy at low power

### DIFF
--- a/src/qibocal/protocols/resonator_spectroscopies/resonator_spectroscopy.py
+++ b/src/qibocal/protocols/resonator_spectroscopies/resonator_spectroscopy.py
@@ -315,6 +315,7 @@ def _update(
     update.readout_frequency(results.frequency[target], platform, target)
     if len(results.bare_frequency) == 0:
         update.readout_amplitude(results.amplitude[target], platform, target)
+        update.dressed_resonator_frequency(results.frequency[target], platform, target)
 
     else:
         update.bare_resonator_frequency(


### PR DESCRIPTION
When running at low power we were not updating the `dressed_resonator_frequency` which is what we are scanning around. 