### PR TITLE
Improve flipping sequence generation

### DIFF
--- a/src/qibocal/protocols/flipping.py
+++ b/src/qibocal/protocols/flipping.py
@@ -31,27 +31,18 @@ def flipping_sequence(
 ):
     """Pulse sequence for flipping experiment."""
 
-    sequence = PulseSequence()
     natives = platform.natives.single_qubit[qubit]
+    sequence = natives.R(theta=np.pi / 2)
 
-    sequence |= natives.R(theta=np.pi / 2)
+    if rx90:
+        qd_channel, qd_pulse = natives.RX90()[0]
+    else:
+        qd_channel, qd_pulse = natives.RX()[0]
 
-    for _ in range(flips):
-        if rx90:
-            qd_channel, qd_pulse = natives.RX90()[0]
-        else:
-            qd_channel, qd_pulse = natives.RX()[0]
-
-        qd_detuned = update.replace(
-            qd_pulse, amplitude=qd_pulse.amplitude + delta_amplitude
-        )
-        sequence.append((qd_channel, qd_detuned))
-        sequence.append((qd_channel, qd_detuned))
-
-        if rx90:
-            sequence.append((qd_channel, qd_detuned))
-            sequence.append((qd_channel, qd_detuned))
-
+    qd_detuned = update.replace(
+        qd_pulse, amplitude=qd_pulse.amplitude + delta_amplitude
+    )
+    sequence.extend([(qd_channel, qd_detuned)] * (flips * (4 if rx90 else 2)))
     sequence |= natives.MZ()
 
     return sequence


### PR DESCRIPTION
While testing https://github.com/qiboteam/qibocal/pull/1504, I noticed that the flipping sequence generation was a bit slow especially with the default settings.

I tried to speed it up by moving the detuned pulse generation out of the loop and using `list.extend` instead of multiple `list.append` calls. Not sure if there is a problem for the other instruments if the same pulse object is reused.

QPU test to check if flipping still works
[flipping.tar.gz](https://github.com/user-attachments/files/28004630/flipping.tar.gz)


Small perf test and script
```
New flipping sequence generation completed in 2.848101232200861s
New flipping sequence generation completed in 2.8209174927324057s
New flipping sequence generation completed in 2.805138450115919s
New flipping sequence generation completed in 2.8024905808269978s
New flipping sequence generation completed in 2.812884099781513s
Previous flipping sequence generation completed in 7.275865795090795s
Previous flipping sequence generation completed in 7.24155573733151s
Previous flipping sequence generation completed in 7.248768800869584s
Previous flipping sequence generation completed in 7.233881413936615s
Previous flipping sequence generation completed in 7.333734508603811s
```

```python
import time


import numpy as np
from qibocal import update
from qibocal.auto.operation import QubitId
from qibocal.calibration import CalibrationPlatform, create_calibration_platform
from qibolab import PulseSequence


def flipping_sequence_new(
    platform: CalibrationPlatform,
    qubit: QubitId,
    delta_amplitude: float,
    flips: int,
    rx90: bool,
):
    """Pulse sequence for flipping experiment."""

    natives = platform.natives.single_qubit[qubit]
    sequence = natives.R(theta=np.pi / 2)

    if rx90:
        qd_channel, qd_pulse = natives.RX90()[0]
    else:
        qd_channel, qd_pulse = natives.RX()[0]

    qd_detuned = update.replace(
        qd_pulse, amplitude=qd_pulse.amplitude + delta_amplitude
    )
    sequence.extend([(qd_channel, qd_detuned)] * (flips * (4 if rx90 else 2)))
    sequence |= natives.MZ()

    return sequence

def flipping_sequence(
    platform: CalibrationPlatform,
    qubit: QubitId,
    delta_amplitude: float,
    flips: int,
    rx90: bool,
):
    """Pulse sequence for flipping experiment."""

    sequence = PulseSequence()
    natives = platform.natives.single_qubit[qubit]

    sequence |= natives.R(theta=np.pi / 2)

    for _ in range(flips):
        if rx90:
            qd_channel, qd_pulse = natives.RX90()[0]
        else:
            qd_channel, qd_pulse = natives.RX()[0]

        qd_detuned = update.replace(
            qd_pulse, amplitude=qd_pulse.amplitude + delta_amplitude
        )
        sequence.append((qd_channel, qd_detuned))
        sequence.append((qd_channel, qd_detuned))

        if rx90:
            sequence.append((qd_channel, qd_detuned))
            sequence.append((qd_channel, qd_detuned))

    sequence |= natives.MZ()

    return sequence

flips_range = range(0, 21, 1)
delta_amplitude_range = np.arange(-0.05,0.05,0.001)
platform = create_calibration_platform("sinq20")


for k in range(5):
    start = time.perf_counter()
    for qb in range(20):
        for flips in flips_range:
            for delta_amp in delta_amplitude_range:
                flipping_sequence_new(platform, qb, delta_amp, flips, False)
    end = time.perf_counter()
    print(f"New flipping sequence generation completed in {end-start}s")


for k in range(5):
    start = time.perf_counter()
    for qb in range(20):
        for flips in flips_range:
            for delta_amp in delta_amplitude_range:
                flipping_sequence(platform, qb, delta_amp, flips, False)
    end = time.perf_counter()
    print(f"Previous flipping sequence generation completed in {end-start}s")
```