### PR TITLE
RB: make inner loop over circuit-depth for better packing of batches

### DIFF
--- a/src/qibocal/protocols/randomized_benchmarking/utils.py
+++ b/src/qibocal/protocols/randomized_benchmarking/utils.py
@@ -382,9 +382,9 @@ def _generate_indexed_circuits(
 
     inv_file = getattr(params, "file_inv", None)
 
-    for depth in params.depths:
-        for target in targets:
-            for iteration in range(params.niter):
+    for target in targets:
+        for iteration in range(params.niter):
+            for depth in params.depths:
                 circuit = layer_circuit(rb_gen, depth, target, interleave)
                 if inverse_layer:
                     add_inverse_layer(circuit, rb_gen, inv_file)


### PR DESCRIPTION
Since doing the optimal packing for many sequences into batches is computationally inefficient, qibolab relies on approximate methods. For now, the best result I obtained is by doing a small optimization in qibolab, on top of an inner loop over depths. This is mostly empirical, and at some point we may change qibolab to perform it's own ordering first, but since this works best after some empirical tests, I'd like to make this change in qibocal. 

Still to be tested on qpu. 