### PR TITLE
Fix `integers()` TypeError in qibocal randomized benchmarking

### DIFF
--- a/src/qibocal/protocols/randomized_benchmarking/utils.py
+++ b/src/qibocal/protocols/randomized_benchmarking/utils.py
@@ -230,7 +230,7 @@ class RB_Generator:
 
     def random_index(self, gate_dict):
         """Generates a random index within the range of the given file len."""
-        return self.local_state.integers(0, len(gate_dict), 1)
+        return self.local_state.integers(0, len(gate_dict))
 
     def layer_gen_single_qubit(self):
         """Generates a random single-qubit clifford gate."""


### PR DESCRIPTION
[Fix for issue #1395 ](https://github.com/qiboteam/qibocal/issues/1395)

**File:** `src/qibocal/protocols/randomized_benchmarking/utils.py`, line 233
**The bug:**

`standard_rb` crashes with:

```

File ".../utils.py", line 96, in random_clifford

random_index = int(random_index_gen(SINGLE_QUBIT_CLIFFORDS))

TypeError: only 0-dimensional arrays can be converted to Python scalars

```

The `random_index` method at line 233 calls:

```python

return self.local_state.integers(0, len(gate_dict), 1)

```

The third argument (`1`) is the `size` parameter of `numpy.Generator.integers()`. With `size=1`, it returns `array([N])` (a 1D array) instead of a scalar `N`. The caller at line 96 does `int(result)`, which fails because numpy can't convert a 1D array to a Python int.

**The fix (one line):**

```python

# Before:

return self.local_state.integers(0, len(gate_dict), 1)


# After (remove the ", 1"):

return self.local_state.integers(0, len(gate_dict))

```

**Verification:** This fix was tested on the sinq20 hardware. After applying it, `standard_rb` completed a full 331-second acquisition run successfully.
