### PR TITLE
Normalize signal data to the amplitude of the pulse sent

### DIFF
--- a/src/qibocal/protocols/resonator_spectroscopies/resonator_punchout.py
+++ b/src/qibocal/protocols/resonator_spectroscopies/resonator_punchout.py
@@ -202,11 +202,14 @@ def _plot(data: ResonatorPunchoutData, fit: ResonatorPunchoutResults, target: Qu
     qubit_phase -= qubit_phase_compensation
     x *= HZ_TO_GHZ
 
+    signal_norm = signal / np.repeat(data.amplitudes, len(data.frequencies[target]))
     fig.add_trace(
         go.Heatmap(
             x=x,
             y=y,
-            z=signal,
+            z=signal_norm,
+            zmin=np.percentile(signal_norm, 0.5),
+            zmax=np.percentile(signal_norm, 99.5),
             colorbar=dict(title="Raw signal"),
             colorbar_x=1.01,
             colorscale="Viridis",


### PR DESCRIPTION
I know I said that I prefer to have the raw data in the plots. But when we sweep the amplitude of the pulse the instruments does not normalize the signal it reads against that different amplitude, and in consequence, especially for large ranges, the plot of amplitude doesn't show much in the punch out (with @alecandido  we talked about this the other day). 

So we can go from
<img width="1401" height="400" alt="newplot(60)" src="https://github.com/user-attachments/assets/7f81affc-048e-4a22-a133-f8ddae9667d2" />

to:
<img width="1401" height="400" alt="newplot(59)" src="https://github.com/user-attachments/assets/a5781137-9710-4a1a-9ca0-93511fdd74ee" />

I also added a dummy scaler for the signal visualization (color) to cover 99% of the data range that helps prevent outliers changing the color range. 