### PR TITLE
adding validation for relative phase in the platform parameters.json

### DIFF
--- a/src/qibocal/calibration/platform.py
+++ b/src/qibocal/calibration/platform.py
@@ -21,8 +21,8 @@ class CalibrationPlatform(Platform):
     """Calibration information."""
 
     def __post_init__(self):
-        """
-        Post-initialization method for the Platform class.
+        """Post-initialization method for the Platform class.
+
         Validates that all X rotation native gates (RX, RX90, RX12) for each qubit
         have a relative_phase of 0.0. If any gate does not meet this condition,
         logs an error and raises a ValueError.

--- a/src/qibocal/calibration/platform.py
+++ b/src/qibocal/calibration/platform.py
@@ -1,4 +1,3 @@
-import logging
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -8,7 +7,10 @@ from .calibration import CALIBRATION, Calibration
 
 __all__ = ["CalibrationPlatform", "create_calibration_platform"]
 
-log = logging.getLogger(__name__)
+
+class CalibrationError(Exception):
+    def __init__(self, *args):
+        super().__init__(*args)
 
 
 @dataclass
@@ -30,23 +32,24 @@ class CalibrationPlatform(Platform):
         for q in self.qubits:
             phase_rx = (
                 True
-                if natives[q].RX() is None
-                else natives[q].RX()[0][1].relative_phase == 0.0
+                if natives[q].RX is None
+                else natives[q].RX[0][1].relative_phase == 0.0
             )
             phase_rx90 = (
                 True
-                if natives[q].RX90() is None
-                else natives[q].RX90()[0][1].relative_phase == 0.0
+                if natives[q].RX90 is None
+                else natives[q].RX90[0][1].relative_phase == 0.0
             )
             phase_rx12 = (
                 True
-                if natives[q].RX() is None
-                else natives[q].RX12()[0][1].relative_phase == 0.0
+                if natives[q].RX12 is None
+                else natives[q].RX12[0][1].relative_phase == 0.0
             )
 
             if not (phase_rx and phase_rx90 and phase_rx12):
-                log.error("%s - All X rotation must be set with relative_phase = 0.")
-                raise ValueError
+                raise CalibrationError(
+                    "All X rotation must be set with relative_phase = 0."
+                )
 
     @classmethod
     def from_platform(cls, platform: Platform):

--- a/src/qibocal/calibration/platform.py
+++ b/src/qibocal/calibration/platform.py
@@ -1,3 +1,4 @@
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -7,6 +8,8 @@ from .calibration import CALIBRATION, Calibration
 
 __all__ = ["CalibrationPlatform", "create_calibration_platform"]
 
+log = logging.getLogger(__name__)
+
 
 @dataclass
 class CalibrationPlatform(Platform):
@@ -14,6 +17,36 @@ class CalibrationPlatform(Platform):
 
     calibration: Calibration = None
     """Calibration information."""
+
+    def __post_init__(self):
+        """
+        Post-initialization method for the Platform class.
+        Validates that all X rotation native gates (RX, RX90, RX12) for each qubit
+        have a relative_phase of 0.0. If any gate does not meet this condition,
+        logs an error and raises a ValueError.
+        """
+
+        natives = self.parameters.native_gates.single_qubit
+        for q in self.qubits:
+            phase_rx = (
+                True
+                if natives[q].RX() is None
+                else natives[q].RX()[0][1].relative_phase == 0.0
+            )
+            phase_rx90 = (
+                True
+                if natives[q].RX90() is None
+                else natives[q].RX90()[0][1].relative_phase == 0.0
+            )
+            phase_rx12 = (
+                True
+                if natives[q].RX() is None
+                else natives[q].RX12()[0][1].relative_phase == 0.0
+            )
+
+            if not (phase_rx and phase_rx90 and phase_rx12):
+                log.error("%s - All X rotation must be set with relative_phase = 0.")
+                raise ValueError
 
     @classmethod
     def from_platform(cls, platform: Platform):

--- a/tests/platforms/mock1_faulty/calibration.json
+++ b/tests/platforms/mock1_faulty/calibration.json
@@ -1,0 +1,78 @@
+{
+  "single_qubits": {
+    "0": {
+      "resonator": {
+        "bare_frequency": 0.0,
+        "dressed_frequency": null,
+        "depletion_time": 0
+      },
+      "qubit": {
+        "frequency_01": 4000000000.0,
+        "frequency_12": 3800000000.0,
+        "maximum_frequency": 4000000000.0,
+        "asymmetry": 0.0,
+        "sweetspot": 0.0,
+        "flux_coefficients": [
+          2.0,
+          0.1,
+          0.001
+        ]
+      },
+      "readout": {
+        "fidelity": 0.0,
+        "ground_state": [
+          0.0,
+          1.0
+        ],
+        "excited_state": [
+          1.0,
+          0.0
+        ]
+      },
+      "rb_fidelity": null
+    },
+    "1": {
+      "resonator": {
+        "bare_frequency": 0.0,
+        "dressed_frequency": 4900000000.0,
+        "depletion_time": 0
+      },
+      "qubit": {
+        "frequency_01": 4200000000.0,
+        "frequency_12": 4000000000.0,
+        "maximum_frequency": 4000000000.0,
+        "asymmetry": 0.0,
+        "sweetspot": 0.0,
+        "flux_coefficients": [
+          2.0,
+          0.1,
+          0.001
+        ]
+      },
+      "readout": {
+        "fidelity": 0.0,
+        "ground_state": [
+          0.25,
+          0.0
+        ],
+        "excited_state": [
+          0.0,
+          0.25
+        ],
+        "qudits_frequency": {
+          "1": 6100000000.0
+        }
+      },
+      "rb_fidelity": null
+    }
+  },
+  "two_qubits": {
+    "0-1": {
+      "rb_fidelity": [
+        0.99,
+        0.01
+      ]
+    }
+  },
+  "readout_mitigation_matrix": "k05VTVBZAQB2AHsnZGVzY3InOiAnPGk4JywgJ2ZvcnRyYW5fb3JkZXInOiBGYWxzZSwgJ3NoYXBlJzogKDIsKSwgfSAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAoEAAAAAAAAAAQAAAAAAAAAk05VTVBZAQB2AHsnZGVzY3InOiAnPGY4JywgJ2ZvcnRyYW5fb3JkZXInOiBGYWxzZSwgJ3NoYXBlJzogKDE2LCksIH0gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAoEAAAAAAAcwNHMzMzMzARAmpmZmZmZ6T9nZmZmZmYSQAQAAAAAAAhAZWZmZmZmEkCamZmZmZkJwDUzMzMzMwvAAgAAAAAACEA2MzMzMzMLwGZmZmZmZgZAZWZmZmZm9r8CAAAAAAAIQGlmZmZmZva/NDMzMzMz878yMzMzMzPjP5NOVU1QWQEAdgB7J2Rlc2NyJzogJzxpNCcsICdmb3J0cmFuX29yZGVyJzogRmFsc2UsICdzaGFwZSc6ICgxNiwpLCB9ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKAAAAAAEAAAACAAAAAwAAAAAAAAABAAAAAgAAAAMAAAAAAAAAAQAAAAIAAAADAAAAAAAAAAEAAAACAAAAAwAAAJNOVU1QWQEAdgB7J2Rlc2NyJzogJzxpNCcsICdmb3J0cmFuX29yZGVyJzogRmFsc2UsICdzaGFwZSc6ICg1LCksIH0gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKAAAAAAQAAAAIAAAADAAAABAAAAA="
+}

--- a/tests/platforms/mock1_faulty/parameters.json
+++ b/tests/platforms/mock1_faulty/parameters.json
@@ -1,0 +1,300 @@
+{
+  "settings": {
+    "nshots": 1024,
+    "relaxation_time": 0
+  },
+  "configs": {
+    "0/drive": {
+      "kind": "iq",
+      "frequency": 4000000000.0
+    },
+    "1/drive": {
+      "kind": "iq",
+      "frequency": 4200000000.0
+    },
+    "0/drive12": {
+      "kind": "iq",
+      "frequency": 4700000000.0
+    },
+    "1/drive12": {
+      "kind": "iq",
+      "frequency": 4855663000.0
+    },
+    "0/flux": {
+      "kind": "dc-filter",
+      "offset": -0.1,
+      "filter": []
+    },
+    "1/flux": {
+      "kind": "dc-filter",
+      "offset": 0.0,
+      "filter": []
+    },
+
+    "0/probe": {
+      "kind": "iq",
+      "frequency": 7200000000.0
+    },
+    "1/probe": {
+      "kind": "iq",
+      "frequency": 7400000000.0
+    },
+    "0/acquisition": {
+      "kind": "acquisition",
+      "delay": 0.0,
+      "smearing": 0.0,
+      "threshold": 0.0,
+      "iq_angle": 0.0,
+      "kernel": "k05VTVBZAQB2AHsnZGVzY3InOiAnPGY4JywgJ2ZvcnRyYW5fb3JkZXInOiBGYWxzZSwgJ3NoYXBlJzogKDEwLCksIH0gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAp5sDfS7uHlP2DIMKNvnKc/gCqN8KV/pT94FQCYYJC3PzSbwfi/894/APwg6C61rj8MSN3blizAP2ha9unQYsM/+BFjHTxcwT+gXaJazvbpPw=="
+    },
+    "1/acquisition": {
+      "kind": "acquisition",
+      "delay": 0.0,
+      "smearing": 0.0,
+      "threshold": 0.0,
+      "iq_angle": 0.0,
+      "kernel": "k05VTVBZAQB2AHsnZGVzY3InOiAnPGY4JywgJ2ZvcnRyYW5fb3JkZXInOiBGYWxzZSwgJ3NoYXBlJzogKDEwLCksIH0gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAr4dT6V5tHrP1w+JhHImN8/sPePZeSUuj/4yTKrD5fRP/ysonZip98/6GJMAPV9xD/LTiJo4k7oP96aWXpxduU/6fUxETe/7z9GXEBNGebWPw=="
+    },
+    "coupler_01/flux": {
+      "kind": "dc-filter",
+      "offset": 0.0,
+      "filter": []
+    },
+    "twpa_pump": {
+      "kind": "oscillator",
+      "frequency": 1000000000.0,
+      "power": 10.0
+    },
+    "0/drive_lo": {
+            "kind": "oscillator",
+            "frequency": 4900000000,
+            "power": 0
+    },
+    "1/drive_lo": {
+            "kind": "oscillator",
+            "frequency": 4900000000,
+            "power": 0
+    },
+    "01/probe_lo": {
+            "kind": "oscillator",
+            "frequency": 7000000000,
+            "power": 0
+    }
+
+  },
+  "native_gates": {
+    "single_qubit": {
+      "0": {
+        "RX": null,
+        "RX90": null,
+        "RX12": null,
+        "MZ": [
+          [
+            "0/acquisition",
+            {
+              "kind": "readout",
+              "acquisition": {
+                "kind": "acquisition",
+                "duration": 2000.0
+              },
+              "probe": {
+                "duration": 2000.0,
+                "amplitude": 0.1,
+                "envelope": {
+                  "kind": "gaussian_square",
+                  "sigma": 0.2,
+                  "risefall": 10
+                },
+                "relative_phase": 0.0,
+                "kind": "pulse"
+              }
+            }
+          ]
+        ],
+        "CP": null
+      },
+      "1": {
+        "RX": [
+          [
+            "1/drive",
+            {
+              "duration": 40.0,
+              "amplitude": 0.3,
+              "envelope": {
+                "kind": "drag",
+                "rel_sigma": 0.2,
+                "beta": 0.02
+              },
+              "relative_phase": 1.5,
+              "kind": "pulse"
+            }
+          ]
+        ],
+        "RX90": [
+          [
+            "1/drive",
+            {
+              "duration": 40.0,
+              "amplitude": 0.15,
+              "envelope": {
+                "kind": "drag",
+                "rel_sigma": 0.2,
+                "beta": 0.02
+              },
+              "relative_phase": 0.0,
+              "kind": "pulse"
+            }
+          ]
+        ],
+        "RX12": [
+          [
+            "1/drive12",
+            {
+              "duration": 40.0,
+              "amplitude": 0.3,
+              "envelope": {
+                "kind": "drag",
+                "rel_sigma": 0.2,
+                "beta": 0.02
+              },
+              "relative_phase": 3.14,
+              "kind": "pulse"
+            }
+          ]
+        ],
+        "MZ": [
+          [
+            "1/acquisition",
+            {
+              "kind": "readout",
+              "acquisition": {
+                "kind": "acquisition",
+                "duration": 2000.0
+              },
+              "probe": {
+                "duration": 2000.0,
+                "amplitude": 0.1,
+                "envelope": {
+                  "kind": "gaussian_square",
+                  "sigma": 0.2,
+                  "risefall": 10
+                },
+                "relative_phase": 0.0,
+                "kind": "pulse"
+              }
+            }
+          ]
+        ],
+        "CP": null
+      }
+    },
+    "two_qubit": {
+      "0-1": {
+        "CZ": [
+          [
+            "1/flux",
+            {
+              "duration": 30.0,
+              "amplitude": 0.05,
+              "envelope": {
+                "kind": "gaussian_square",
+                "sigma": 0.2,
+                "risefall": 2
+              },
+              "relative_phase": 0.0,
+              "kind": "pulse"
+            }
+          ],
+          [
+            "0/drive",
+            {
+              "phase": 0.0,
+              "kind": "virtualz"
+            }
+          ],
+          [
+            "1/drive",
+            {
+              "phase": 0.0,
+              "kind": "virtualz"
+            }
+          ],
+          [
+            "coupler_01/flux",
+            {
+              "duration": 30.0,
+              "amplitude": 0.05,
+              "envelope": {
+                "kind": "gaussian_square",
+                "sigma": 0.2,
+                "risefall": 2
+              },
+              "relative_phase": 0.0,
+              "kind": "pulse"
+            }
+          ]
+        ],
+        "CNOT": [
+          [
+            "1/drive",
+            {
+              "duration": 40.0,
+              "amplitude": 0.3,
+              "envelope": {
+                "kind": "drag",
+                "rel_sigma": 0.2,
+                "beta": 0.02
+              },
+              "relative_phase": 0.0,
+              "kind": "pulse"
+            }
+          ]
+        ],
+        "iSWAP": [
+          [
+            "1/flux",
+            {
+              "duration": 30.0,
+              "amplitude": 0.05,
+              "envelope": {
+                "kind": "gaussian_square",
+                "sigma": 0.2,
+                "risefall": 2
+              },
+              "relative_phase": 0.0,
+              "kind": "pulse"
+            }
+          ],
+          [
+            "0/drive",
+            {
+              "phase": 0.0,
+              "kind": "virtualz"
+            }
+          ],
+          [
+            "1/drive",
+            {
+              "phase": 0.0,
+              "kind": "virtualz"
+            }
+          ],
+          [
+            "coupler_01/flux",
+            {
+              "duration": 30.0,
+              "amplitude": 0.05,
+              "envelope": {
+                "kind": "gaussian_square",
+                "sigma": 0.2,
+                "risefall": 2
+              },
+              "relative_phase": 0.0,
+              "kind": "pulse"
+            }
+          ]
+        ]
+      }
+      }
+    }
+}

--- a/tests/platforms/mock1_faulty/platform.py
+++ b/tests/platforms/mock1_faulty/platform.py
@@ -1,0 +1,51 @@
+import pathlib
+
+from qibolab import ConfigKinds
+from qibolab._core.components import AcquisitionChannel, DcChannel, IqChannel
+from qibolab._core.instruments.dummy import DummyInstrument, DummyLocalOscillator
+from qibolab._core.parameters import Hardware
+from qibolab._core.platform import Platform
+from qibolab._core.qubits import Qubit
+
+from qibocal.protocols.utils import DcFilteredConfig
+
+ConfigKinds.extend([DcFilteredConfig])
+
+FOLDER = pathlib.Path(__file__).parent
+
+
+def create_mock_hardware() -> Hardware:
+    """Create dummy hardware configuration based on the dummy instrument."""
+
+    qubits = {}
+    channels = {}
+    # attach the channels
+    pump_name = "twpa_pump"
+    for q in range(2):
+        drive12 = f"{q}/drive12"
+        qubits[q] = qubit = Qubit.default(q, drive_extra={(1, 2): drive12})
+        channels |= {
+            qubit.probe: IqChannel(mixer=None, lo="01/probe_lo"),
+            qubit.acquisition: AcquisitionChannel(
+                twpa_pump=pump_name, probe=qubit.probe
+            ),
+            qubit.drive: IqChannel(mixer=None, lo=f"{q}/drive_lo"),
+            drive12: IqChannel(mixer=None, lo=f"{q}/drive_lo"),
+            qubit.flux: DcChannel(),
+        }
+
+    couplers = {}
+    couplers["01"] = coupler = Qubit(flux="coupler_01/flux")
+    channels |= {coupler.flux: DcChannel()}
+    # register the instruments
+    instruments = {
+        "dummy": DummyInstrument(address="0.0.0.0", channels=channels),
+        pump_name: DummyLocalOscillator(address="0.0.0.0"),
+    }
+    return Hardware(instruments=instruments, qubits=qubits, couplers=couplers)
+
+
+def create() -> Platform:
+    """Create a dummy platform using the dummy instrument."""
+    hardware = create_mock_hardware()
+    return Platform.load(path=FOLDER, **vars(hardware))

--- a/tests/platforms/mock2/calibration.json
+++ b/tests/platforms/mock2/calibration.json
@@ -1,0 +1,78 @@
+{
+  "single_qubits": {
+    "0": {
+      "resonator": {
+        "bare_frequency": 0.0,
+        "dressed_frequency": null,
+        "depletion_time": 0
+      },
+      "qubit": {
+        "frequency_01": 4000000000.0,
+        "frequency_12": 3800000000.0,
+        "maximum_frequency": 4000000000.0,
+        "asymmetry": 0.0,
+        "sweetspot": 0.0,
+        "flux_coefficients": [
+          2.0,
+          0.1,
+          0.001
+        ]
+      },
+      "readout": {
+        "fidelity": 0.0,
+        "ground_state": [
+          0.0,
+          1.0
+        ],
+        "excited_state": [
+          1.0,
+          0.0
+        ]
+      },
+      "rb_fidelity": null
+    },
+    "1": {
+      "resonator": {
+        "bare_frequency": 0.0,
+        "dressed_frequency": 4900000000.0,
+        "depletion_time": 0
+      },
+      "qubit": {
+        "frequency_01": 4200000000.0,
+        "frequency_12": 4000000000.0,
+        "maximum_frequency": 4000000000.0,
+        "asymmetry": 0.0,
+        "sweetspot": 0.0,
+        "flux_coefficients": [
+          2.0,
+          0.1,
+          0.001
+        ]
+      },
+      "readout": {
+        "fidelity": 0.0,
+        "ground_state": [
+          0.25,
+          0.0
+        ],
+        "excited_state": [
+          0.0,
+          0.25
+        ],
+        "qudits_frequency": {
+          "1": 6100000000.0
+        }
+      },
+      "rb_fidelity": null
+    }
+  },
+  "two_qubits": {
+    "0-1": {
+      "rb_fidelity": [
+        0.99,
+        0.01
+      ]
+    }
+  },
+  "readout_mitigation_matrix": "k05VTVBZAQB2AHsnZGVzY3InOiAnPGk4JywgJ2ZvcnRyYW5fb3JkZXInOiBGYWxzZSwgJ3NoYXBlJzogKDIsKSwgfSAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAoEAAAAAAAAAAQAAAAAAAAAk05VTVBZAQB2AHsnZGVzY3InOiAnPGY4JywgJ2ZvcnRyYW5fb3JkZXInOiBGYWxzZSwgJ3NoYXBlJzogKDE2LCksIH0gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAoEAAAAAAAcwNHMzMzMzARAmpmZmZmZ6T9nZmZmZmYSQAQAAAAAAAhAZWZmZmZmEkCamZmZmZkJwDUzMzMzMwvAAgAAAAAACEA2MzMzMzMLwGZmZmZmZgZAZWZmZmZm9r8CAAAAAAAIQGlmZmZmZva/NDMzMzMz878yMzMzMzPjP5NOVU1QWQEAdgB7J2Rlc2NyJzogJzxpNCcsICdmb3J0cmFuX29yZGVyJzogRmFsc2UsICdzaGFwZSc6ICgxNiwpLCB9ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKAAAAAAEAAAACAAAAAwAAAAAAAAABAAAAAgAAAAMAAAAAAAAAAQAAAAIAAAADAAAAAAAAAAEAAAACAAAAAwAAAJNOVU1QWQEAdgB7J2Rlc2NyJzogJzxpNCcsICdmb3J0cmFuX29yZGVyJzogRmFsc2UsICdzaGFwZSc6ICg1LCksIH0gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKAAAAAAQAAAAIAAAADAAAABAAAAA="
+}

--- a/tests/platforms/mock2/parameters.json
+++ b/tests/platforms/mock2/parameters.json
@@ -1,0 +1,269 @@
+{
+  "settings": {
+    "nshots": 1024,
+    "relaxation_time": 0
+  },
+  "configs": {
+    "0/drive": {
+      "kind": "iq",
+      "frequency": 4000000000.0
+    },
+    "1/drive": {
+      "kind": "iq",
+      "frequency": 4200000000.0
+    },
+    "0/drive12": {
+      "kind": "iq",
+      "frequency": 4700000000.0
+    },
+    "1/drive12": {
+      "kind": "iq",
+      "frequency": 4855663000.0
+    },
+    "0/flux": {
+      "kind": "dc-filter",
+      "offset": -0.1,
+      "filter": []
+    },
+    "1/flux": {
+      "kind": "dc-filter",
+      "offset": 0.0,
+      "filter": []
+    },
+
+    "0/probe": {
+      "kind": "iq",
+      "frequency": 7200000000.0
+    },
+    "1/probe": {
+      "kind": "iq",
+      "frequency": 7400000000.0
+    },
+    "0/acquisition": {
+      "kind": "acquisition",
+      "delay": 0.0,
+      "smearing": 0.0,
+      "threshold": 0.0,
+      "iq_angle": 0.0,
+      "kernel": "k05VTVBZAQB2AHsnZGVzY3InOiAnPGY4JywgJ2ZvcnRyYW5fb3JkZXInOiBGYWxzZSwgJ3NoYXBlJzogKDEwLCksIH0gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAp5sDfS7uHlP2DIMKNvnKc/gCqN8KV/pT94FQCYYJC3PzSbwfi/894/APwg6C61rj8MSN3blizAP2ha9unQYsM/+BFjHTxcwT+gXaJazvbpPw=="
+    },
+    "1/acquisition": {
+      "kind": "acquisition",
+      "delay": 0.0,
+      "smearing": 0.0,
+      "threshold": 0.0,
+      "iq_angle": 0.0,
+      "kernel": "k05VTVBZAQB2AHsnZGVzY3InOiAnPGY4JywgJ2ZvcnRyYW5fb3JkZXInOiBGYWxzZSwgJ3NoYXBlJzogKDEwLCksIH0gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAr4dT6V5tHrP1w+JhHImN8/sPePZeSUuj/4yTKrD5fRP/ysonZip98/6GJMAPV9xD/LTiJo4k7oP96aWXpxduU/6fUxETe/7z9GXEBNGebWPw=="
+    },
+    "coupler_01/flux": {
+      "kind": "dc-filter",
+      "offset": 0.0,
+      "filter": []
+    },
+    "twpa_pump": {
+      "kind": "oscillator",
+      "frequency": 1000000000.0,
+      "power": 10.0
+    },
+    "0/drive_lo": {
+            "kind": "oscillator",
+            "frequency": 4900000000,
+            "power": 0
+    },
+    "1/drive_lo": {
+            "kind": "oscillator",
+            "frequency": 4900000000,
+            "power": 0
+    },
+    "01/probe_lo": {
+            "kind": "oscillator",
+            "frequency": 7000000000,
+            "power": 0
+    }
+
+  },
+  "native_gates": {
+    "single_qubit": {
+      "0": {
+        "RX": [
+          [
+            "0/drive",
+            {
+              "duration": 40,
+              "amplitude": 0.1,
+              "envelope": {
+                "kind": "gaussian",
+                "rel_sigma": 0.2
+              },
+              "relative_phase": 0.0,
+              "kind": "pulse"
+            }
+          ]
+        ],
+        "RX90": null,
+        "RX12": null,
+        "MZ": [
+          [
+            "0/acquisition",
+            {
+              "kind": "readout",
+              "acquisition": {
+                "kind": "acquisition",
+                "duration": 2000.0
+              },
+              "probe": {
+                "duration": 2000.0,
+                "amplitude": 0.1,
+                "envelope": {
+                  "kind": "gaussian_square",
+                  "sigma": 0.2,
+                  "risefall": 10
+                },
+                "relative_phase": 0.0,
+                "kind": "pulse"
+              }
+            }
+          ]
+        ],
+        "CP": null
+      },
+      "1": {
+        "RX": null,
+        "RX90": null,
+        "RX12": null,
+        "MZ": [
+          [
+            "1/acquisition",
+            {
+              "kind": "readout",
+              "acquisition": {
+                "kind": "acquisition",
+                "duration": 2000.0
+              },
+              "probe": {
+                "duration": 2000.0,
+                "amplitude": 0.1,
+                "envelope": {
+                  "kind": "gaussian_square",
+                  "sigma": 0.2,
+                  "risefall": 10
+                },
+                "relative_phase": 0.0,
+                "kind": "pulse"
+              }
+            }
+          ]
+        ],
+        "CP": null
+      }
+    },
+    "two_qubit": {
+      "0-1": {
+        "CZ": [
+          [
+            "1/flux",
+            {
+              "duration": 30.0,
+              "amplitude": 0.05,
+              "envelope": {
+                "kind": "gaussian_square",
+                "sigma": 0.2,
+                "risefall": 2
+              },
+              "relative_phase": 0.0,
+              "kind": "pulse"
+            }
+          ],
+          [
+            "0/drive",
+            {
+              "phase": 0.0,
+              "kind": "virtualz"
+            }
+          ],
+          [
+            "1/drive",
+            {
+              "phase": 0.0,
+              "kind": "virtualz"
+            }
+          ],
+          [
+            "coupler_01/flux",
+            {
+              "duration": 30.0,
+              "amplitude": 0.05,
+              "envelope": {
+                "kind": "gaussian_square",
+                "sigma": 0.2,
+                "risefall": 2
+              },
+              "relative_phase": 0.0,
+              "kind": "pulse"
+            }
+          ]
+        ],
+        "CNOT": [
+          [
+            "1/drive",
+            {
+              "duration": 40.0,
+              "amplitude": 0.3,
+              "envelope": {
+                "kind": "drag",
+                "rel_sigma": 0.2,
+                "beta": 0.02
+              },
+              "relative_phase": 0.0,
+              "kind": "pulse"
+            }
+          ]
+        ],
+        "iSWAP": [
+          [
+            "1/flux",
+            {
+              "duration": 30.0,
+              "amplitude": 0.05,
+              "envelope": {
+                "kind": "gaussian_square",
+                "sigma": 0.2,
+                "risefall": 2
+              },
+              "relative_phase": 0.0,
+              "kind": "pulse"
+            }
+          ],
+          [
+            "0/drive",
+            {
+              "phase": 0.0,
+              "kind": "virtualz"
+            }
+          ],
+          [
+            "1/drive",
+            {
+              "phase": 0.0,
+              "kind": "virtualz"
+            }
+          ],
+          [
+            "coupler_01/flux",
+            {
+              "duration": 30.0,
+              "amplitude": 0.05,
+              "envelope": {
+                "kind": "gaussian_square",
+                "sigma": 0.2,
+                "risefall": 2
+              },
+              "relative_phase": 0.0,
+              "kind": "pulse"
+            }
+          ]
+        ]
+      }
+      }
+    }
+}

--- a/tests/platforms/mock2/platform.py
+++ b/tests/platforms/mock2/platform.py
@@ -1,0 +1,51 @@
+import pathlib
+
+from qibolab import ConfigKinds
+from qibolab._core.components import AcquisitionChannel, DcChannel, IqChannel
+from qibolab._core.instruments.dummy import DummyInstrument, DummyLocalOscillator
+from qibolab._core.parameters import Hardware
+from qibolab._core.platform import Platform
+from qibolab._core.qubits import Qubit
+
+from qibocal.protocols.utils import DcFilteredConfig
+
+ConfigKinds.extend([DcFilteredConfig])
+
+FOLDER = pathlib.Path(__file__).parent
+
+
+def create_mock_hardware() -> Hardware:
+    """Create dummy hardware configuration based on the dummy instrument."""
+
+    qubits = {}
+    channels = {}
+    # attach the channels
+    pump_name = "twpa_pump"
+    for q in range(2):
+        drive12 = f"{q}/drive12"
+        qubits[q] = qubit = Qubit.default(q, drive_extra={(1, 2): drive12})
+        channels |= {
+            qubit.probe: IqChannel(mixer=None, lo="01/probe_lo"),
+            qubit.acquisition: AcquisitionChannel(
+                twpa_pump=pump_name, probe=qubit.probe
+            ),
+            qubit.drive: IqChannel(mixer=None, lo=f"{q}/drive_lo"),
+            drive12: IqChannel(mixer=None, lo=f"{q}/drive_lo"),
+            qubit.flux: DcChannel(),
+        }
+
+    couplers = {}
+    couplers["01"] = coupler = Qubit(flux="coupler_01/flux")
+    channels |= {coupler.flux: DcChannel()}
+    # register the instruments
+    instruments = {
+        "dummy": DummyInstrument(address="0.0.0.0", channels=channels),
+        pump_name: DummyLocalOscillator(address="0.0.0.0"),
+    }
+    return Hardware(instruments=instruments, qubits=qubits, couplers=couplers)
+
+
+def create() -> Platform:
+    """Create a dummy platform using the dummy instrument."""
+    hardware = create_mock_hardware()
+    return Platform.load(path=FOLDER, **vars(hardware))

--- a/tests/platforms/mock2/platform.py
+++ b/tests/platforms/mock2/platform.py
@@ -1,15 +1,13 @@
-import pathlib
-
 from qibolab import ConfigKinds
 from qibolab._core.components import AcquisitionChannel, DcChannel, IqChannel
 from qibolab._core.instruments.dummy import DummyInstrument, DummyLocalOscillator
 from qibolab._core.parameters import Hardware
-from qibolab._core.platform import Platform
 from qibolab._core.qubits import Qubit
 
 from qibocal.protocols.utils import DcFilteredConfig
 
 ConfigKinds.extend([DcFilteredConfig])
+
 
 def create() -> Hardware:
     """Create dummy hardware configuration based on the dummy instrument."""

--- a/tests/platforms/mock2/platform.py
+++ b/tests/platforms/mock2/platform.py
@@ -11,10 +11,7 @@ from qibocal.protocols.utils import DcFilteredConfig
 
 ConfigKinds.extend([DcFilteredConfig])
 
-FOLDER = pathlib.Path(__file__).parent
-
-
-def create_mock_hardware() -> Hardware:
+def create() -> Hardware:
     """Create dummy hardware configuration based on the dummy instrument."""
 
     qubits = {}
@@ -43,9 +40,3 @@ def create_mock_hardware() -> Hardware:
         pump_name: DummyLocalOscillator(address="0.0.0.0"),
     }
     return Hardware(instruments=instruments, qubits=qubits, couplers=couplers)
-
-
-def create() -> Platform:
-    """Create a dummy platform using the dummy instrument."""
-    hardware = create_mock_hardware()
-    return Platform.load(path=FOLDER, **vars(hardware))

--- a/tests/test_calibration_platform.py
+++ b/tests/test_calibration_platform.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import pytest
+from qibolab import create_platform
+from qibolab._core.platform.load import PLATFORMS
+
+from qibocal.calibration.platform import CalibrationError, CalibrationPlatform
+
+
+def test_validation_calibration_platform(monkeypatch):
+    """Test for phase validation in the CalibrationPlatform initialization."""
+
+    monkeypatch.setenv(PLATFORMS, str(Path(__file__).parent / "platforms"))
+
+    faulty_plat_name = "mock1_faulty"
+    faulty_platform = create_platform(faulty_plat_name)
+    with pytest.raises(CalibrationError):
+        _ = CalibrationPlatform.from_platform(faulty_platform)
+
+    good_plat_name = "mock2"
+    good_platform = create_platform(good_plat_name)
+    cal_plat = CalibrationPlatform.from_platform(good_platform)
+    assert isinstance(cal_plat, CalibrationPlatform)


### PR DESCRIPTION
We noticed an incosistency in Qibocal when handling pulses relative phases. 
Intrinsically it relies on the fact that the `relative_phase` of all `X`-rotations present in the platform `parameters.json` are set to `0`, but then it is not validating their actual values. 
This might lead to some inconsistencies if we hard-code different values of these phases (i.e. if we set this phase to `pi/2` and apply a `RX` and a `R(pi, pi/2)` gates we might actually think we are playing RX and RY back-to-back but actually we are playing the same pulse twice).
That's why we decided to add a `__post_init__` method that checks that all relative phases for all calibrated X pulses have effectively 0 relative phase.