### PR TITLE
Cross Resonance: bugfix in CR pulse and plot-style update

### DIFF
--- a/src/qibocal/protocols/two_qubit_interaction/cross_resonance/plotting.py
+++ b/src/qibocal/protocols/two_qubit_interaction/cross_resonance/plotting.py
@@ -86,7 +86,9 @@ def tomography_cr_plot(
                 col=2,
             )
             if fit is not None and (*target, setup) in fit.fitted_parameters:
-                x = np.linspace(pair_data.x.min(), pair_data.x.max(), 100)
+                x = np.linspace(
+                    pair_data.x.min(), pair_data.x.max(), 50 * len(pair_data.x)
+                )
                 fig.add_trace(
                     go.Scatter(
                         x=x,
@@ -115,12 +117,19 @@ def tomography_cr_plot(
                     fit_dict = fit.cr_lengths
 
                 if target in fit_dict:
-                    fig.add_vline(
-                        x=fit_dict[target],
-                        line_width=2,
-                        line_dash="dash",
-                        line_color="red",
-                        annotation_text=annotation,
+                    fig.add_trace(
+                        go.Scatter(
+                            x=fit_dict[target],
+                            y=[
+                                -1.2,
+                                1.2,
+                            ],
+                            mode="lines",
+                            line=go.scatter.Line(color="orange", width=3, dash="dash"),
+                            name="Best frequency",
+                            showlegend=True,
+                            legendgroup=annotation,
+                        ),
                         row=i + 1,
                         col=1,
                     )
@@ -153,7 +162,9 @@ def tomography_cr_plot(
         )
 
         if bloch_fit_targ is not None:
-            x = np.linspace(pair_data.x.min(), pair_data.x.max(), len(bloch_fit_targ))
+            x = np.linspace(
+                pair_data.x.min(), pair_data.x.max(), 50 * len(bloch_fit_targ)
+            )
             fig.add_trace(
                 go.Scatter(
                     x=x,
@@ -173,12 +184,19 @@ def tomography_cr_plot(
             fit_dict = fit.cr_lengths
 
         if target in fit_dict:
-            fig.add_vline(
-                x=fit_dict[target],
-                line_width=2,
-                line_dash="dash",
-                line_color="red",
-                annotation_text=annotation,
+            fig.add_trace(
+                go.Scatter(
+                    x=fit_dict[target],
+                    y=[
+                        -1.2,
+                        1.2,
+                    ],
+                    mode="lines",
+                    line=go.scatter.Line(color="orange", width=3, dash="dash"),
+                    name="Best frequency",
+                    showlegend=True,
+                    legendgroup=annotation,
+                ),
                 row=4,
                 col=1,
             )

--- a/src/qibocal/protocols/two_qubit_interaction/cross_resonance/plotting.py
+++ b/src/qibocal/protocols/two_qubit_interaction/cross_resonance/plotting.py
@@ -119,15 +119,15 @@ def tomography_cr_plot(
                 if target in fit_dict:
                     fig.add_trace(
                         go.Scatter(
-                            x=fit_dict[target],
+                            x=[fit_dict[target]] * 2,
                             y=[
                                 -1.2,
                                 1.2,
                             ],
                             mode="lines",
-                            line=go.scatter.Line(color="orange", width=3, dash="dash"),
-                            name="Best frequency",
-                            showlegend=True,
+                            line=go.scatter.Line(color="red", width=3, dash="dash"),
+                            name=annotation,
+                            showlegend=False,
                             legendgroup=annotation,
                         ),
                         row=i + 1,
@@ -162,9 +162,7 @@ def tomography_cr_plot(
         )
 
         if bloch_fit_targ is not None:
-            x = np.linspace(
-                pair_data.x.min(), pair_data.x.max(), 50 * len(bloch_fit_targ)
-            )
+            x = np.linspace(pair_data.x.min(), pair_data.x.max(), len(bloch_fit_targ))
             fig.add_trace(
                 go.Scatter(
                     x=x,
@@ -186,14 +184,14 @@ def tomography_cr_plot(
         if target in fit_dict:
             fig.add_trace(
                 go.Scatter(
-                    x=fit_dict[target],
+                    x=[fit_dict[target]] * 2,
                     y=[
                         -1.2,
                         1.2,
                     ],
                     mode="lines",
                     line=go.scatter.Line(color="orange", width=3, dash="dash"),
-                    name="Best frequency",
+                    name=annotation,
                     showlegend=True,
                     legendgroup=annotation,
                 ),

--- a/src/qibocal/protocols/two_qubit_interaction/cross_resonance/utils.py
+++ b/src/qibocal/protocols/two_qubit_interaction/cross_resonance/utils.py
@@ -328,14 +328,7 @@ def cross_resonance_experiment(
             control_drive_channel, control_drive_pulse = platform.natives.single_qubit[
                 control
             ].RX()[0]
-            target_drive_channel, _ = platform.natives.single_qubit[target].RX()[0]
-            cr_channel = platform.qubits[control].drive_extra[target]
-
-            control_delay = Delay(duration=control_drive_pulse.duration)
-
             cntl_setup_sequence.append((control_drive_channel, control_drive_pulse))
-            cntl_setup_sequence.append((target_drive_channel, control_delay))
-            cntl_setup_sequence.append((cr_channel, control_delay))
 
         cr_sequence, cr_pulses, cr_target_pulses, cr_delays = cross_res_sequence(
             platform=platform,
@@ -357,7 +350,6 @@ def cross_resonance_experiment(
             echo=echo,
             interpolated_sweeper=interpolated_sweeper,
         )
-        cr_sequence = cntl_setup_sequence | cr_sequence
 
         total_sequence, ro_delays = appending_ro_sequence(
             platform=platform,
@@ -367,6 +359,8 @@ def cross_resonance_experiment(
             basis=basis,
             interpolated_sweeper=interpolated_sweeper,
         )
+        # aligning with the state preparation pulses
+        total_sequence = cntl_setup_sequence | total_sequence
 
         parallel_cr_sequences += total_sequence
         parallel_cr_pulses |= {pair: cr_pulses}

--- a/src/qibocal/protocols/two_qubit_interaction/cross_resonance/utils.py
+++ b/src/qibocal/protocols/two_qubit_interaction/cross_resonance/utils.py
@@ -29,7 +29,7 @@ def cross_resonance_pulses(
 
     cr_params = None
     canc_params = None
-    if cnot_cal_seq is None and len(cnot_cal_seq) != 0:
+    if cnot_cal_seq is not None and len(cnot_cal_seq) != 0:
         for p in cnot_cal_seq[2:]:
             if cr_params is None and p[0] == cr_channel and isinstance(p[1], Pulse):
                 cr_params = p[1]


### PR DESCRIPTION
In this PR I first fixed the following:

1.  a small bug in CR pulse (a missing `not`).

3. modified the plotting script, in particular for plotting the vertical lines in the extrapolated best CR duration (or amplitude).

5. modified the creation of the CR pulse sequence in `cross_resonance/utils.py` in `cross_resonant_experiment` function. Essentially instead of adding `Delay` between the state preparation sequence `cntl_setup_sequence` I simply aligned it with the `cr_sequence` and the `readout_sequence`.
	
	So now the logic is no more:
	
	`cntl_setup_sequence + delays + cr_sequence + delays + readout_sequence` 
	but
	`cntl_setup_sequence | ( cr_sequence + delays +  readout_sequence)`

here is a report for a `cross_resonance_amplitude` experiment:
http://login.qrccluster.com:9000/Se69VYDrT2aUbz6di6wpgg==
<img width="1734" height="946" alt="image" src="https://github.com/user-attachments/assets/b0f64f9b-348b-44ef-977c-bd324ccfa3d5" />
