### PR TITLE
rescaling data plot based on attenuation

### DIFF
--- a/src/qibocal/protocols/resonator_spectroscopies/resonator_punchout_attenuation.py
+++ b/src/qibocal/protocols/resonator_spectroscopies/resonator_punchout_attenuation.py
@@ -215,7 +215,10 @@ def _fit(data: ResonatorPunchoutAttenuationData) -> ResonatorPunchoutAttenuation
             successful_fit[qubit] = False
             continue
 
-        bare_freq, readout_freq, ro_val = fit_punchout(filtered_x, -filtered_y)
+        # flipping sign to the filtered signal: convert attenuation (positive) to
+        # power (negative)
+        filtered_y = -filtered_y
+        bare_freq, readout_freq, ro_val = fit_punchout(filtered_x, filtered_y)
         successful_fit[qubit] = True
 
         readout_freqs[qubit] = float(readout_freq)


### PR DESCRIPTION
this PR is a follow-up of PR #1386, where we also scale the punchout with attenuation data with respect to the attenuation values.

this is the plot before this PR:
<img width="1512" height="395" alt="Screenshot from 2026-02-19 10-46-22" src="https://github.com/user-attachments/assets/da21588b-0a8e-4de6-8f31-e88da798edaf" />

and this is after:
<img width="1512" height="395" alt="Screenshot from 2026-02-19 10-42-15" src="https://github.com/user-attachments/assets/176cb877-109a-45df-a8ed-d0248b479f3d" />