### PR TITLE
update minum delay to be compatible with Quantum Machines

### DIFF
--- a/src/qibocal/protocols/signal_experiments/time_of_flight_readout.py
+++ b/src/qibocal/protocols/signal_experiments/time_of_flight_readout.py
@@ -15,7 +15,7 @@ from .utils import _get_lo_frequency
 
 __all__ = ["time_of_flight_readout"]
 
-MINIMUM_TOF = 24
+MINIMUM_TOF = 28
 """Minimum value for time of flight"""
 
 


### PR DESCRIPTION
A tof routine while using OPX1000 returns
```
Invalidation ERROR time of flight@elements.0/acquisition: Time of flight must be a multiple of 4 and greater or equal than 28 (got 24)
```
This can be changed in the `MINIMUM_TOF` constant (this PR), or perhaps be part of the instrument bounds (part of the driver or in the configs json)