### PR TITLE
Sweep offset of external DC source

### DIFF
--- a/src/qibocal/protocols/flux_dependence/__init__.py
+++ b/src/qibocal/protocols/flux_dependence/__init__.py
@@ -2,9 +2,9 @@ from .cryoscope import cryoscope
 from .flux_amplitude_frequency import flux_amplitude_frequency
 from .flux_gate import flux_gate
 from .qubit_crosstalk import qubit_crosstalk
-from .qubit_flux_dependence import qubit_flux
+from .qubit_flux_dependence import qubit_flux, qubit_flux_dc
 from .qubit_vz import qubit_vz
-from .resonator_flux_dependence import resonator_flux
+from .resonator_flux_dependence import resonator_flux, resonator_flux_dc
 
 __all__ = [
     "qubit_flux",

--- a/src/qibocal/protocols/flux_dependence/__init__.py
+++ b/src/qibocal/protocols/flux_dependence/__init__.py
@@ -2,9 +2,11 @@ from .cryoscope import cryoscope
 from .flux_amplitude_frequency import flux_amplitude_frequency
 from .flux_gate import flux_gate
 from .qubit_crosstalk import qubit_crosstalk
-from .qubit_flux_dependence import qubit_flux, qubit_flux_dc
+from .qubit_flux_dependence import qubit_flux
+from .qubit_flux_dependence_dc import qubit_flux_dc
 from .qubit_vz import qubit_vz
-from .resonator_flux_dependence import resonator_flux, resonator_flux_dc
+from .resonator_flux_dependence import resonator_flux
+from .resonator_flux_dependence_dc import resonator_flux_dc
 
 __all__ = [
     "qubit_flux",

--- a/src/qibocal/protocols/flux_dependence/__init__.py
+++ b/src/qibocal/protocols/flux_dependence/__init__.py
@@ -8,7 +8,9 @@ from .resonator_flux_dependence import resonator_flux
 
 __all__ = [
     "qubit_flux",
+    "qubit_flux_dc",
     "resonator_flux",
+    "resonator_flux_dc",
     "qubit_crosstalk",
     "flux_gate",
     "flux_amplitude_frequency",

--- a/src/qibocal/protocols/flux_dependence/qubit_flux_dependence.py
+++ b/src/qibocal/protocols/flux_dependence/qubit_flux_dependence.py
@@ -50,8 +50,6 @@ class QubitFluxParameters(ResonatorFluxParameters):
     Otherwise the default amplitude defined on the platform runcard will be used"""
     drive_duration: int = 2000
     """Duration of the drive pulse."""
-    dc_source: bool = False
-    """Sweep bias offset on software when external DC source is used."""
 
 
 @dataclass

--- a/src/qibocal/protocols/flux_dependence/qubit_flux_dependence_dc.py
+++ b/src/qibocal/protocols/flux_dependence/qubit_flux_dependence_dc.py
@@ -1,0 +1,34 @@
+from qibocal.auto.operation import QubitId, Routine
+from qibocal.calibration import CalibrationPlatform
+
+from .qubit_flux_dependence import (
+    QubitFluxData,
+    QubitFluxParameters,
+    QubitFluxResults,
+    _acquisition_base,
+    _fit,
+    _plot,
+    _update_base,
+)
+
+__all__ = ["qubit_flux_dc"]
+
+
+def _acquisition(
+    params: QubitFluxParameters,
+    platform: CalibrationPlatform,
+    targets: list[QubitId],
+) -> QubitFluxData:
+    return _acquisition_base(params, platform, targets, True)
+
+
+def _update(
+    results: QubitFluxResults,
+    platform: CalibrationPlatform,
+    qubit: QubitId,
+):
+    _update_base(results, platform, qubit, True)
+
+
+qubit_flux_dc = Routine(_acquisition, _fit, _plot, _update)
+"""QubitFlux Routine object."""

--- a/src/qibocal/protocols/flux_dependence/resonator_flux_dependence_dc.py
+++ b/src/qibocal/protocols/flux_dependence/resonator_flux_dependence_dc.py
@@ -1,0 +1,34 @@
+from qibocal.calibration import CalibrationPlatform
+
+from ...auto.operation import QubitId, Routine
+from .resonator_flux_dependence import (
+    ResonatorFluxData,
+    ResonatorFluxParameters,
+    ResonatorFluxResults,
+    _acquisition_base,
+    _fit,
+    _plot,
+    _update_base,
+)
+
+__all__ = ["resonator_flux_dc"]
+
+
+def _acquisition(
+    params: ResonatorFluxParameters,
+    platform: CalibrationPlatform,
+    targets: list[QubitId],
+) -> ResonatorFluxData:
+    return _acquisition_base(params, platform, targets, True)
+
+
+def _update(
+    results: ResonatorFluxResults,
+    platform: CalibrationPlatform,
+    qubit: QubitId,
+):
+    _update_base(results, platform, qubit, True)
+
+
+resonator_flux_dc = Routine(_acquisition, _fit, _plot, _update)
+"""ResonatorFlux Routine object."""

--- a/src/qibocal/update.py
+++ b/src/qibocal/update.py
@@ -208,6 +208,11 @@ def flux_offset(offset: float, platform: Platform, qubit: QubitId):
     platform.update({f"configs.{platform.qubits[qubit].flux}.offset": offset})
 
 
+def dc_flux_offset(offset: float, platform: Platform, qubit: QubitId):
+    """Update flux offset parameter in platform for specific qubit."""
+    platform.update({f"configs.{platform.qubits[qubit].dc_flux}.offset": offset})
+
+
 def frequency_12_transition(frequency: int, platform: Platform, qubit: QubitId):
     channel = platform.qubits[qubit].drive_extra[1, 2]
     platform.update({f"configs.{channel}.frequency": frequency})


### PR DESCRIPTION
Adds the possibility to sweep the current of an external DC source (such as the SPI rack: https://github.com/qiboteam/qibolab/pull/1260) for the resonator and qubit flux routines.

A more elegant solution would be to implement software sweepers directly on the SPI driver, so that we don't need to modify the routines (which may be many more). However, that solution requires some rework of the `Platform` for multi-instrument support, which we decided to postpone for now and provide modify the routines directly as a simpler solutions.