### PR TITLE
remove unused function `flux_coefficients` and module-level variables

### DIFF
--- a/doc/source/protocols/flux/flux_amplitude.rst
+++ b/doc/source/protocols/flux/flux_amplitude.rst
@@ -48,7 +48,7 @@ On the left we can see the detuning on the qubit frequency as a function of the 
 with the corresponding fit (green). Although the correct formula is given by Eq. :math:numref:`transmon`
 in this protocol we approximate the dependence using a quadratic form.
 
-On the right we derive the how the magnetic flux changing by applying a flux pulse by inverting Eq. Eq. :math:numref:`transmon`
+On the right we derive the how the magnetic flux changing by applying a flux pulse by inverting Eq. :math:numref:`transmon`
 to compute the flux experienced by the qubit. We are using an approximation where we neglect both the anharmonicity
 and asymmetry of the junction. We expect a linear dependence which is fitted accordingly.
 

--- a/src/qibocal/auto/operation.py
+++ b/src/qibocal/auto/operation.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 from dataclasses import asdict, dataclass, fields
 from functools import wraps
 from pathlib import Path
-from typing import Generic, NewType, TypeVar, Union
+from typing import Generic, NewType, TypeVar
 
 import numpy as np
 import numpy.typing as npt
@@ -19,8 +19,6 @@ from .serialize import deserialize, load, serialize
 
 OperationId = NewType("OperationId", str)
 """Identifier for a calibration routine."""
-ParameterValue = Union[float, int]
-"""Valid value for a routine and runcard parameter."""
 Qubits = dict[QubitId, Qubit]
 """Convenient way of passing qubit pairs in the routines."""
 

--- a/src/qibocal/protocols/ramsey/processing.py
+++ b/src/qibocal/protocols/ramsey/processing.py
@@ -26,20 +26,13 @@ from .acquisition import RamseyResults
 MAXIMUM_FIT_POINTS = 1_000
 """maximum number of points to use when plotting fit results."""
 
-POPT_EXCEPTION = [0, 0, 0, 0, 1]
-"""Fit parameters output to handle exceptions"""
-PERR_EXCEPTION = [1] * 5
-"""Fit errors to handle exceptions; their choice has no physical meaning
-and is meant to avoid breaking the code."""
-THRESHOLD = 0.5
-"""Threshold parameters for find_peaks to guess frequency for sinusoidal fit."""
 DAMPED_CONSTANT = 1.5
 """See :const:`rabi.utils.QUANTILE_CONSTANT` for details.
 
 In general in Ramsey it's intended to observe the decay of the signal due to decoherence, hence we
 need to correct and decrease a little the value of :const:`rabi.utils.DAMPED_CONSTANT`;
 Indeed, for damped oscillations, the factor is not easily determined, since the
-value associated to a certian quantile depends on the observation window extent, and the
+value associated to a certain quantile depends on the observation window extent, and the
 ratio between the decay rate and the oscillation.
 
 Assuming a mild decay, and we can approximate this factor with the same one for the

--- a/src/qibocal/protocols/resonator_spectroscopies/resonator_utils.py
+++ b/src/qibocal/protocols/resonator_spectroscopies/resonator_utils.py
@@ -30,30 +30,12 @@ from ..utils import (
     table_html,
 )
 
-# from .resonator_punchout import ResonatorPunchoutData
-# from .resonator_punchout_attenuation import ResonatorPunchoutAttenuationData
-
 PHASES_THRESHOLD_PERCENTAGE = 80
 r"""Threshold percentage to ensure the phase data covers a significant portion of the full 2 :math:\pi circle."""
 STD_DEV_GAUSSIAN_KERNEL = 30
 """Standard deviation for the Gaussian kernel."""
 PHASE_ELEMENTS = 5
 """Number of values to better guess :math:`\theta` (in rad) in the phase fit function."""
-SATURATION_WINDOW_RATIO = 5
-"""The ratio of the signal of the window for evaluating the effective saturation of the punchout signal."""
-SATURATION_WINDOW_MAX = 10
-"""Maximum length of the saturation window."""
-SATURATION_WINDOW_MIN = 5
-"""Minimum length of the window the saturation window."""
-SAVGOL_FILTER_WINDOW_RATIO = 5
-"""The ratio of the signal of the Sav-Gol filter window."""
-SAVGOL_FILTER_WINDOW_MIN = 5
-"""The min length forthe Sav-Gol filter window."""
-SAVGOL_FILTER_DERIVATIVE = 1
-"""The order of the derivative to compute."""
-SAVGOL_FILTER_ORDER = 3
-"""The order of the polynomial used to fit the samples."""
-SATURATION_TOLERANCE = 1.5e-3
 
 
 def s21(

--- a/src/qibocal/update.py
+++ b/src/qibocal/update.py
@@ -216,15 +216,6 @@ def sweetspot(sweetspot: float, platform: Platform, qubit: QubitId):
     platform.calibration.single_qubits[qubit].qubit.sweetspot = sweetspot
 
 
-def flux_coefficients(
-    flux_coefficients: list[float], platform: Platform, qubit: QubitId
-):
-    """Update flux-amplitude relation parameters for specific qubit."""
-    platform.calibration.single_qubits[qubit].qubit.flux_coefficients = [
-        value for value in flux_coefficients
-    ]
-
-
 def flux_offset(offset: float, platform: Platform, qubit: QubitId):
     """Update flux offset parameter in platform for specific qubit."""
     platform.update({f"configs.{platform.qubits[qubit].flux}.offset": offset})


### PR DESCRIPTION
`flux_coefficients` is not called anywhere so can be removed. 