### PR TITLE
fix: cannot import `qibocal` without `qblox_instruments` 

### DIFF
--- a/src/qibocal/config.py
+++ b/src/qibocal/config.py
@@ -1,7 +1,9 @@
-"""Custom logger implemenation."""
+"""Custom logger implementation."""
 
 import logging
 import os
+
+from qibocal.version import __version__
 
 # Logging levels available here https://docs.python.org/3/library/logging.html#logging-levels
 QIBOCAL_LOG_LEVEL = 10
@@ -31,21 +33,10 @@ class CustomHandler(logging.StreamHandler):
         super().__init__()
         self.FORMATS = None
 
-    @staticmethod
-    def _qibocal_version():
-        """Return qibocal version without importing package root during init."""
-        try:
-            from qibocal.version import __version__
-
-            return __version__
-        except Exception:
-            return "unknown"
-
     def format(self, record):
         """Format the record with specific format."""
-        version = self._qibocal_version()
 
-        fmt = f"[Qibocal {version}|%(levelname)s|%(asctime)s]: %(message)s"
+        fmt = f"[Qibocal {__version__}|%(levelname)s|%(asctime)s]: %(message)s"
 
         grey = "\x1b[38;20m"
         green = "\x1b[92m"

--- a/src/qibocal/config.py
+++ b/src/qibocal/config.py
@@ -31,11 +31,21 @@ class CustomHandler(logging.StreamHandler):
         super().__init__()
         self.FORMATS = None
 
+    @staticmethod
+    def _qibocal_version():
+        """Return qibocal version without importing package root during init."""
+        try:
+            from qibocal.version import __version__
+
+            return __version__
+        except Exception:
+            return "unknown"
+
     def format(self, record):
         """Format the record with specific format."""
-        from qibocal import __version__
+        version = self._qibocal_version()
 
-        fmt = f"[Qibocal {__version__}|%(levelname)s|%(asctime)s]: %(message)s"
+        fmt = f"[Qibocal {version}|%(levelname)s|%(asctime)s]: %(message)s"
 
         grey = "\x1b[38;20m"
         green = "\x1b[92m"

--- a/src/qibocal/protocols/__init__.py
+++ b/src/qibocal/protocols/__init__.py
@@ -1,5 +1,3 @@
-from qibocal.config import log
-
 from . import (
     allxy,
     classification,
@@ -45,15 +43,10 @@ from .twpa import *
 try:
     from . import calibrate_mixers
     from .calibrate_mixers import *
-except ModuleNotFoundError as exc:
+except ModuleNotFoundError as e:
     # Keep protocols importable when optional Qblox dependencies are absent.
-    if exc.name != "qblox_instruments":
+    if e.name != "qblox_instruments":
         raise
-    log.warning(
-        "Skipping calibrate_mixers import because the optional qblox_instruments "
-        "dependency is not installed. While optional, it is required for the mixer "
-        "calibration protocol."
-    )
 
 __all__ = []
 __all__ += ["allxy"]


### PR DESCRIPTION
Fixes #1422. Thanks @sorewachigauyo for pointing it out! Please let me know if this fixes the issue for you. 

Importing qibocal without having the optional `qblox_instruments` in the environment raises an error. 

If `qblox_instruments` is not in the environment, `protocols.__init__` will ty to make a call to `log.warning()` in `calibrate_mixers`. However, printing using the logger executes `from qibocal import __version__`, and thus requires `qibocal` to be initialized, which just failed... This is fixed by importing `__version__` as from `qibocal.version import __version__` rather than from `qibocal import __version__`, avoiding the import of the `qibocal.__init__` module.

Since I realize printing a warning whenever qibocal is used without `qblox_instruments` is very annoying the logger that triggered the error fixed in the first commit, is itself also removed in the second commit. 
