### PR TITLE
Long qubit spectroscopy

### DIFF
--- a/doc/source/protocols/qubit_spectroscopy/qubit_spectroscopy.rst
+++ b/doc/source/protocols/qubit_spectroscopy/qubit_spectroscopy.rst
@@ -22,6 +22,10 @@ to the transition frequency  :math:`w_{01}` some of the population will
 move to the excited state. If the drive pulse is long enough it will be
 generated a maximally mixed state with :math:`\rho \propto I` :cite:p:`Baur2012RealizingQG, gao2021practical`.
 
+When the frequency bandwidth measured exceeds the IF bandwidth range (+/- 300 MHz),
+the routine automatically splits the sweep into multiple batches, adjusting
+the LO frequency accordingly for each batch.
+"""
 
 Parameters
 ^^^^^^^^^^

--- a/src/qibocal/protocols/qubit_spectroscopies/qubit_spectroscopy.py
+++ b/src/qibocal/protocols/qubit_spectroscopies/qubit_spectroscopy.py
@@ -284,13 +284,4 @@ def _update(
 
 qubit_spectroscopy = Routine(_acquisition, _fit, _plot, _update)
 """Qubit Spectroscopy routine.
-
-A qubit spectroscopy sweeps the drive frequency around the qubit
-frequency at which the qubit's transition from |0> to |1> occurs.
-Typically a long pulse is used to ensure a narrow frequency spectrum of the
-drive, and helping the qubit to get excited to a superposition state.
-
-When the frequency sweep width exceeds the IF bandwidth range (+/- 300 MHz),
-the routine automatically splits the sweep into multiple batches, adjusting
-the LO frequency accordingly for each batch.
 """


### PR DESCRIPTION
This is a possible implementation of the loooong spectroscopy.
The fit and report functions are the same as the opriginal qubit spectrscopy, and the main difference is that in the acquisition there is a for loop that runs the spectroscopy updating the LO each time. I tested this with one qubit and it looks like its working well.

<img width="1417" height="400" alt="newplot (4)" src="https://github.com/user-attachments/assets/29fd9707-91eb-4ade-8f4f-7a07f803e035" />

I am currently hardcoding the maximum IF frequency before splitting the job, for qblox this may be available in the codes validator of the qcm (qrm) driver. But for other electronics I don't know. Maybe qibolab would need to expose something that can be accessed to be able to have a generic implementation (+- 300 MHz should work for QM and QBlox)

I was having issues with the validation of the `nco_freq`:  When setting the initial values (lo and nco frequencies) the validator compares against whatever is on the json specification after updates (which for a very wide spectroscopy may set an nco too far from the updated lo  frequency), even though the nco frequency is later swept in a reasonable range. So a dirty fix was to also send an update of the drive frequency to some value in range, I used
```python
update_dict[drive_channels[qubit]] = {
                "frequency": platform.config(drive_channels[qubit]).frequency + lo_offset
            }
```