### PR TITLE
Capture `ZeroDivisionError` in `drag_simple`

### DIFF
--- a/src/qibocal/protocols/drag/drag_simple.py
+++ b/src/qibocal/protocols/drag/drag_simple.py
@@ -186,9 +186,16 @@ def _fit(data: DragTuningSimpleData) -> DragTuningSimpleResults:
                 sigma=qubit_data["error"],
             )
             fitted_parameters[qubit, setup] = popt.tolist()
-        betas_optimal[qubit] = -(
-            fitted_parameters[qubit, "YpX9"][1] - fitted_parameters[qubit, "XpY9"][1]
-        ) / (fitted_parameters[qubit, "YpX9"][0] - fitted_parameters[qubit, "XpY9"][0])
+        try:
+            betas_optimal[qubit] = -(
+                fitted_parameters[qubit, "YpX9"][1]
+                - fitted_parameters[qubit, "XpY9"][1]
+            ) / (
+                fitted_parameters[qubit, "YpX9"][0]
+                - fitted_parameters[qubit, "XpY9"][0]
+            )
+        except ZeroDivisionError:
+            pass
     return DragTuningSimpleResults(betas_optimal, fitted_parameters)
 
 


### PR DESCRIPTION
If the single shot classification is not done properly it may be that all values in `drag_simple` return either 0 or 1. In this case the denominator when evaluating the optimal beta may be 0 resulting in a `ZeroDivisionError`. Since we still want to plot the data even if the extraction of the optimal beta parameter fails, we capture the `ZeroDivisionError` in a try-except. I tested that it works, even in the case where one qubit has this error while another does not.

http://login.qrccluster.com:9000/YFvfWN4JR4S4det-R-WXGQ==