### PR TITLE
mixer cal: use `_configure_sequencers` instead of `configure` 

### DIFF
--- a/src/qibocal/protocols/calibrate_mixers.py
+++ b/src/qibocal/protocols/calibrate_mixers.py
@@ -237,7 +237,7 @@ def _acquisition(
     # TODO: Optimize by directly using Cluster._channels_by_module to assign
     # one sequencer per output port instead of calling configure(). This would
     # allow sequential calibration of individual channel mixers.
-    seq_map, _ = cluster.configure(
+    seq_map, _ = cluster._configure_sequencers(
         configs=configs,
     )
 


### PR DESCRIPTION
This reflects a change in qibolab (https://github.com/qiboteam/qibolab/pull/1494). While the mixer calibration now explicitly depends on a piece of non-public API, I don't believe it is a problem to make this change. The reason is that mixer calibration in qibocal is already hardware dependent while qibocal should be hardware-agnostic. 