### PR TITLE
Lorentzian Dispersive

### DIFF
--- a/src/qibocal/protocols/coherence/spin_echo_signal.py
+++ b/src/qibocal/protocols/coherence/spin_echo_signal.py
@@ -51,6 +51,11 @@ class SpinEchoSignalResults(Results):
     pcov: dict[QubitId, list[float]]
     """Approximate covariance of fitted parameters."""
 
+    @property
+    def t2_echo(self) -> dict[QubitId, Union[float, list[float]]]:
+        """T2 echo for each qubit."""
+        return self.t2
+
 
 class SpinEchoSignalData(T1SignalData):
     """SpinEcho acquisition outputs."""

--- a/src/qibocal/protocols/qubit_spectroscopies/qubit_spectroscopy.py
+++ b/src/qibocal/protocols/qubit_spectroscopies/qubit_spectroscopy.py
@@ -116,7 +116,7 @@ def _acquisition(
 
     # Create data structure for data acquisition.
     data = QubitSpectroscopyData(
-        resonator_type=platform.resonator_type, amplitudes=amplitudes
+        resonator_type=platform.resonator_type, amplitudes=amplitudes, power_level=None
     )
 
     results = platform.execute(

--- a/src/qibocal/protocols/resonator_spectroscopies/resonator_spectroscopy.py
+++ b/src/qibocal/protocols/resonator_spectroscopies/resonator_spectroscopy.py
@@ -19,9 +19,11 @@ from ..utils import (
     chi2_reduced_complex,
     lorentzian,
     lorentzian_fit,
+    lorentzian_dispersive,
+    lorentzian_dispersive_fit,
     readout_frequency,
 )
-from .resonator_utils import s21, s21_fit, s21_spectroscopy_plot, spectroscopy_plot
+from .resonator_utils import s21, s21_fit, s21_spectroscopy_plot, spectroscopy_plot, lorentzian_dispersive_plot
 
 __all__ = ["resonator_spectroscopy", "ResonatorSpectroscopyData", "ResSpecType"]
 
@@ -72,6 +74,14 @@ FITS = {
         lambda z: (z.error_signal, z.error_phase),
         s21_spectroscopy_plot,
     ),
+    "lorentzian_dispersive": ResonatorSpectroscopyFit(
+        lorentzian_dispersive,
+        lorentzian_dispersive_fit,
+        chi2_reduced,
+        lambda z: z.signal,
+        lambda z: z.error_signal,
+        lorentzian_dispersive_plot,
+    )
 }
 """Dictionary of available fitting routines for ResonatorSpectroscopy."""
 

--- a/src/qibocal/protocols/resonator_spectroscopies/resonator_spectroscopy.py
+++ b/src/qibocal/protocols/resonator_spectroscopies/resonator_spectroscopy.py
@@ -18,12 +18,18 @@ from ..utils import (
     chi2_reduced,
     chi2_reduced_complex,
     lorentzian,
-    lorentzian_fit,
     lorentzian_dispersive,
     lorentzian_dispersive_fit,
+    lorentzian_fit,
     readout_frequency,
 )
-from .resonator_utils import s21, s21_fit, s21_spectroscopy_plot, spectroscopy_plot, lorentzian_dispersive_plot
+from .resonator_utils import (
+    lorentzian_dispersive_plot,
+    s21,
+    s21_fit,
+    s21_spectroscopy_plot,
+    spectroscopy_plot,
+)
 
 __all__ = ["resonator_spectroscopy", "ResonatorSpectroscopyData", "ResSpecType"]
 
@@ -81,7 +87,7 @@ FITS = {
         lambda z: z.signal,
         lambda z: z.error_signal,
         lorentzian_dispersive_plot,
-    )
+    ),
 }
 """Dictionary of available fitting routines for ResonatorSpectroscopy."""
 

--- a/src/qibocal/protocols/resonator_spectroscopies/resonator_utils.py
+++ b/src/qibocal/protocols/resonator_spectroscopies/resonator_utils.py
@@ -14,9 +14,9 @@ from ..utils import (
     HZ_TO_GHZ,
     PowerLevel,
     lorentzian,
+    lorentzian_dispersive,
     table_dict,
     table_html,
-    lorentzian_dispersive,
 )
 
 PHASES_THRESHOLD_PERCENTAGE = 80
@@ -118,7 +118,7 @@ def s21_fit(
     return model_parameters[0], model_parameters, perr
 
 
-def _plot(data, qubit, fit: Results = None, model = lorentzian):
+def _plot(data, qubit, fit: Results = None, model=lorentzian):
     figures = []
     fig = make_subplots(
         rows=1,
@@ -598,6 +598,7 @@ def s21_spectroscopy_plot(data, qubit, fit: Results = None):
 
 def spectroscopy_plot(data, qubit, fit: Results = None):
     return _plot(data, qubit, fit, lorentzian)
+
 
 def lorentzian_dispersive_plot(data, qubit, fit: Results = None):
     return _plot(data, qubit, fit, lorentzian_dispersive)

--- a/src/qibocal/protocols/resonator_spectroscopies/resonator_utils.py
+++ b/src/qibocal/protocols/resonator_spectroscopies/resonator_utils.py
@@ -16,6 +16,7 @@ from ..utils import (
     lorentzian,
     table_dict,
     table_html,
+    lorentzian_dispersive,
 )
 
 PHASES_THRESHOLD_PERCENTAGE = 80
@@ -117,7 +118,7 @@ def s21_fit(
     return model_parameters[0], model_parameters, perr
 
 
-def spectroscopy_plot(data, qubit, fit: Results = None):
+def _plot(data, qubit, fit: Results = None, model = lorentzian):
     figures = []
     fig = make_subplots(
         rows=1,
@@ -202,7 +203,7 @@ def spectroscopy_plot(data, qubit, fit: Results = None):
         fig.add_trace(
             go.Scatter(
                 x=freqrange,
-                y=lorentzian(freqrange, *params),
+                y=model(freqrange, *params),
                 name="Fit",
                 line=go.scatter.Line(dash="dot"),
             ),
@@ -593,6 +594,13 @@ def s21_spectroscopy_plot(data, qubit, fit: Results = None):
     figures.reverse()
 
     return figures, fitting_report
+
+
+def spectroscopy_plot(data, qubit, fit: Results = None):
+    return _plot(data, qubit, fit, lorentzian)
+
+def lorentzian_dispersive_plot(data, qubit, fit: Results = None):
+    return _plot(data, qubit, fit, lorentzian_dispersive)
 
 
 def cable_delay(frequencies: NDArray, phases: NDArray, num_points: int) -> float:

--- a/src/qibocal/protocols/utils.py
+++ b/src/qibocal/protocols/utils.py
@@ -144,6 +144,72 @@ def lorentzian_fit(data, resonator_type=None, fit=None):
     except RuntimeError as e:
         log.warning(f"Lorentzian fit not successful due to {e}")
 
+def lorentzian_dispersive(frequency, amplitude, center, sigma, offset, alpha):
+    """Lorentzian function with an arbitary linear offset background term."""
+    return (frequency - center) * alpha + lorentzian(
+        frequency, amplitude, center, sigma, offset
+    )
+
+def lorentzian_dispersive_fit(data, resonator_type=None, fit=None):
+    frequencies = data.freq * HZ_TO_GHZ
+    voltages = data.signal
+
+    guess_alpha = (voltages[-1] - voltages[0]) / (frequencies[-1] - frequencies[0])
+
+    guess_offset = np.mean(
+        voltages[np.abs(voltages - np.mean(voltages)) < np.std(voltages)]
+    )
+    if resonator_type == "3D":
+        peaks, _ = find_peaks(voltages,
+                              height=(np.max(voltages)-np.min(voltages))*0.2)
+    else:
+        peaks, _ = find_peaks(np.min(voltages)-voltages,
+                              height=np.max(np.min(voltages)-voltages)*0.2)
+    
+    if len(peaks) == 0:
+        guess_center = frequencies[np.argmin(voltages)]
+    else:
+        guess_center = frequencies[peaks[0]]
+
+    guess_sigma = abs(frequencies[np.argmax(voltages)] - guess_center)
+    guess_amplitude = (np.max(voltages) - guess_offset) * guess_sigma * np.pi
+
+    initial_parameters = [
+        guess_amplitude,
+        guess_center,
+        guess_sigma,
+        guess_offset,
+        guess_alpha
+    ]
+
+    # fit the model with the data and guessed parameters
+    try:
+        if hasattr(data, "error_signal"):
+            if not np.isnan(data.error_signal).any():
+                fit_parameters, perr = curve_fit(
+                    lorentzian_dispersive,
+                    frequencies,
+                    voltages,
+                    p0=initial_parameters,
+                    sigma=data.error_signal,
+                )
+                perr = np.sqrt(np.diag(perr)).tolist()
+                model_parameters = list(fit_parameters)
+        else:
+            fit_parameters, perr = curve_fit(
+                lorentzian_dispersive,
+                frequencies,
+                voltages,
+                p0=initial_parameters,
+            )
+            perr = [0] * 5
+            model_parameters = list(fit_parameters)
+
+        return model_parameters[1] * GHZ_TO_HZ, model_parameters, perr
+    except RuntimeError as e:
+        log.warning(f"Lorentzian dispersive fit not successful due to a runtime error: {e}")
+    except Exception as e:
+        log.warning(f"Lorentzian dispersive fit not successful:{e}")
 
 class DcFilteredConfig(Config):
     """Dummy config for dc with filters.

--- a/src/qibocal/protocols/utils.py
+++ b/src/qibocal/protocols/utils.py
@@ -144,27 +144,34 @@ def lorentzian_fit(data, resonator_type=None, fit=None):
     except RuntimeError as e:
         log.warning(f"Lorentzian fit not successful due to {e}")
 
+
 def lorentzian_dispersive(frequency, amplitude, center, sigma, offset, alpha):
     """Lorentzian function with an arbitary linear offset background term."""
-    return   (amplitude / np.pi) * (1 + (frequency - center) / center * alpha ) * (
+    return (amplitude / np.pi) * (1 + (frequency - center) / center * alpha) * (
         sigma / ((frequency - center) ** 2 + sigma**2)
     ) + offset
+
 
 def lorentzian_dispersive_fit(data, resonator_type=None, fit=None):
     frequencies = data.freq * HZ_TO_GHZ
     voltages = data.signal
 
-    guess_alpha = (voltages[-1] - voltages[0]) / ((frequencies[-1] - frequencies[0])/np.mean(frequencies))
+    guess_alpha = (voltages[-1] - voltages[0]) / (
+        (frequencies[-1] - frequencies[0]) / np.mean(frequencies)
+    )
     guess_offset = np.mean(
         voltages[np.abs(voltages - np.mean(voltages)) < np.std(voltages)]
     )
     if resonator_type == "3D":
-        peaks, _ = find_peaks(voltages,
-                              height=(np.max(voltages)-np.min(voltages))*0.2)
+        peaks, _ = find_peaks(
+            voltages, height=(np.max(voltages) - np.min(voltages)) * 0.2
+        )
     else:
-        peaks, _ = find_peaks(np.min(voltages)-voltages,
-                              height=np.max(np.min(voltages)-voltages)*0.2)
-    
+        peaks, _ = find_peaks(
+            np.min(voltages) - voltages,
+            height=np.max(np.min(voltages) - voltages) * 0.2,
+        )
+
     if len(peaks) == 0:
         guess_center = frequencies[np.argmin(voltages)]
         guess_peak_voltage = voltages[np.argmin(voltages)]
@@ -172,7 +179,7 @@ def lorentzian_dispersive_fit(data, resonator_type=None, fit=None):
         guess_center = frequencies[peaks[0]]
         guess_peak_voltage = voltages[peaks[0]]
 
-    half_volt = (guess_peak_voltage + guess_offset)/2
+    half_volt = (guess_peak_voltage + guess_offset) / 2
     half_max_freq = frequencies[np.argmin(np.abs(voltages - half_volt))]
 
     guess_sigma = abs(guess_center - half_max_freq)
@@ -183,7 +190,7 @@ def lorentzian_dispersive_fit(data, resonator_type=None, fit=None):
         guess_center,
         guess_sigma,
         guess_offset,
-        guess_alpha
+        guess_alpha,
     ]
 
     # fit the model with the data and guessed parameters
@@ -211,9 +218,12 @@ def lorentzian_dispersive_fit(data, resonator_type=None, fit=None):
 
         return model_parameters[1] * GHZ_TO_HZ, model_parameters, perr
     except RuntimeError as e:
-        log.warning(f"Lorentzian dispersive fit not successful due to a runtime error: {e}")
+        log.warning(
+            f"Lorentzian dispersive fit not successful due to a runtime error: {e}"
+        )
     except Exception as e:
         log.warning(f"Lorentzian dispersive fit not successful:{e}")
+
 
 class DcFilteredConfig(Config):
     """Dummy config for dc with filters.


### PR DESCRIPTION
This is a modified version of the Lorentzian adding a dispersive background for the magnitude component, perhaps related to #1245. This helps to account for a linear background, similar to how they add it in [this work from Delft](https://arxiv.org/pdf/1502.04082) to the s21 fitting. The model becomes

$$
|S_{21}| = \frac{A}{\pi}\left( 1 + \alpha \frac{f-f_c}{f_c}    \right) \left( \frac{\Sigma}{\Sigma^2 + (f - f_c)^2}\right)
$$

And helps to go from this fit:
<img width="874" height="287" alt="image" src="https://github.com/user-attachments/assets/eaa7d6d0-074b-492e-9305-c53fad3e4cb3" />


To:
<img width="876" height="286" alt="image" src="https://github.com/user-attachments/assets/2c79bb4c-5190-4f65-8b71-08089597faa6" />

----
I also added the fix I mentioned in #1276 so that the qubit spectroscopy result table doesn't say "resonator frequency"
