### PR TITLE
Punchout realtive amp fix

### DIFF
--- a/src/qibocal/protocols/resonator_spectroscopies/resonator_punchout.py
+++ b/src/qibocal/protocols/resonator_spectroscopies/resonator_punchout.py
@@ -101,7 +101,9 @@ def _acquisition(
     for qubit in targets:
         natives = platform.natives.single_qubit[qubit]
         ro_channel, ro_pulse = natives.MZ()[0]
-        ro_pulses[qubit] = ro_pulse.model_copy(update = {'probe': ro_pulse.probe.model_copy(update={'amplitude': 1.0})})
+        ro_pulses[qubit] = ro_pulse.model_copy(
+            update={"probe": ro_pulse.probe.model_copy(update={"amplitude": 1.0})}
+        )
         sequence.append((ro_channel, ro_pulses[qubit]))
 
         probe = platform.qubits[qubit].probe


### PR DESCRIPTION
This partially addresses #1339 in the case of the punchout, a similar fix needs to be implemented in other protocols that use amplitude sweepers. This is because the amplitude of the pulse as set in the `parameters.json` directly modifies the envelope amplitude (in `qibolab._core.pulses.pulse` and in consequence the value swept is applied as an additional gain. This is solved by overwriting the pulse amplitude as `1.0` 