### PR TITLE
Fix rendering of results table 

### DIFF
--- a/src/qibocal/protocols/resonator_spectroscopies/resonator_utils.py
+++ b/src/qibocal/protocols/resonator_spectroscopies/resonator_utils.py
@@ -220,7 +220,6 @@ def spectroscopy_plot(data, qubit, fit: Results = None):
             label = "Qubit Frequency [Hz]"
             freq = fit.frequency
 
-
         if data.amplitudes[qubit] is not None:
             if show_error_bars:
                 labels = [label, "Amplitude", "Chi2 reduced"]
@@ -247,7 +246,6 @@ def spectroscopy_plot(data, qubit, fit: Results = None):
                 display_error=show_error_bars,
             )
         )
-            
 
     fig.update_layout(
         showlegend=True,


### PR DESCRIPTION
when there is no amplitude parameter being saved from the fitting results, the report was not showing the qubit (resonator) frequency, even when the fit did not fail. In general there should be an amplitude saved but it has no effect to this protocol whether it was saved or not to show the results. .  