### PR TITLE
history updated just if acquisition succeeded

### DIFF
--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -133,11 +133,16 @@ class Task:
         self,
         platform: Optional[Platform] = None,
         targets: Optional[Targets] = None,
-        mode: Optional[ExecutionMode] = None,
+        mode: Optional[ExecutionMode] = [],
         folder: Optional[Path] = None,
     ) -> "Completed":
         if self.targets is None:
             self.action.targets = targets
+
+        if mode is None:
+            # None is no iterable so code might crash in lines
+            # 169 and 185
+            mode = []
 
         completed = Completed(self, folder)
         try:
@@ -174,8 +179,13 @@ class Task:
                 )
             completed.dump_data()
         if ExecutionMode.FIT in mode:
-            completed.results, completed.results_time = operation.fit(completed.data)
-            completed.dump_results()
+            try:
+                completed.results, completed.results_time = operation.fit(
+                    completed.data
+                )
+                completed.dump_results()
+            except Exception as e:
+                log.warning(f"{e}")
         return completed
 
 

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -133,15 +133,15 @@ class Task:
         self,
         platform: Optional[Platform] = None,
         targets: Optional[Targets] = None,
-        mode: Optional[ExecutionMode] = [],
+        mode: Optional[ExecutionMode] = None,
         folder: Optional[Path] = None,
     ) -> "Completed":
         if self.targets is None:
             self.action.targets = targets
 
         if mode is None:
-            # None is no iterable so code might crash in lines
-            # 169 and 185
+            # None is no iterable so code might crash later when checking
+            # executino modes if-statements since None is not iterable
             mode = []
 
         completed = Completed(self, folder)


### PR DESCRIPTION
When something crashes in the execution of experiments during the `_fit` step, the program still saves the `data.npz` file so in theory it is still possible to fix the fitting function and test it using the CLI command `qq fit`.
However it does not work out of the box since in this scenario `history.json` does not contain the failed task, hence it ignore those data.
In thi PR indeed I try to update this json file with the sufficient and necessary condition that `acquisition` step succedeed. This solves the scenario described above. 
Of course this is simply `postponing` an eventual crash in the code in the following lines, where indeed the `Executor` sees `history.json` has been updated with the task and look for `results.json` even though it does not exist. 

Finally it modifies a small bug that I found in `task.py:run` method, that from what I saw probably it has never been triggered.