### PR TITLE
small fix in merging function

### DIFF
--- a/src/qibocal/protocols/utils.py
+++ b/src/qibocal/protocols/utils.py
@@ -921,6 +921,7 @@ def merging(
     if first_label < 0:
         max_lab = np.max(indexed_labels[:, 0]) + 1
         first_label = max_lab
+        unique_labels = np.append(unique_labels, max_lab)
 
     active_clusters = {
         first_label: {


### PR DESCRIPTION
in PR #1342 I missed a possible bug. 
Without the modification the signal dictionary was overwriting the values of clusters. 