### PR TITLE
purge `hardware_average` and `classify` from `Parameters` Class

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -38,7 +38,7 @@ autodoc_default_options = {
     "undoc-members": True,
     "private-members": True,
     "inherited-members": True,
-    "exclude-members": "load, execution_parameters, classify",
+    "exclude-members": "load",
 }
 
 # Add any Sphinx extension module names here, as strings. They can be

--- a/src/qibocal/auto/operation.py
+++ b/src/qibocal/auto/operation.py
@@ -9,7 +9,7 @@ from typing import Callable, Generic, NewType, Optional, TypeVar, Union
 
 import numpy as np
 import numpy.typing as npt
-from qibolab import AcquisitionType, AveragingMode, Platform, Qubit
+from qibolab import Platform, Qubit
 
 from qibocal.config import log
 
@@ -70,11 +70,7 @@ class Parameters:
     nshots: int
     """Number of executions on hardware."""
     relaxation_time: float
-    """Wait time for the qubit to decohere back to the `gnd` state."""
-    hardware_average: bool = False
-    """By default hardware average will be performed."""
-    classify: bool = False
-    """By default qubit state classification will not be performed."""
+    """Wait time for the qubit to decohere back to the ground state."""
 
     @classmethod
     def load(cls, input_parameters):
@@ -98,24 +94,6 @@ class Parameters:
         for parameter, value in default_parent_parameters.items():
             setattr(instantiated_class, parameter, value)
         return instantiated_class
-
-    @property
-    def execution_parameters(self):
-        """Default execution parameters."""
-        averaging_mode = (
-            AveragingMode.CYCLIC if self.hardware_average else AveragingMode.SINGLESHOT
-        )
-        acquisition_type = (
-            AcquisitionType.DISCRIMINATION
-            if self.classify
-            else AcquisitionType.INTEGRATION
-        )
-        return dict(
-            nshots=self.nshots,
-            relaxation_time=self.relaxation_time,
-            acquisition_type=acquisition_type,
-            averaging_mode=averaging_mode,
-        )
 
 
 class AbstractData:

--- a/src/qibocal/protocols/qubit_spectroscopies/qubit_spectroscopy.py
+++ b/src/qibocal/protocols/qubit_spectroscopies/qubit_spectroscopy.py
@@ -3,7 +3,14 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 import numpy as np
-from qibolab import Delay, Parameter, PulseSequence, Sweeper
+from qibolab import (
+    AcquisitionType,
+    AveragingMode,
+    Delay,
+    Parameter,
+    PulseSequence,
+    Sweeper,
+)
 from qibolab._core.components import IqChannel
 
 from qibocal.auto.operation import Parameters, QubitId, Results, Routine
@@ -44,8 +51,6 @@ class QubitSpectroscopyParameters(Parameters):
     """Drive pulse duration [ns]. Same for all qubits."""
     drive_amplitude: Optional[float] = None
     """Drive pulse amplitude (optional). Same for all qubits."""
-    hardware_average: bool = True
-    """By default hardware average will be performed."""
 
 
 @dataclass
@@ -174,7 +179,10 @@ def _acquisition(
             [sequence],
             [sweepers],
             updates=batch_updates,
-            **params.execution_parameters,
+            averaging_mode=AveragingMode.SINGLESHOT,
+            acquisition_type=AcquisitionType.INTEGRATION,
+            nshots=params.nshots,
+            relaxation_time=params.relaxation_time,
         )
 
         # Collect results from this batch

--- a/src/qibocal/protocols/qubit_spectroscopies/qubit_spectroscopy.py
+++ b/src/qibocal/protocols/qubit_spectroscopies/qubit_spectroscopy.py
@@ -179,7 +179,7 @@ def _acquisition(
             [sequence],
             [sweepers],
             updates=batch_updates,
-            averaging_mode=AveragingMode.SINGLESHOT,
+            averaging_mode=AveragingMode.CYCLIC,
             acquisition_type=AcquisitionType.INTEGRATION,
             nshots=params.nshots,
             relaxation_time=params.relaxation_time,

--- a/src/qibocal/protocols/qubit_spectroscopies/qubit_spectroscopy_ef.py
+++ b/src/qibocal/protocols/qubit_spectroscopies/qubit_spectroscopy_ef.py
@@ -1,7 +1,14 @@
 from dataclasses import asdict, dataclass, field
 
 import numpy as np
-from qibolab import Delay, Parameter, PulseSequence, Sweeper
+from qibolab import (
+    AcquisitionType,
+    AveragingMode,
+    Delay,
+    Parameter,
+    PulseSequence,
+    Sweeper,
+)
 
 from qibocal.auto.operation import QubitId, Routine
 from qibocal.calibration import CalibrationPlatform
@@ -130,7 +137,10 @@ def _acquisition(
             }
             for q in targets
         ],
-        **params.execution_parameters,
+        averaging_mode=AveragingMode.SINGLESHOT,
+        acquisition_type=AcquisitionType.INTEGRATION,
+        nshots=params.nshots,
+        relaxation_time=params.relaxation_time,
     )
 
     # retrieve the results for every qubit

--- a/src/qibocal/protocols/qubit_spectroscopies/qubit_spectroscopy_ef.py
+++ b/src/qibocal/protocols/qubit_spectroscopies/qubit_spectroscopy_ef.py
@@ -137,7 +137,7 @@ def _acquisition(
             }
             for q in targets
         ],
-        averaging_mode=AveragingMode.SINGLESHOT,
+        averaging_mode=AveragingMode.CYCLIC,
         acquisition_type=AcquisitionType.INTEGRATION,
         nshots=params.nshots,
         relaxation_time=params.relaxation_time,

--- a/tests/runcards/protocols.yml
+++ b/tests/runcards/protocols.yml
@@ -49,7 +49,7 @@ actions:
       fit_function: s21
       nshots: 10
 
-  - id: qubit spectroscopy average
+  - id: qubit spectroscopy
     operation: qubit_spectroscopy
     parameters:
       drive_amplitude: 0.001
@@ -68,17 +68,7 @@ actions:
       step_amp: 0.05
       duration: 100
 
-  - id: qubit spectroscopy singleshot
-    operation: qubit_spectroscopy
-    parameters:
-      drive_amplitude: 0.001
-      drive_duration: 1000
-      freq_width: 2_000_000
-      freq_step: 200_000
-      nshots: 10
-      hardware_average: false
-
-  - id: qubit spectroscopy ef average
+  - id: qubit spectroscopy ef
     operation: qubit_spectroscopy_ef
     parameters:
       drive_amplitude: 0.001
@@ -86,17 +76,6 @@ actions:
       freq_width: 2_000_000
       freq_step: 500_000
       nshots: 10
-
-  - id: qubit spectroscopy ef single shot
-    operation: qubit_spectroscopy_ef
-    parameters:
-      drive_amplitude: 0.001
-      drive_duration: 1000
-      freq_width: 2_000_000
-      freq_step: 200_000
-      nshots: 10
-      hardware_average: false
-
 
   - id: resonator flux dependence bias
     operation: resonator_flux


### PR DESCRIPTION
closes https://github.com/qiboteam/qibocal/issues/1418

These flags could always be provided as input but were ignored in all protocols except qubit spectroscopy. There is no point in exposing them to the user since the acquisition type and averaging mode should be fixed depending on the protocol. 

SINGLESHOT -> CYCLIC for qubit spectroscopy will be done in a separate PR