### PR TITLE
Fix: create directory before writing circuit.json in Action.dump()

### DIFF
--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -46,13 +46,14 @@ class Action:
     def dump(self, path: Path):
         """Dump single action to yaml."""
         if self.parameters is not None:
+            path.mkdir(parents=True, exist_ok=True)
+
             for param, value in self.parameters.items():
                 if type(value) is Circuit:
                     circuit_path = path / CIRCUIT
                     circuit_path.write_text(json.dumps(value.raw), encoding="utf-8")
                     self.parameters[param] = str(circuit_path)
 
-            (path / SINGLE_ACTION).parent.mkdir(parents=True, exist_ok=True)
             (path / SINGLE_ACTION).write_text(
                 yaml.safe_dump(asdict(self)), encoding="utf-8"
             )


### PR DESCRIPTION
## Summary
- `Action.dump()` writes `circuit.json` before the target directory is created, causing `FileNotFoundError` whenever a protocol receives a `Circuit` parameter (e.g., `two_qubit_state_tomography`)
- Moved `mkdir` call before the circuit serialization loop

## Problem
In `task.py`, `Action.dump()` attempts to write `circuit.json` on line 52, but the directory is only created on line 55 via `(path / SINGLE_ACTION).parent.mkdir(...)`. When the task path doesn't exist yet (which is always the case for a fresh execution), the write fails with:

This silently breaks any protocol that passes a `Circuit` object as a parameter, including `two_qubit_state_tomography`.

## Fix
Move `path.mkdir(parents=True, exist_ok=True)` before the parameter serialization loop so the directory exists before any file writes.

## Test plan
- [x] Create an `Action` with a `Circuit` parameter and call `dump()` on a non-existent directory — confirms `circuit.json` and `action.yml` are both created
