### PR TITLE
fix: qq fit in case of repeated protocols

### DIFF
--- a/src/qibocal/auto/output.py
+++ b/src/qibocal/auto/output.py
@@ -253,9 +253,7 @@ class Output:
             self.history._tasks[task_id.id][task_id.iteration] = completed.task.run(
                 platform=self.platform,
                 mode=mode,
-                folder=self.history.task_path(
-                    self.history._executed_task_id(task_id.id), output
-                ),
+                folder=self.history.task_path(task_id, output),
             )
             if update and completed.task.update:
                 completed.update_platform(platform=self.platform)


### PR DESCRIPTION
task_id is an instance of TaskID, which contains TaskID.id (protocol name) and TaskID.iteration (counting the number of calls to the same protocol, even with different inputs). However, when calling qq fit it would always construct the path based only on task_id.id, ignoring the task_id.iteration. Therefore, the output of all iterations was the same path.

I don't fully understand the original rationale for implementing it like this, but it only affects the cli `fit` function.