### PR TITLE
Make unrolling mandatory, remove the optional flags

### DIFF
--- a/doc/source/protocols/drag/drag.rst
+++ b/doc/source/protocols/drag/drag.rst
@@ -47,7 +47,6 @@ Example
             beta_end: 1
             beta_step: 0.1
             nflips: 5
-            unrolling: true
 
 
 Running this protocol you should get something like this:
@@ -83,7 +82,6 @@ Example
             beta_start: -1
             beta_end: 1
             beta_step: 0.1
-            unrolling: true
 
 .. image:: drag_simple.png
 

--- a/src/qibocal/protocols/allxy/allxy.py
+++ b/src/qibocal/protocols/allxy/allxy.py
@@ -25,9 +25,6 @@ class AllXYParameters(Parameters):
 
     beta_param: float = None
     """Beta parameter for drag pulse. If None is given, the native rx pulse in the parameters will be used"""
-    unrolling: bool = False
-    """If ``True`` it uses sequence unrolling to deploy multiple sequences in a single instrument call.
-    Defaults to ``False``."""
 
 
 @dataclass
@@ -107,12 +104,7 @@ def _acquisition(
         averaging_mode=AveragingMode.CYCLIC,
         acquisition_type=AcquisitionType.DISCRIMINATION,
     )
-    if params.unrolling:
-        results = platform.execute(sequences, **options)
-    else:
-        results = {}
-        for sequence in sequences:
-            results.update(platform.execute([sequence], **options))
+    results = platform.execute(sequences, **options)
 
     for gates, ro_pulses in zip(gatelist, all_ro_pulses):
         gate = "-".join(gates)

--- a/src/qibocal/protocols/allxy/allxy_resonator_depletion_tuning.py
+++ b/src/qibocal/protocols/allxy/allxy_resonator_depletion_tuning.py
@@ -23,9 +23,6 @@ class AllXYResonatorParameters(Parameters):
     """Step delay parameter for resonator depletion."""
     readout_delay: int = 1000
     """Delay on readout."""
-    unrolling: bool = False
-    """If ``True`` it uses sequence unrolling to deploy multiple sequences in a single instrument call.
-    Defaults to ``False``."""
     beta_param: float = None
     """Beta parameter for drag pulse."""
 
@@ -87,12 +84,7 @@ def _acquisition(
             sequences.append(sequence)
             all_ro_pulses.append(ro_pulses)
         options = dict(nshots=params.nshots, averaging_mode=AveragingMode.CYCLIC)
-        if params.unrolling:
-            results = platform.execute(sequences, **options)
-        else:
-            results = {}
-            for sequence in sequences:
-                results.update(platform.execute([sequence], **options))
+        results = platform.execute(sequences, **options)
 
         for gates, ro_pulses in zip(gatelist, all_ro_pulses):
             gate = "-".join(gates)

--- a/src/qibocal/protocols/flux_dependence/cryoscope.py
+++ b/src/qibocal/protocols/flux_dependence/cryoscope.py
@@ -50,7 +50,6 @@ class CryoscopeParameters(Parameters):
     """Flux pulse amplitude."""
     fir: int = 20
     """Number of feedforward taps to be optimized after IIR."""
-    unrolling: bool = True
 
 
 @dataclass
@@ -232,16 +231,8 @@ def _acquisition(
         averaging_mode=AveragingMode.CYCLIC,
     )
 
-    if params.unrolling:
-        results_x = platform.execute(sequences_x, **options)
-        results_y = platform.execute(sequences_y, **options)
-    else:
-        results_x = [
-            platform.execute([sequence], **options) for sequence in sequences_x
-        ]
-        results_y = [
-            platform.execute([sequence], **options) for sequence in sequences_y
-        ]
+    results_x = platform.execute(sequences_x, **options)
+    results_y = platform.execute(sequences_y, **options)
 
     for measure, results, sequence in zip(
         ["MX", "MY"], [results_x, results_y], [sequences_x, sequences_y]
@@ -251,11 +242,7 @@ def _acquisition(
                 ro_pulse = list(sequence.channel(platform.qubits[qubit].acquisition))[
                     -1
                 ]
-                result = (
-                    results[ro_pulse.id]
-                    if params.unrolling
-                    else results[i][ro_pulse.id]
-                )
+                result = results[ro_pulse.id]
                 data.register_qubit(
                     CryoscopeType,
                     (qubit, measure),

--- a/src/qibocal/protocols/signal_experiments/calibrate_state_discrimination.py
+++ b/src/qibocal/protocols/signal_experiments/calibrate_state_discrimination.py
@@ -24,7 +24,6 @@ class CalibrateStateDiscriminationParameters(Parameters):
     """Number of shots."""
     relaxation_time: int | None = None
     """Relaxation time (ns)."""
-    unrolling: bool | None = False
 
 
 CalibrateStateDiscriminationResType = np.dtype(
@@ -110,12 +109,7 @@ def _acquisition(
         averaging_mode=AveragingMode.CYCLIC,
     )
 
-    if params.unrolling:
-        results = platform.execute(sequences, **options)
-    else:
-        results = {}
-        for sequence in sequences:
-            results.update(platform.execute([sequence], **options))
+    results = platform.execute(sequences, **options)
 
     intermediate_frequency = {
         qubit: platform.config(platform.qubits[qubit].probe).frequency

--- a/tests/runcards/protocols.yml
+++ b/tests/runcards/protocols.yml
@@ -475,12 +475,6 @@ actions:
     parameters:
       nshots: 10
 
-  - id: calibrate_state_discrimination unrolling
-    operation: calibrate_state_discrimination
-    parameters:
-      nshots: 10
-      unrolling: true
-
   - id: ramsey_detuned
     operation: ramsey
     parameters:
@@ -520,13 +514,6 @@ actions:
       beta_param: null
       nshots: 10
 
-  - id: allXY unrolling
-    operation: allxy
-    parameters:
-      beta_param: null
-      unrolling: True
-      nshots: 10
-
   - id: resonator_depletion_tuning
     operation: allxy_resonator_depletion_tuning
     parameters:
@@ -534,15 +521,6 @@ actions:
       delay_end: 3000.0
       delay_step: 1000.0
       nshots: 10
-
-  - id: resonator_depletion_tuning unrolling
-    operation: allxy_resonator_depletion_tuning
-    parameters:
-      delay_start: 1000.0
-      delay_end: 3000.0
-      delay_step: 1000.0
-      nshots: 10
-      unrolling: true
 
   - id: drag_pulse_tuning
     operation: drag_tuning


### PR DESCRIPTION
In a few protocols unrolling can still be toggled through an input parameter. However, as agreed before, the decision of how to execute a list of sequences should be handled by qibolab, so in qibocal we should do only a single call to `platform.execute`.