### PR TITLE
Fix emulator example platform drive config

### DIFF
--- a/platforms/qubit/parameters.json
+++ b/platforms/qubit/parameters.json
@@ -23,14 +23,12 @@
     "0/drive": {
       "kind": "drive-emulator",
       "frequency": 5e9,
-      "rabi_frequency": 20e6,
-      "scale_factor": 10
+      "rabi_frequency": 200e6
     },
     "0/drive12": {
       "kind": "drive-emulator",
       "frequency": 4.8e9,
-      "rabi_frequency": 20e6,
-      "scale_factor": 10
+      "rabi_frequency": 200e6
     },
   "0/probe": {
     "kind": "iq",

--- a/platforms/qutrit/parameters.json
+++ b/platforms/qutrit/parameters.json
@@ -24,14 +24,12 @@
       "0/drive": {
         "kind": "drive-emulator",
         "frequency": 5e9,
-        "rabi_frequency": 20e6,
-        "scale_factor": 10
+        "rabi_frequency": 200e6
       },
       "0/drive12": {
         "kind": "drive-emulator",
         "frequency": 4.8e9,
-        "rabi_frequency": 20e6,
-        "scale_factor": 10
+        "rabi_frequency": 200e6
       },
     "0/probe": {
       "kind": "iq",


### PR DESCRIPTION
## Summary

This is a small compatibility follow-up for the example emulator platforms.

While setting up a Qibocal-on-emulator smoke workflow, the `qubit` and `qutrit` example platforms failed to load with current qibolab because their `drive-emulator` configs still include `scale_factor`. Current qibolab's `DriveEmulatorConfig` accepts `rabi_frequency`, but rejects `scale_factor` as an extra field.

This PR removes the stale `scale_factor` entries and folds their old effect into `rabi_frequency`:

```json
{
  "rabi_frequency": 20e6,
  "scale_factor": 10
}
```

becomes:

```json
{
  "rabi_frequency": 200e6
}
```

This keeps the examples calibrated while matching the current qibolab schema.

## Follow-up Context

This PR is intentionally limited to the example-platform compatibility blocker. It does not address the qibolab emulator result-handling issues directly.

The motivation for fixing these examples is to make the Qibocal-on-emulator workflow usable as a small reproducible smoke test for follow-up qibolab work, including:

- qiboteam/qibolab#1413: marginalizing probabilities before applying confusion matrices;
- qiboteam/qibolab#1216: bypassing emulator sampling for non-discriminated results;
- qiboteam/qibolab#1223: further cleanup of emulator result handling.

With the example platforms loading and running again, follow-up fixes in qibolab can be tied to concrete Qibocal workflows instead of isolated emulator internals.

## Validation

Run from the Qibocal checkout, with current qibolab installed in the active Python environment:

```text
python3 -m json.tool platforms/qubit/parameters.json >/dev/null
python3 -m json.tool platforms/qutrit/parameters.json >/dev/null

QIBOLAB_PLATFORMS="$PWD/platforms" \
  python -c "from qibolab import create_platform; print(create_platform('qubit').name); print(create_platform('qutrit').name)"
# qubit
# qutrit
```

Smoke-test runcard:

```yaml
platform: qubit
targets: [0]
actions:
  - id: rabi-emulator-smoke
    operation: rabi_amplitude
    parameters:
      min_amp: 0.02
      max_amp: 0.32
      step_amp: 0.02
      pulse_length: 40
      nshots: 200
```

Qibocal smoke runs:

```text
QIBOLAB_PLATFORMS="$PWD/platforms" \
MPLCONFIGDIR=/tmp/mplconfig-qibocal \
  qq run /tmp/qibocal-emulator-rabi-smoke.yml \
  -o /tmp/qibocal-emulator-rabi-smoke-qubit \
  --no-update
# acquisition passed; fit passed

QIBOLAB_PLATFORMS="$PWD/platforms" \
MPLCONFIGDIR=/tmp/mplconfig-qibocal \
  qq run /tmp/qibocal-emulator-rabi-smoke.yml \
  -o /tmp/qibocal-emulator-rabi-smoke-qutrit \
  --platform qutrit \
  --no-update
# acquisition passed; fit passed
```

The fitted pi amplitudes are close to the platform native `RX` amplitudes:

```text
qubit fitted pi amplitude: 0.1263479362
qubit native RX amplitude: 0.12698

qutrit fitted pi amplitude: 0.1276651439
```
