### PR TITLE
improve intial parameters guess Lorentzian fit

### DIFF
--- a/src/qibocal/protocols/utils.py
+++ b/src/qibocal/protocols/utils.py
@@ -133,7 +133,8 @@ def lorentzian_fit(data, resonator_type=None, fit=None):
             frequencies[indices_beyond_half[-1]] - frequencies[indices_beyond_half[0]]
         ) / 2
     else:
-        guess_sigma = frequencies[1] - frequencies[0]
+        # if there is no clear peak, we give a high flexibility
+        guess_sigma = frequencies[-1] - frequencies[0]
 
     guess_amp = guess_peak_height * guess_sigma * np.pi
 

--- a/src/qibocal/protocols/utils.py
+++ b/src/qibocal/protocols/utils.py
@@ -108,34 +108,45 @@ def lorentzian_fit(data, resonator_type=None, fit=None):
     voltages = data.signal
 
     # Guess parameters for Lorentzian max or min
-    # TODO: probably this is not working on HW
-    guess_offset = np.mean(
-        voltages[np.abs(voltages - np.mean(voltages)) < np.std(voltages)]
-    )
-    guess_slope = 0.0
+    guess_slope = (voltages[-1] - voltages[0]) / (frequencies[-1] - frequencies[0])
+    guess_offset = voltages[0] - guess_slope * frequencies[0]
+    voltages_no_background = voltages - (guess_slope * frequencies + guess_offset)
+
     if (resonator_type == "3D" and fit == "resonator") or (
         resonator_type == "2D" and fit == "qubit"
     ):
-        guess_center = frequencies[
-            np.argmax(voltages)
-        ]  # Argmax = Returns the indices of the maximum values along an axis.
-        guess_sigma = abs(frequencies[np.argmin(voltages)] - guess_center)
-        guess_amp = (np.max(voltages) - guess_offset) * guess_sigma * np.pi
-
+        guess_center = frequencies[np.argmax(voltages_no_background)]
+        peak_amp = voltages_no_background.max()
+        indices_beyond_half = np.where(voltages_no_background > peak_amp / 2)[0]
     else:
-        guess_center = frequencies[
-            np.argmin(voltages)
-        ]  # Argmin = Returns the indices of the minimum values along an axis.
-        guess_sigma = abs(frequencies[np.argmax(voltages)] - guess_center)
-        guess_amp = (np.min(voltages) - guess_offset) * guess_sigma * np.pi
+        guess_center = frequencies[np.argmin(voltages_no_background)]
+        peak_amp = voltages_no_background.min()
+        indices_beyond_half = np.where(voltages_no_background < peak_amp / 2)[0]
+
+    if len(indices_beyond_half) >= 1:
+        guess_sigma = (
+            frequencies[indices_beyond_half[-1]] - frequencies[indices_beyond_half[0]]
+        ) / 2
+    else:
+        guess_sigma = frequencies[1] - frequencies[0]
+
+    guess_amp = peak_amp * guess_sigma * np.pi
+    guess_offset_at_center = guess_slope * guess_center + guess_offset
 
     initial_parameters = [
         guess_amp,
         guess_center,
         guess_sigma,
-        guess_offset,
+        guess_offset_at_center,
         guess_slope,
     ]
+
+    freq_domain_size = frequencies[-1] - frequencies[0]
+    bounds = (
+        [-np.inf, frequencies[0], 0.0, -np.inf, -np.inf],
+        [np.inf, frequencies[-1], freq_domain_size, np.inf, np.inf],
+    )
+
     # fit the model with the data and guessed parameters
     try:
         sigma = (
@@ -150,6 +161,7 @@ def lorentzian_fit(data, resonator_type=None, fit=None):
             voltages,
             p0=initial_parameters,
             sigma=sigma,
+            bounds=bounds,
         )
         # The output results are stored in a json, but ndarray is not JSON serializable,
         # so the parameters are converted to list.

--- a/src/qibocal/protocols/utils.py
+++ b/src/qibocal/protocols/utils.py
@@ -140,7 +140,6 @@ def lorentzian_fit(data, resonator_type=None, fit=None):
         guess_offset_at_center,
         guess_slope,
     ]
-
     freq_domain_size = frequencies[-1] - frequencies[0]
     bounds = (
         [-np.inf, frequencies[0], 0.0, -np.inf, -np.inf],
@@ -149,27 +148,16 @@ def lorentzian_fit(data, resonator_type=None, fit=None):
 
     # fit the model with the data and guessed parameters
     try:
-        sigma = (
-            data.error_signal
-            if (hasattr(data, "error_signal") and not np.isnan(data.error_signal).any())
-            else None
-        )
-
         fit_parameters, perr = curve_fit(
             lorentzian,
             frequencies,
             voltages,
             p0=initial_parameters,
-            sigma=sigma,
             bounds=bounds,
         )
         # The output results are stored in a json, but ndarray is not JSON serializable,
         # so the parameters are converted to list.
-        perr = (
-            np.sqrt(np.diag(perr)).tolist()
-            if sigma is not None
-            else [0] * len(initial_parameters)
-        )
+        perr = np.sqrt(np.diag(perr)).tolist()
         model_parameters = fit_parameters.tolist()
         return model_parameters[1] * GHZ_TO_HZ, model_parameters, perr
     except RuntimeError as e:

--- a/src/qibocal/protocols/utils.py
+++ b/src/qibocal/protocols/utils.py
@@ -110,18 +110,23 @@ def lorentzian_fit(data, resonator_type=None, fit=None):
     # Guess parameters for Lorentzian max or min
     guess_slope = (voltages[-1] - voltages[0]) / (frequencies[-1] - frequencies[0])
     guess_offset = voltages[0] - guess_slope * frequencies[0]
-    voltages_no_background = voltages - (guess_slope * frequencies + guess_offset)
+    guess_background = guess_offset + guess_slope * frequencies
+    voltages_no_background = voltages - guess_background
 
     if (resonator_type == "3D" and fit == "resonator") or (
         resonator_type == "2D" and fit == "qubit"
     ):
         guess_center = frequencies[np.argmax(voltages_no_background)]
-        peak_amp = voltages_no_background.max()
-        indices_beyond_half = np.where(voltages_no_background > peak_amp / 2)[0]
+        guess_peak_height = voltages_no_background.max()
+        indices_beyond_half = np.where(voltages_no_background > guess_peak_height / 2)[
+            0
+        ]
     else:
         guess_center = frequencies[np.argmin(voltages_no_background)]
-        peak_amp = voltages_no_background.min()
-        indices_beyond_half = np.where(voltages_no_background < peak_amp / 2)[0]
+        guess_peak_height = voltages_no_background.min()
+        indices_beyond_half = np.where(voltages_no_background < guess_peak_height / 2)[
+            0
+        ]
 
     if len(indices_beyond_half) >= 1:
         guess_sigma = (
@@ -130,14 +135,13 @@ def lorentzian_fit(data, resonator_type=None, fit=None):
     else:
         guess_sigma = frequencies[1] - frequencies[0]
 
-    guess_amp = peak_amp * guess_sigma * np.pi
-    guess_offset_at_center = guess_slope * guess_center + guess_offset
+    guess_amp = guess_peak_height * guess_sigma * np.pi
 
     initial_parameters = [
         guess_amp,
         guess_center,
         guess_sigma,
-        guess_offset_at_center,
+        guess_offset,
         guess_slope,
     ]
     freq_domain_size = frequencies[-1] - frequencies[0]
@@ -148,7 +152,7 @@ def lorentzian_fit(data, resonator_type=None, fit=None):
 
     # fit the model with the data and guessed parameters
     try:
-        fit_parameters, perr = curve_fit(
+        fit_parameters, parameters_cov = curve_fit(
             lorentzian,
             frequencies,
             voltages,
@@ -157,9 +161,9 @@ def lorentzian_fit(data, resonator_type=None, fit=None):
         )
         # The output results are stored in a json, but ndarray is not JSON serializable,
         # so the parameters are converted to list.
-        perr = np.sqrt(np.diag(perr)).tolist()
+        parameter_errors = np.sqrt(np.diag(parameters_cov)).tolist()
         model_parameters = fit_parameters.tolist()
-        return model_parameters[1] * GHZ_TO_HZ, model_parameters, perr
+        return model_parameters[1] * GHZ_TO_HZ, model_parameters, parameter_errors
     except RuntimeError as e:
         log.warning(f"Lorentzian fit not successful due to {e}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,9 @@ TESTING_PLATFORM_NAMES = [
     "mock",
 ]
 
+TEST_FILE_DIR = Path(__file__).resolve().parent
+PATH_TESTING_DATA = TEST_FILE_DIR / "tests_data"
+
 
 @pytest.fixture(autouse=True)
 def cd(tmp_path_factory: pytest.TempdirFactory):

--- a/tests/test_fit_functions.py
+++ b/tests/test_fit_functions.py
@@ -1,9 +1,7 @@
 import json
 import math
-from pathlib import Path
 
 import numpy as np
-import pytest
 
 from qibocal.protocols.rabi.utils import (
     fit_amplitude_function as rabi_fit_amplitude_function,
@@ -11,17 +9,9 @@ from qibocal.protocols.rabi.utils import (
 from qibocal.protocols.rabi.utils import fit_length_function as rabi_fit_length_function
 from qibocal.protocols.ramsey.processing import fitting as ramsey_fitting
 from qibocal.protocols.ramsey.processing import process_fit as ramsey_process_fit
-from qibocal.protocols.resonator_spectroscopies.resonator_spectroscopy import (
-    ResonatorSpectroscopyData,
-    ResonatorSpectroscopyResults,
-)
-from qibocal.protocols.resonator_spectroscopies.resonator_spectroscopy import (
-    _fit as resonator_spectroscopy_fit,
-)
 from qibocal.protocols.utils import fallback_period, guess_period
 
-TEST_FILE_DIR = Path(__file__).resolve().parent
-PATH_TESTING_DATA = TEST_FILE_DIR / "tests_data"
+from .conftest import TEST_FILE_DIR
 
 
 def test_ramsey_fit():
@@ -158,13 +148,3 @@ def test_rabi_fit():
                     true_duration = results['"duration"'][f]
 
                 assert math.isclose(true_duration, new_duration, rel_tol=2.5e-2)
-
-
-def test_resonator_spectroscopy_fit():
-    results_folder = PATH_TESTING_DATA / "resonator_spectroscopy-0"
-    data = ResonatorSpectroscopyData.load(results_folder)
-    expected = ResonatorSpectroscopyResults.load(results_folder)
-    assert data is not None and expected is not None
-    fitted = resonator_spectroscopy_fit(data)
-    qubit = 0  # the data contains only qubit 0
-    assert fitted.frequency[qubit] == pytest.approx(expected.frequency[qubit])

--- a/tests/test_fit_functions.py
+++ b/tests/test_fit_functions.py
@@ -2,6 +2,7 @@ import json
 import math
 
 import numpy as np
+from conftest import TEST_FILE_DIR
 
 from qibocal.protocols.rabi.utils import (
     fit_amplitude_function as rabi_fit_amplitude_function,
@@ -10,8 +11,6 @@ from qibocal.protocols.rabi.utils import fit_length_function as rabi_fit_length_
 from qibocal.protocols.ramsey.processing import fitting as ramsey_fitting
 from qibocal.protocols.ramsey.processing import process_fit as ramsey_process_fit
 from qibocal.protocols.utils import fallback_period, guess_period
-
-from .conftest import TEST_FILE_DIR
 
 
 def test_ramsey_fit():

--- a/tests/test_resonator_spectroscopy.py
+++ b/tests/test_resonator_spectroscopy.py
@@ -1,0 +1,20 @@
+import pytest
+from conftest import PATH_TESTING_DATA
+
+from qibocal.protocols.resonator_spectroscopies.resonator_spectroscopy import (
+    ResonatorSpectroscopyData,
+    ResonatorSpectroscopyResults,
+)
+from qibocal.protocols.resonator_spectroscopies.resonator_spectroscopy import (
+    _fit as resonator_spectroscopy_fit,
+)
+
+
+def test_resonator_spectroscopy_fit():
+    results_folder = PATH_TESTING_DATA / "resonator_spectroscopy-0"
+    data = ResonatorSpectroscopyData.load(results_folder)
+    expected = ResonatorSpectroscopyResults.load(results_folder)
+    assert data is not None and expected is not None
+    fitted = resonator_spectroscopy_fit(data)
+    qubit = 0  # the data contains only qubit 0
+    assert fitted.frequency[qubit] == pytest.approx(expected.frequency[qubit])


### PR DESCRIPTION
closes #1408

The fits in #1408 that before failed now pass.

The background was made linear in an earlier PR. In this PR we heavily rely on the assumption of a linear background to make the guesses for the initial parameters so it is stable only up to a point where the background is linear enough. 

Specifically what changed are the following things:
- the linear background consisting of offset and slope is now estimated from the endpoints of the frequency domain. This linear function is subtracted before peak detection, so argmax/argmin operate on the residual signal.
- sigma is now derived from the half-maximum width of the peak after subtracting the linear background from the data. Before the distance between argmax and argmin of the raw data was used, which is much less stable.
- uncertainties are no longer passed to the fit function since uncertainties in a spectroscopy are largely unnecessary overhead. Bounds have been added to constrain the fit parameters. 

