### PR TITLE
Add support for parallel benchmarking

### DIFF
--- a/src/qibocal/protocols/randomized_benchmarking/utils.py
+++ b/src/qibocal/protocols/randomized_benchmarking/utils.py
@@ -34,7 +34,7 @@ from .fitting import fit_exp1B_func
 
 
 class CircuitIndex(BaseModel):
-    """Tracks the (qubits, depth, iteration) CircuitIndex of a circuit."""
+    """Tracks the (depth, iteration) CircuitIndex of a circuit."""
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
@@ -413,7 +413,7 @@ def _execute_indexed_circuits(
     indexed_circuits: list[IndexedCircuit],
     params: Parameters,
     platform: CalibrationPlatform,
-    targets: list[QubitId],
+    qubit_map: list[QubitId],
     averaging_mode: AveragingMode = AveragingMode.SINGLESHOT,
 ) -> list[IndexedResult]:
     """Execute indexed circuits and return results paired with their indices.
@@ -422,13 +422,13 @@ def _execute_indexed_circuits(
         indexed_circuits: List of IndexedCircuit objects to execute.
         params: Experiment parameters.
         platform: CalibrationPlatform to execute on.
-        targets: List of target qubit IDs.
+        qubit_map: List of physical qubit IDs.
 
     Returns:
         List of IndexedResult objects with execution results paired with their indices.
     """
 
-    qubit_maps = [targets] * len(indexed_circuits)
+    qubit_maps = [qubit_map] * len(indexed_circuits)
     circuits = []
     for indexed_circuit in indexed_circuits:
         circuits.append(indexed_circuit.circuit)
@@ -492,7 +492,7 @@ def rb_acquisition(
         indexed_circuits=indexed_circuits,
         params=params,
         platform=platform,
-        targets=targets,
+        qubit_map=targets,
         averaging_mode=AveragingMode.CYCLIC
         if len(targets) == 1
         else AveragingMode.SINGLESHOT,
@@ -560,7 +560,7 @@ def twoq_rb_acquisition(
         indexed_circuits=indexed_circuits,
         params=params,
         platform=platform,
-        targets=list(chain.from_iterable(targets)),
+        qubit_map=list(chain.from_iterable(targets)),
     )
 
     # Create a dict of the form {(qubit[0], qubit[1], depth): list[result]}.

--- a/src/qibocal/protocols/randomized_benchmarking/utils.py
+++ b/src/qibocal/protocols/randomized_benchmarking/utils.py
@@ -38,7 +38,6 @@ class CircuitIndex(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    targets: list[QubitId]
     depth: int
     iteration: int
 
@@ -360,7 +359,7 @@ def setup_data(
 def _generate_indexed_circuits(
     params: Parameters,
     rb_gen: RBGenerator,
-    targets: list[QubitId | QubitPairId],
+    targets: list[QubitId] | list[QubitPairId],
     inverse_layer: bool = True,
     interleave: str | None = None,
 ) -> list[IndexedCircuit]:
@@ -402,7 +401,6 @@ def _generate_indexed_circuits(
 
             add_measurement_layer(full_circuit)
             index = CircuitIndex(
-                targets=list(chain.from_iterable(targets)) if two_qubit else targets,
                 depth=depth,
                 iteration=iteration,
             )
@@ -415,28 +413,24 @@ def _execute_indexed_circuits(
     indexed_circuits: list[IndexedCircuit],
     params: Parameters,
     platform: CalibrationPlatform,
+    targets: list[QubitId],
     averaging_mode: AveragingMode = AveragingMode.SINGLESHOT,
 ) -> list[IndexedResult]:
     """Execute indexed circuits and return results paired with their indices.
 
     Args:
         indexed_circuits: List of IndexedCircuit objects to execute.
-        targets: List of target qubit IDs.
         params: Experiment parameters.
         platform: CalibrationPlatform to execute on.
+        targets: List of target qubit IDs.
 
     Returns:
         List of IndexedResult objects with execution results paired with their indices.
     """
 
-    qubit_maps = []
+    qubit_maps = [targets] * len(indexed_circuits)
     circuits = []
     for indexed_circuit in indexed_circuits:
-        target = indexed_circuit.index.targets
-        if isinstance(target, (list, tuple)):  # Multi-qubit, default
-            qubit_maps.append(list(target))
-        else:  # Single-qubit
-            qubit_maps.append([target])
         circuits.append(indexed_circuit.circuit)
 
     transpiler = build_native_gate_transpiler(platform)
@@ -498,6 +492,7 @@ def rb_acquisition(
         indexed_circuits=indexed_circuits,
         params=params,
         platform=platform,
+        targets=targets,
         averaging_mode=AveragingMode.CYCLIC
         if len(targets) == 1
         else AveragingMode.SINGLESHOT,
@@ -565,6 +560,7 @@ def twoq_rb_acquisition(
         indexed_circuits=indexed_circuits,
         params=params,
         platform=platform,
+        targets=list(chain.from_iterable(targets)),
     )
 
     # Create a dict of the form {(qubit[0], qubit[1], depth): list[result]}.

--- a/src/qibocal/protocols/randomized_benchmarking/utils.py
+++ b/src/qibocal/protocols/randomized_benchmarking/utils.py
@@ -1,6 +1,7 @@
 import pathlib
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
+from itertools import chain
 from numbers import Number
 from typing import Union
 
@@ -27,23 +28,23 @@ from qibocal.protocols.randomized_benchmarking.dict_utils import (
     load_cliffords,
     separator,
 )
-from qibocal.protocols.utils import significant_digit
+from qibocal.protocols.utils import marginalize_qubit_counts, significant_digit
 
 from .fitting import fit_exp1B_func
 
 
 class CircuitIndex(BaseModel):
-    """Tracks the (qubit, depth, iteration) CircuitIndex of a circuit."""
+    """Tracks the (qubits, depth, iteration) CircuitIndex of a circuit."""
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    qubit: QubitId | QubitPairId
+    targets: list[QubitId]
     depth: int
     iteration: int
 
 
 class IndexedCircuit(BaseModel):
-    """A circuit paired with its (qubit, depth, iteration) CircuitIndex."""
+    """A circuit paired with its (qubits, depth, iteration) CircuitIndex."""
 
     # arbitrary_types_allowed is needed to allow the Circuit type to be a field.
     model_config = ConfigDict(frozen=True, extra="forbid", arbitrary_types_allowed=True)
@@ -359,7 +360,7 @@ def setup_data(
 def _generate_indexed_circuits(
     params: Parameters,
     rb_gen: RBGenerator,
-    targets,  # list[QubitId] or list[QubitPairId]
+    targets: list[QubitId | QubitPairId],
     inverse_layer: bool = True,
     interleave: str | None = None,
 ) -> list[IndexedCircuit]:
@@ -380,16 +381,32 @@ def _generate_indexed_circuits(
 
     inv_file = getattr(params, "file_inv", None)
 
-    for target in targets:
-        for iteration in range(params.niter):
-            for depth in params.depths:
+    assert len(targets) > 0
+    two_qubit = isinstance(targets[0], tuple)
+    nqubits = len(targets) * (2 if two_qubit else 1)
+
+    qubit_map = {
+        target: (idx * 2, idx * 2 + 1) if two_qubit else (idx,)
+        # Reverse assignment for big-endianess
+        for idx, target in enumerate(reversed(targets))
+    }
+
+    for iteration in range(params.niter):
+        for depth in params.depths:
+            full_circuit = Circuit(nqubits)
+            for target in targets:
                 circuit = layer_circuit(rb_gen, depth, target, interleave)
                 if inverse_layer:
                     add_inverse_layer(circuit, rb_gen, inv_file)
-                add_measurement_layer(circuit)
+                full_circuit.add(circuit.on_qubits(*qubit_map[target]))
 
-                index = CircuitIndex(qubit=target, depth=depth, iteration=iteration)
-                indexed_circuits.append(IndexedCircuit(circuit=circuit, index=index))
+            add_measurement_layer(full_circuit)
+            index = CircuitIndex(
+                targets=list(chain.from_iterable(targets)) if two_qubit else targets,
+                depth=depth,
+                iteration=iteration,
+            )
+            indexed_circuits.append(IndexedCircuit(circuit=full_circuit, index=index))
 
     return indexed_circuits
 
@@ -415,11 +432,11 @@ def _execute_indexed_circuits(
     qubit_maps = []
     circuits = []
     for indexed_circuit in indexed_circuits:
-        qubit = indexed_circuit.index.qubit
-        if isinstance(qubit, (list, tuple)):  # Multi-qubit
-            qubit_maps.append(list(qubit))
+        target = indexed_circuit.index.targets
+        if isinstance(target, (list, tuple)):  # Multi-qubit, default
+            qubit_maps.append(list(target))
         else:  # Single-qubit
-            qubit_maps.append([qubit])
+            qubit_maps.append([target])
         circuits.append(indexed_circuit.circuit)
 
     transpiler = build_native_gate_transpiler(platform)
@@ -481,19 +498,21 @@ def rb_acquisition(
         indexed_circuits=indexed_circuits,
         params=params,
         platform=platform,
-        averaging_mode=AveragingMode.CYCLIC,
+        averaging_mode=AveragingMode.CYCLIC
+        if len(targets) == 1
+        else AveragingMode.SINGLESHOT,
     )
 
     # Create a dict of the form {(qubit, depth): list[result]}.
     # This marginalises over the iterations for a given (qubit, depth)
     grouped: defaultdict = defaultdict(list)
     for indexed_result in indexed_results:
-        key = (indexed_result.index.qubit, indexed_result.index.depth)
-        survival_counts = (
-            indexed_result.result["0"] if inverse_layer else indexed_result.result["1"]
-        )
-        survival_prob = survival_counts / params.nshots
-        grouped[key].append(survival_prob)
+        for qubit_id, target in enumerate(targets):
+            result = marginalize_qubit_counts(indexed_result.result, qubit_id)
+            key = (target, indexed_result.index.depth)
+            survival_counts = result["0"] if inverse_layer else result["1"]
+            survival_prob = survival_counts / params.nshots
+            grouped[key].append(survival_prob)
 
     for (qubit, depth), results in grouped.items():
         data.register_qubit(
@@ -552,16 +571,16 @@ def twoq_rb_acquisition(
     # This marginalises over the iterations for a given (qubit_pair, depth)
     grouped: defaultdict = defaultdict(list)
     for indexed_result in indexed_results:
-        qubit_pair = indexed_result.index.qubit
-        assert isinstance(qubit_pair, tuple)
-        key = (qubit_pair[0], qubit_pair[1], indexed_result.index.depth)
-        survival_counts = (
-            indexed_result.result["00"]
-            if inverse_layer
-            else indexed_result.result["11"]
-        )
-        survival_prob = survival_counts / params.nshots
-        grouped[key].append(survival_prob)
+        for pair_id, qubit_pair in enumerate(targets):
+            partial_result = marginalize_qubit_counts(
+                indexed_result.result, [pair_id * 2, pair_id * 2 + 1]
+            )
+            key = (qubit_pair[0], qubit_pair[1], indexed_result.index.depth)
+            survival_counts = (
+                partial_result["00"] if inverse_layer else partial_result["11"]
+            )
+            survival_prob = survival_counts / params.nshots
+            grouped[key].append(survival_prob)
 
     for (qubit0, qubit1, depth), results in grouped.items():
         data.register_qubit(

--- a/src/qibocal/protocols/randomized_benchmarking/utils.py
+++ b/src/qibocal/protocols/randomized_benchmarking/utils.py
@@ -384,7 +384,7 @@ def _generate_indexed_circuits(
     two_qubit = isinstance(targets[0], tuple)
     nqubits = len(targets) * (2 if two_qubit else 1)
 
-    qubit_map = {
+    target_id_map = {
         target: (idx * 2, idx * 2 + 1) if two_qubit else (idx,)
         # Reverse assignment for big-endianess
         for idx, target in enumerate(reversed(targets))
@@ -397,7 +397,7 @@ def _generate_indexed_circuits(
                 circuit = layer_circuit(rb_gen, depth, target, interleave)
                 if inverse_layer:
                     add_inverse_layer(circuit, rb_gen, inv_file)
-                full_circuit.add(circuit.on_qubits(*qubit_map[target]))
+                full_circuit.add(circuit.on_qubits(*target_id_map[target]))
 
             add_measurement_layer(full_circuit)
             index = CircuitIndex(

--- a/src/qibocal/protocols/randomized_benchmarking/utils.py
+++ b/src/qibocal/protocols/randomized_benchmarking/utils.py
@@ -43,7 +43,7 @@ class CircuitIndex(BaseModel):
 
 
 class IndexedCircuit(BaseModel):
-    """A circuit paired with its (qubits, depth, iteration) CircuitIndex."""
+    """A circuit paired with its (depth, iteration) CircuitIndex."""
 
     # arbitrary_types_allowed is needed to allow the Circuit type to be a field.
     model_config = ConfigDict(frozen=True, extra="forbid", arbitrary_types_allowed=True)
@@ -53,7 +53,7 @@ class IndexedCircuit(BaseModel):
 
 
 class IndexedResult(BaseModel):
-    """An execution result paired with its (qubit, depth, iteration) CircuitIndex."""
+    """An execution result paired with its (depth, iteration) CircuitIndex."""
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 

--- a/src/qibocal/protocols/randomized_benchmarking/utils.py
+++ b/src/qibocal/protocols/randomized_benchmarking/utils.py
@@ -386,7 +386,7 @@ def _generate_indexed_circuits(
 
     target_id_map = {
         target: (idx * 2, idx * 2 + 1) if two_qubit else (idx,)
-        # Reverse assignment for big-endianess
+        # Reverse assignment for little-endianess resolution
         for idx, target in enumerate(reversed(targets))
     }
 

--- a/tests/test_randomized_benchmarking.py
+++ b/tests/test_randomized_benchmarking.py
@@ -3,10 +3,11 @@ from functools import reduce
 import numpy as np
 import pytest
 
-from qibocal.protocols.randomized_benchmarking import fitting
+from qibocal.protocols.randomized_benchmarking import fitting, standard_rb
 from qibocal.protocols.randomized_benchmarking.dict_utils import load_inverse_cliffords
 from qibocal.protocols.randomized_benchmarking.utils import (
     RBGenerator,
+    _generate_indexed_circuits,
     generate_inv_dict_cliffords_file,
     layer_circuit,
     load_cliffords,
@@ -194,3 +195,26 @@ def test_layer_circuit_two_qubit(mocker, depth):
     circuit_gates = [g for m in circuit.queue.moments for g in m if g is not None]
     for gates in two_qubit_spy.spy_return_list:
         assert all(g in circuit_gates for g in gates)
+
+
+def test_single_qubit_circuit_generation_parallel():
+    targets = [0, 1, 2]
+    params = standard_rb.parameters_type.load(dict(depths=[1], niter=1))
+    rb_gen = RBGenerator(123)
+    circuits = _generate_indexed_circuits(params=params, rb_gen=rb_gen, targets=targets)
+    assert len(circuits) == 1
+
+    circuit = circuits[0].circuit
+    assert circuit.nqubits == len(targets)
+    assert circuit.ngates == len(targets) * 3
+
+
+def test_two_qubit_circuit_generation_parallel():
+    targets = [(0, 1), (2, 3), (4, 5)]
+    params = standard_rb.parameters_type.load(dict(depths=[1], niter=1))
+    rb_gen = RBGenerator(123, file="2qubitCliffs.json")
+    circuits = _generate_indexed_circuits(params=params, rb_gen=rb_gen, targets=targets)
+    assert len(circuits) == 1
+
+    circuit = circuits[0].circuit
+    assert circuit.nqubits == len(targets) * 2


### PR DESCRIPTION
Following PR https://github.com/qiboteam/qibocal/pull/1393, this is a rework of PR https://github.com/qiboteam/qibocal/pull/1416 with the new RB and circuit execution APIs.

For each depth/iteration combination, we generate a benchmarking circuit for each qubit pair and fuse them together into a larger circuit. These circuits are then accumulated onto an array which is passed for batched execution.

It may be nice to add a flag to re-use the same circuit for all pairs to save time on sequence generation.

Tests on QPU
(without parallel benchmarking)
[rb-2q-test.tar.gz](https://github.com/user-attachments/files/27583241/rb-2q-test.tar.gz)

(with parallel benchmarking)
[rb-2q-test.tar.gz](https://github.com/user-attachments/files/27592429/rb-2q-test.tar.gz)
