### PR TITLE
Coupler Ramsey

### DIFF
--- a/src/qibocal/protocols/two_qubit_interaction/__init__.py
+++ b/src/qibocal/protocols/two_qubit_interaction/__init__.py
@@ -1,4 +1,4 @@
-from .chevron import chevron, chevron_signal
+from .chevron import chevron, chevron_signal, coupler_ramsey
 from .chsh import chsh
 from .cross_resonance import (
     cancellation_amplitude_tuning,
@@ -25,4 +25,5 @@ __all__ = [
     "cr_amplitude",
     "cancellation_amplitude_tuning",
     "cancellation_phase_tuning",
+    "coupler_ramsey",
 ]

--- a/src/qibocal/protocols/two_qubit_interaction/chevron/__init__.py
+++ b/src/qibocal/protocols/two_qubit_interaction/chevron/__init__.py
@@ -1,4 +1,5 @@
 from .chevron import chevron
 from .chevron_signal import chevron_signal
+from .coupler_ramsey import coupler_ramsey
 
-__all__ = ["chevron", "chevron_signal"]
+__all__ = ["chevron", "chevron_signal", "coupler_ramsey"]

--- a/src/qibocal/protocols/two_qubit_interaction/chevron/coupler_ramsey.py
+++ b/src/qibocal/protocols/two_qubit_interaction/chevron/coupler_ramsey.py
@@ -1,0 +1,245 @@
+"""Coupler ramsey.
+
+In this experiment, we perform a regular ZZ Ramsey protocol while applying a bias on the coupler.
+This varies the cross-Kerr shift in order to find the coupler bias at which there is no net coupling.
+
+NOTE: This assumes the qubit frequency is already well-calibrated from an existing Ramsey procedure.
+"""
+
+from dataclasses import dataclass, field
+
+import numpy as np
+import numpy.typing as npt
+import plotly.graph_objects as go
+from qibolab import (
+    AcquisitionType,
+    AveragingMode,
+    Delay,
+    Parameter,
+    Pulse,
+    PulseSequence,
+    Rectangular,
+    Sweeper,
+)
+
+from qibocal.auto.operation import Data, Parameters, QubitPairId, Results, Routine
+from qibocal.calibration import CalibrationPlatform
+from qibocal.protocols.utils import table_dict, table_html
+
+
+@dataclass
+class CouplerRamseyResults(Results):
+    """CouplerRamsey outputs."""
+
+    offset_adjustment: dict[QubitPairId, float]
+    """Coupler offset adjustment."""
+
+
+CouplerRamseyType = np.dtype(
+    [
+        ("tau", np.float64),
+        ("amplitude", np.float64),
+        ("prob", np.float64),
+        ("error", np.float64),
+    ]
+)
+
+
+@dataclass
+class CouplerRamseyData(Data):
+    """CouplerRamsey acquisition outputs."""
+
+    data: dict[QubitPairId, npt.NDArray[CouplerRamseyType]] = field(
+        default_factory=dict
+    )
+    """Raw data acquired."""
+
+
+@dataclass
+class CouplerRamseyParameters(Parameters):
+    """T2Signal runcard inputs."""
+
+    delay_between_pulses_start: int
+    """Initial delay between RX(pi/2) pulses in ns."""
+    delay_between_pulses_end: int
+    """Final delay between RX(pi/2) pulses in ns."""
+    delay_between_pulses_step: int
+    """Step delay between RX(pi/2) pulses in ns."""
+    amplitude_coupler_min: float
+    """Amplitude coupler minimum."""
+    amplitude_coupler_max: float
+    """Amplitude coupler maximum."""
+    amplitude_coupler_step: float
+    """Amplitude coupler step."""
+
+
+def _acquisition(
+    params: CouplerRamseyParameters,
+    platform: CalibrationPlatform,
+    targets: list[QubitPairId],
+):
+    waits = np.arange(
+        params.delay_between_pulses_start,
+        params.delay_between_pulses_end,
+        params.delay_between_pulses_step,
+    )
+    amplitudes = np.arange(
+        params.amplitude_coupler_min,
+        params.amplitude_coupler_max,
+        params.amplitude_coupler_step,
+    )
+
+    sequence = PulseSequence()
+
+    coupler_pulse = Pulse(duration=0, amplitude=0, envelope=Rectangular())
+    delay = Delay(duration=0)
+    coupler_amplitude_sweeper = Sweeper(
+        parameter=Parameter.amplitude, values=amplitudes, pulses=[coupler_pulse]
+    )
+    duration_sweeper = Sweeper(
+        parameter=Parameter.duration, values=waits, pulses=[delay, coupler_pulse]
+    )
+
+    for pair in targets:
+        coupler_channel = platform.couplers[
+            platform.calibration.two_qubits[pair].coupler
+        ].flux
+        target_qubit_id, control_qubit_id = pair
+        target_qubit = platform.qubits[target_qubit_id]
+        rx90 = platform.natives.single_qubit[target_qubit_id].R(np.pi / 2)
+
+        seq = PulseSequence()
+        seq += rx90
+        seq |= [
+            (coupler_channel, coupler_pulse),
+            (target_qubit.acquisition, delay),
+            (target_qubit.drive, delay),
+        ]
+        seq += (
+            rx90 | platform.natives.single_qubit[target_qubit_id].MZ()
+        ).align_to_delays()
+
+        seq += platform.natives.single_qubit[control_qubit_id].RX()
+        # Add the partial sequence to the full sequence
+        sequence += seq
+
+    results = platform.execute(
+        sequences=[sequence],
+        sweepers=[[duration_sweeper], [coupler_amplitude_sweeper]],
+        nshots=params.nshots,
+        relaxation_time=params.relaxation_time,
+        acquisition_type=AcquisitionType.DISCRIMINATION,
+        averaging_mode=AveragingMode.CYCLIC,
+    )
+    data = CouplerRamseyData()
+
+    for pair in targets:
+        target_qubit_id, control_qubit_id = pair
+        ro_pulse = list(sequence.channel(platform.qubits[target_qubit_id].acquisition))[
+            -1
+        ]
+        prob_2d = results[ro_pulse.id]
+
+        for wait, prob_1d in zip(waits, prob_2d):
+            for amplitude, prob in zip(amplitudes, prob_1d):
+                error = np.sqrt(prob * (1 - prob) / params.nshots)
+                data.register_qubit(
+                    CouplerRamseyType,
+                    pair,
+                    {
+                        "tau": np.array([wait]),
+                        "amplitude": np.array([amplitude]),
+                        "prob": np.array([prob]),
+                        "error": np.array([error]),
+                    },
+                )
+    return data
+
+
+def _fit(data: CouplerRamseyData) -> CouplerRamseyResults:
+    offset_adjustment: dict[QubitPairId, list[float]] = {}
+
+    for pair in data.pairs:
+        pair_data = data[pair]
+        amplitudes = np.unique(pair_data["amplitude"])
+        variances = []
+
+        for amp in amplitudes:
+            mask = pair_data["amplitude"] == amp
+            probs = pair_data["prob"][mask]
+            variances.append(float(np.var(probs)))
+
+        best_idx = int(np.argmin(variances))
+        best_amp = float(amplitudes[best_idx])
+
+        offset_adjustment[pair] = [best_amp, 0.0]
+
+    return CouplerRamseyResults(offset_adjustment=offset_adjustment)
+
+
+def _plot(
+    data: CouplerRamseyData,
+    target: QubitPairId,
+    fit: CouplerRamseyResults | None = None,
+):
+    pair_data = data[target]
+    amplitudes = np.unique(pair_data["amplitude"])
+    waits = np.unique(pair_data["tau"])
+
+    # Build 2D probability matrix: rows = waits, cols = amplitudes
+    z = np.full((len(waits), len(amplitudes)), np.nan)
+    amp_index = {amp: i for i, amp in enumerate(amplitudes)}
+    tau_index = {tau: j for j, tau in enumerate(waits)}
+
+    for row in pair_data:
+        i = amp_index[row["amplitude"]]
+        j = tau_index[row["tau"]]
+        z[j, i] = row["prob"]
+
+    fig = go.Figure(
+        go.Heatmap(
+            x=amplitudes,
+            y=waits,
+            z=z,
+            colorscale="viridis",
+            zmid=0.5,
+            colorbar=dict(title={"text": "Excited State Probability", "side": "right"}),
+        )
+    )
+
+    if fit is not None and target in fit.offset_adjustment:
+        best_amp = fit.offset_adjustment[target][0]
+        fig.add_vline(
+            x=best_amp,
+            line=dict(color="black", dash="dash", width=2),
+            annotation_text=f"Offset adjustment: {best_amp:.4f}",
+            annotation_position="right",
+        )
+
+    fig.update_layout(
+        yaxis_title="Time [ns]",
+        xaxis_title="Amplitude [a.u.]",
+    )
+
+    fitting_report = ""
+    if fit is not None and target in fit.offset_adjustment:
+        fitting_report = table_html(
+            table_dict(
+                str(target),
+                ["Offset adjustment [a.u.]"],
+                [fit.offset_adjustment[target]],
+                display_error=True,
+            )
+        )
+
+    return [fig], fitting_report
+
+
+def _update(
+    results: CouplerRamseyResults, platform: CalibrationPlatform, pair: QubitPairId
+):
+    pass
+
+
+coupler_ramsey = Routine(_acquisition, _fit, _plot, _update)
+"""Ramsey Routine object."""

--- a/src/qibocal/protocols/two_qubit_interaction/chevron/coupler_ramsey.py
+++ b/src/qibocal/protocols/two_qubit_interaction/chevron/coupler_ramsey.py
@@ -22,7 +22,7 @@ from qibolab import (
     Sweeper,
 )
 
-from qibocal.auto.operation import Data, Parameters, QubitPairId, Results, Routine
+from qibocal.auto.operation import Data, Parameters, Protocol, QubitPairId, Results
 from qibocal.calibration import CalibrationPlatform
 from qibocal.protocols.utils import table_dict, table_html
 
@@ -241,5 +241,5 @@ def _update(
     pass
 
 
-coupler_ramsey = Routine(_acquisition, _fit, _plot, _update)
-"""Ramsey Routine object."""
+coupler_ramsey = Protocol(_acquisition, _fit, _plot, _update)
+"""Coupler ramsey zz protocol."""


### PR DESCRIPTION
For a generic two qubit coupled system, under the JC model, there should also be a cross-Kerr shift $\chi \propto \frac{g_\text{eff}^2}{\Delta}$, where the effective coupling is dependent on both the static and coupler-mediated coupling. This shift affects the simultaneous use of both qubits due to the frequency shift incurred when conducting parallel single qubit pulses.

After tuning the coupler to the sweetspot, there may be later drifts of the coupler bias resulting in $\chi$ becoming more prominent in simultaneous qubit usage. Hence, we want a quick routine to move the coupler back to the idling spot.

The goal of this experiment is to simply tune the coupler around its current offset to minimize such effects. By performing a ZZ Ramsey experiment, we are able to measure $\chi$. Here, we modify the ZZ Ramsey experiment by inserting a coupler pulse to temporarily adjust $\chi$ during the free evolution time. The amplitude of the coupler pulse and duration of both the coupler pulse and free evolution time are swept to find the point at which $\chi \approx 0$

<img width="1142" height="452" alt="image" src="https://github.com/user-attachments/assets/668ea14d-9ce4-445a-a9bb-2b912ba6794e" />

We initially tried to adjust the offset of the channel itself in our coupler tuning. However, this also affected the dressed frequency of the qubits and led to inaccurate idling positions, which then required single qubit calibration for each offset. Hopefully, this procedure removes the need for that.

### Results

<img width="3065" height="1467" alt="image" src="https://github.com/user-attachments/assets/f9411fc1-b110-42a9-a6fb-4e5f2e9427fe" />

and corresponding Ramsey-ZZ

<img width="3080" height="1550" alt="image" src="https://github.com/user-attachments/assets/dfe4457a-fd04-4cc3-9cb0-8ec336da1f6d" />

Though, if the qubit frequency is not properly calibrated prior to this experiment, $\chi$ will just compensate for the detuning of the $\pi/2$ pulse and lead to an incorrect result.

### Design

We came up with this protocol earlier after the aforementioned problems of calibrating the single qubit parameters for each coupler offset, but were not sure of how to structure the fitting/plotting for Qibocal, so we took it from PR https://github.com/qiboteam/qibocal/pull/1504, which operates on the same principle essentially.

We tried to use the mean instead of the variance, but both led to similar results generally
<img width="1429" height="1600" alt="WhatsApp Image 2026-05-19 at 10 50 05" src="https://github.com/user-attachments/assets/6e2ff793-6ba0-4923-97eb-39eeecc70989" />

QPU Data
[coupler_ramsey.tar.gz](https://github.com/user-attachments/files/28136936/coupler_ramsey.tar.gz)

TODO:

- [ ] Fix plot annotation
- [ ] Add tests
- [ ] Update coupler offset
- [ ] Check if new coupler position is better than previous
- [ ] Refactor result handling