### PR TITLE
qubit flux: use arbitrary units and require drive amplitude

### DIFF
--- a/src/qibocal/protocols/flux_dependence/qubit_flux_dependence.py
+++ b/src/qibocal/protocols/flux_dependence/qubit_flux_dependence.py
@@ -41,9 +41,9 @@ __all__ = [
 class QubitFluxParameters(utils.FluxFrequencySweepParameters):
     """QubitFlux runcard inputs."""
 
-    drive_amplitude: float
+    drive_amplitude: float = 0.01
     """Amplitude of the drive pulse."""
-    drive_duration: int
+    drive_duration: int = 2000
     """Duration of the drive pulse."""
 
 

--- a/src/qibocal/protocols/flux_dependence/qubit_flux_dependence.py
+++ b/src/qibocal/protocols/flux_dependence/qubit_flux_dependence.py
@@ -41,9 +41,8 @@ __all__ = [
 class QubitFluxParameters(utils.FluxFrequencySweepParameters):
     """QubitFlux runcard inputs."""
 
-    drive_amplitude: float | None = None
-    """Drive amplitude (optional). If defined, same amplitude will be used in all qubits.
-    Otherwise the default amplitude defined on the platform runcard will be used"""
+    drive_amplitude: float = 0.01
+    """Amplitude of the drive pulse."""
     drive_duration: int = 2000
     """Duration of the drive pulse."""
 
@@ -127,8 +126,7 @@ def _acquisition(
         ro_channel, ro_pulse = natives.MZ()[0]
 
         qd_pulse = replace(qd_pulse, duration=params.drive_duration)
-        if params.drive_amplitude is not None:
-            qd_pulse = replace(qd_pulse, amplitude=params.drive_amplitude)
+        qd_pulse = replace(qd_pulse, amplitude=params.drive_amplitude)
 
         qd_pulses[q] = qd_pulse
         ro_pulses[q] = ro_pulse

--- a/src/qibocal/protocols/flux_dependence/qubit_flux_dependence.py
+++ b/src/qibocal/protocols/flux_dependence/qubit_flux_dependence.py
@@ -41,9 +41,9 @@ __all__ = [
 class QubitFluxParameters(utils.FluxFrequencySweepParameters):
     """QubitFlux runcard inputs."""
 
-    drive_amplitude: float = 0.01
+    drive_amplitude: float
     """Amplitude of the drive pulse."""
-    drive_duration: int = 2000
+    drive_duration: int
     """Duration of the drive pulse."""
 
 

--- a/src/qibocal/protocols/flux_dependence/qubit_flux_dependence.py
+++ b/src/qibocal/protocols/flux_dependence/qubit_flux_dependence.py
@@ -283,9 +283,9 @@ def _plot(data: QubitFluxData, fit: QubitFluxResults, target: QubitId):
             table_dict(
                 target,
                 [
-                    "Sweetspot [V]",
+                    "Sweetspot [a.u.]",
                     "Qubit Frequency at Sweetspot [Hz]",
-                    "Flux dependence [V]^-1",
+                    "Flux dependence [a.u.]^-1",
                 ],
                 [
                     np.round(fit.sweetspot[target], 4),

--- a/src/qibocal/protocols/flux_dependence/utils.py
+++ b/src/qibocal/protocols/flux_dependence/utils.py
@@ -29,9 +29,9 @@ class FluxFrequencySweepParameters(Parameters):
     freq_step: int
     """Frequency step for sweep [Hz]."""
     bias_width: float
-    """Width for bias sweep [V]."""
+    """Width for bias sweep [a.u.]."""
     bias_step: float
-    """Bias step for sweep [V]."""
+    """Bias step for sweep [a.u.]."""
 
     @property
     def frequency_range(self) -> np.ndarray:
@@ -122,7 +122,7 @@ def flux_dependence_plot(data, fit, qubit, fit_function=None):
     fig.update_xaxes(
         title_text="Frequency [GHz]",
     )
-    fig.update_yaxes(title_text="Bias [V]")
+    fig.update_yaxes(title_text="Bias [a.u.]")
 
     fig.update_layout(xaxis1=dict(range=[np.min(frequencies), np.max(frequencies)]))
 
@@ -189,7 +189,7 @@ def flux_crosstalk_plot(data, qubit, fit, fit_function):
         )
 
         fig.update_yaxes(
-            title_text=f"Qubit {flux_qubit[1]}: Bias [V]", row=1, col=col + 1
+            title_text=f"Qubit {flux_qubit[1]}: Bias [a.u.]", row=1, col=col + 1
         )
 
     fig.update_layout(xaxis1=dict(range=[np.min(frequencies), np.max(frequencies)]))
@@ -212,7 +212,7 @@ def G_f_d(xi, xj, offset, d, crosstalk_element, normalization):
     Args:
         xi (float): bias of target qubit
         xj (float): bias of neighbor qubit
-        offset (float): phase_offset [V].
+        offset (float): phase_offset [a.u.].
         d (float): asymmetry between the two junctions of the transmon.
                    Typically denoted as :math:`d`. :math:`d = (E_J^1 - E_J^2) / (E_J^1 + E_J^2)`.
         crosstalk_element(float): off-diagonal crosstalk matrix element
@@ -247,7 +247,7 @@ def transmon_frequency(
         d (float): asymmetry between the two junctions of the transmon.
                    Typically denoted as :math:`d`. :math:`d = (E_J^1 - E_J^2) / (E_J^1 + E_J^2)`.
         normalization(float): diagonal crosstalk matrix element
-        offset (float): phase_offset [V].
+        offset (float): phase_offset [a.u.].
         crosstalk_element(float): off-diagonal crosstalk matrix element
         charging_energy (float): Ec / h (GHz)
 
@@ -289,7 +289,7 @@ def transmon_readout_frequency(
          d (float): asymmetry between the two junctions of the transmon.
                     Typically denoted as :math:`d`. :math:`d = (E_J^1 - E_J^2) / (E_J^1 + E_J^2)`.
          normalization(float): diagonal crosstalk matrix element
-         offset (float): phase_offset [V].
+         offset (float): phase_offset [a.u.].
          crosstalk_element(float): off-diagonal crosstalk matrix element
          resonator_freq (float): bare resonator frequency [GHz]
          g (float): readout coupling.

--- a/tests/runcards/protocols.yml
+++ b/tests/runcards/protocols.yml
@@ -95,6 +95,7 @@ actions:
       bias_width: 0.2
       bias_step:  0.005
       drive_amplitude: 0.5
+      drive_duration: 2000
       nshots: 1024
       relaxation_time: 2000
 
@@ -110,6 +111,7 @@ actions:
       bias_width: 0.2
       bias_step:  0.005
       drive_amplitude: 0.5
+      drive_duration: 2000
       flux_qubits: [1]
       nshots: 1024
       relaxation_time: 2000


### PR DESCRIPTION
This PR changes two things for the qubit flux arc experiment: 
- The flux bias is given in arbitrary units, so the plot legend displays `[a.u.]` instead of `[V]`.
- The default drive pulse amplitude and duration are removed. Previously, the drive duration had a default value of 2000ns while the amplitude defaulted to the calibrated pi-pulse amplitude. This was inconsistent and could become problematic after calibration, as calibrated pulses typically have much shorter durations and larger amplitudes than those used for flux arc spectroscopy.
