### PR TITLE
remove `DcFilteredConfig` since duplicate of `DcConfig` in qibolab

### DIFF
--- a/src/qibocal/protocols/flux_dependence/cryoscope.py
+++ b/src/qibocal/protocols/flux_dependence/cryoscope.py
@@ -203,7 +203,7 @@ def _acquisition(
         data.flux_coefficients[qubit] = platform.calibration.single_qubits[
             qubit
         ].qubit.flux_coefficients
-        data.filters[qubit] = platform.config(platform.qubits[qubit].flux).filter
+        data.filters[qubit] = platform.config(platform.qubits[qubit].flux).filters
 
     sequences_x = []
     sequences_y = []

--- a/src/qibocal/protocols/utils.py
+++ b/src/qibocal/protocols/utils.py
@@ -2,7 +2,6 @@ from collections import Counter
 from collections.abc import Sequence
 from colorsys import hls_to_rgb
 from enum import Enum
-from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -10,7 +9,6 @@ import plotly.express as px
 import plotly.graph_objects as go
 from numpy.typing import NDArray
 from plotly.subplots import make_subplots
-from qibolab._core.components import Config
 from scipy import constants, sparse
 from scipy.optimize import curve_fit
 from scipy.signal import find_peaks
@@ -166,18 +164,6 @@ def lorentzian_fit(data, resonator_type=None, fit=None):
         return model_parameters[1] * GHZ_TO_HZ, model_parameters, parameter_errors
     except RuntimeError as e:
         log.warning(f"Lorentzian fit not successful due to {e}")
-
-
-class DcFilteredConfig(Config):
-    """Dummy config for dc with filters.
-
-    Required by cryoscope protocol.
-
-    """
-
-    kind: Literal["dc-filter"] = "dc-filter"
-    offset: float
-    filter: list
 
 
 def effective_qubit_temperature(

--- a/tests/platforms/mock/parameters.json
+++ b/tests/platforms/mock/parameters.json
@@ -21,14 +21,14 @@
       "frequency": 4855663000.0
     },
     "0/flux": {
-      "kind": "dc-filter",
+      "kind": "dc",
       "offset": -0.1,
-      "filter": []
+      "filters": []
     },
     "1/flux": {
-      "kind": "dc-filter",
+      "kind": "dc",
       "offset": 0.0,
-      "filter": []
+      "filters": []
     },
 
     "0/probe": {
@@ -56,9 +56,9 @@
       "kernel": "k05VTVBZAQB2AHsnZGVzY3InOiAnPGY4JywgJ2ZvcnRyYW5fb3JkZXInOiBGYWxzZSwgJ3NoYXBlJzogKDEwLCksIH0gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAr4dT6V5tHrP1w+JhHImN8/sPePZeSUuj/4yTKrD5fRP/ysonZip98/6GJMAPV9xD/LTiJo4k7oP96aWXpxduU/6fUxETe/7z9GXEBNGebWPw=="
     },
     "coupler_01/flux": {
-      "kind": "dc-filter",
+      "kind": "dc",
       "offset": 0.0,
-      "filter": []
+      "filters": []
     },
     "twpa_pump": {
       "kind": "oscillator",

--- a/tests/platforms/mock/platform.py
+++ b/tests/platforms/mock/platform.py
@@ -1,15 +1,10 @@
 import pathlib
 
-from qibolab import ConfigKinds
 from qibolab._core.components import AcquisitionChannel, DcChannel, IqChannel
 from qibolab._core.instruments.dummy import DummyInstrument, DummyLocalOscillator
 from qibolab._core.parameters import Hardware
 from qibolab._core.platform import Platform
 from qibolab._core.qubits import Qubit
-
-from qibocal.protocols.utils import DcFilteredConfig
-
-ConfigKinds.extend([DcFilteredConfig])
 
 FOLDER = pathlib.Path(__file__).parent
 

--- a/tests/platforms/mock1_faulty/parameters.json
+++ b/tests/platforms/mock1_faulty/parameters.json
@@ -21,14 +21,14 @@
       "frequency": 4855663000.0
     },
     "0/flux": {
-      "kind": "dc-filter",
+      "kind": "dc",
       "offset": -0.1,
-      "filter": []
+      "filters": []
     },
     "1/flux": {
-      "kind": "dc-filter",
+      "kind": "dc",
       "offset": 0.0,
-      "filter": []
+      "filters": []
     },
 
     "0/probe": {
@@ -56,9 +56,9 @@
       "kernel": "k05VTVBZAQB2AHsnZGVzY3InOiAnPGY4JywgJ2ZvcnRyYW5fb3JkZXInOiBGYWxzZSwgJ3NoYXBlJzogKDEwLCksIH0gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAr4dT6V5tHrP1w+JhHImN8/sPePZeSUuj/4yTKrD5fRP/ysonZip98/6GJMAPV9xD/LTiJo4k7oP96aWXpxduU/6fUxETe/7z9GXEBNGebWPw=="
     },
     "coupler_01/flux": {
-      "kind": "dc-filter",
+      "kind": "dc",
       "offset": 0.0,
-      "filter": []
+      "filters": []
     },
     "twpa_pump": {
       "kind": "oscillator",

--- a/tests/platforms/mock1_faulty/platform.py
+++ b/tests/platforms/mock1_faulty/platform.py
@@ -1,15 +1,10 @@
 import pathlib
 
-from qibolab import ConfigKinds
 from qibolab._core.components import AcquisitionChannel, DcChannel, IqChannel
 from qibolab._core.instruments.dummy import DummyInstrument, DummyLocalOscillator
 from qibolab._core.parameters import Hardware
 from qibolab._core.platform import Platform
 from qibolab._core.qubits import Qubit
-
-from qibocal.protocols.utils import DcFilteredConfig
-
-ConfigKinds.extend([DcFilteredConfig])
 
 FOLDER = pathlib.Path(__file__).parent
 

--- a/tests/platforms/mock2/parameters.json
+++ b/tests/platforms/mock2/parameters.json
@@ -21,14 +21,14 @@
       "frequency": 4855663000.0
     },
     "0/flux": {
-      "kind": "dc-filter",
+      "kind": "dc",
       "offset": -0.1,
-      "filter": []
+      "filters": []
     },
     "1/flux": {
-      "kind": "dc-filter",
+      "kind": "dc",
       "offset": 0.0,
-      "filter": []
+      "filters": []
     },
 
     "0/probe": {
@@ -56,9 +56,9 @@
       "kernel": "k05VTVBZAQB2AHsnZGVzY3InOiAnPGY4JywgJ2ZvcnRyYW5fb3JkZXInOiBGYWxzZSwgJ3NoYXBlJzogKDEwLCksIH0gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAr4dT6V5tHrP1w+JhHImN8/sPePZeSUuj/4yTKrD5fRP/ysonZip98/6GJMAPV9xD/LTiJo4k7oP96aWXpxduU/6fUxETe/7z9GXEBNGebWPw=="
     },
     "coupler_01/flux": {
-      "kind": "dc-filter",
+      "kind": "dc",
       "offset": 0.0,
-      "filter": []
+      "filters": []
     },
     "twpa_pump": {
       "kind": "oscillator",

--- a/tests/platforms/mock2/platform.py
+++ b/tests/platforms/mock2/platform.py
@@ -1,12 +1,7 @@
-from qibolab import ConfigKinds
 from qibolab._core.components import AcquisitionChannel, DcChannel, IqChannel
 from qibolab._core.instruments.dummy import DummyInstrument, DummyLocalOscillator
 from qibolab._core.parameters import Hardware
 from qibolab._core.qubits import Qubit
-
-from qibocal.protocols.utils import DcFilteredConfig
-
-ConfigKinds.extend([DcFilteredConfig])
 
 
 def create() -> Hardware:


### PR DESCRIPTION
`DcFilteredConfig` is a qibocal duplicate of qibolab's `DcConfig` so there is no need for it to exist (at least not any longer). Note the attribute name `filter` was used in `DcFilteredConfig` while `filters` is used in `DcConfig`, this was a problem in the cyoscope protocol. This PR does not fully fix the cyroscope protocol though and further work will be done in separate PRs.   