### PR TITLE
Declare acquisition channels in emulator example platforms

### DIFF
--- a/platforms/qubit/platform.py
+++ b/platforms/qubit/platform.py
@@ -1,7 +1,7 @@
 import pathlib
 
 from qibolab import ConfigKinds
-from qibolab._core.components import IqChannel
+from qibolab._core.components import AcquisitionChannel, IqChannel
 from qibolab._core.instruments.emulator.emulator import EmulatorController
 from qibolab._core.instruments.emulator.hamiltonians import (
     DriveEmulatorConfig,
@@ -24,6 +24,7 @@ def create() -> Platform:
         qubits[q] = qubit = Qubit.default(q)
         channels |= {
             qubit.drive: IqChannel(mixer=None, lo=None),
+            qubit.acquisition: AcquisitionChannel(probe=qubit.probe),
         }
 
     # register the instruments

--- a/platforms/qutrit/platform.py
+++ b/platforms/qutrit/platform.py
@@ -1,7 +1,7 @@
 import pathlib
 
 from qibolab import ConfigKinds
-from qibolab._core.components import IqChannel
+from qibolab._core.components import AcquisitionChannel, IqChannel
 from qibolab._core.instruments.emulator.emulator import EmulatorController
 from qibolab._core.instruments.emulator.hamiltonians import (
     DriveEmulatorConfig,
@@ -25,6 +25,7 @@ def create() -> Platform:
         channels |= {
             qubit.drive: IqChannel(mixer=None, lo=None),
             qubits[q].drive_extra[1, 2]: IqChannel(mixer=None, lo=None),
+            qubit.acquisition: AcquisitionChannel(probe=qubit.probe),
         }
 
     # register the instruments


### PR DESCRIPTION
### Summary

This PR adds the missing acquisition-channel declarations to the bundled `qubit` and `qutrit` emulator platforms.

While validating Qibocal workflows with the current Qibolab emulator path, the bundled platforms failed before either the default QuTiP engine or the Dynamiqs engine could run:

```text
ValueError: Unknown channel(s) in pulse sequence: 0/acquisition.
Available channels: 0/drive
```

The native `MZ` gates already use `0/acquisition`, and the platform parameter files already contain acquisition configuration. The platform construction code, however, only registered the drive channels. Current Qibolab validates all sequence channels in `Platform.execute()`, so the platform should declare the acquisition channel explicitly.

### Change

The platform channel maps now include the acquisition channel alongside the existing drive channels:

```python
channels |= {
    qubit.drive: IqChannel(mixer=None, lo=None),
    qubit.acquisition: AcquisitionChannel(probe=qubit.probe),
}
```

For `qutrit`, the same acquisition declaration is added while preserving the existing `drive12` channel.

### Validation

Focused checks:

```bash
QIBOLAB_PLATFORMS=/path/to/qibocal/platforms python -c "from qibolab import create_platform; print(create_platform('qubit').name); print(create_platform('qutrit').name)"
ruff check platforms/qubit/platform.py platforms/qutrit/platform.py
ruff format --check platforms/qubit/platform.py platforms/qutrit/platform.py
```

Qibocal Rabi smoke after this patch:

| Platform | Engine | Status | Acquisition time | Fitted pi amplitude |
|---|---|---|---:|---:|
| `qubit` | QuTiP | acquisition + fit passed | 1.07 s | 0.125629958005 |
| `qutrit` | QuTiP | acquisition + fit passed | 1.75 s | 0.125072691027 |

I also used temporary platform copies to run the same workflow with `DynamiqsEngine()`:

| Platform | Engine | Status | Acquisition time | Fitted pi amplitude |
|---|---|---|---:|---:|
| `qubit` | Dynamiqs | acquisition + fit passed | 17.09 s | 0.125181222344 |
| `qutrit` | Dynamiqs | acquisition + fit passed | 15.17 s | 0.126636922684 |

The Dynamiqs and QuTiP fitted amplitudes agree at the smoke-test level for this Rabi workflow once the platform channel declaration is fixed.

### Scope

This is intentionally a small platform-declaration fix. It does not change emulator physics or result handling.

One separate observation from the validation pass: `platforms/qutrits` currently fails earlier because its `parameters.json` contains a `bounds` config kind that is not registered by the platform file. I left that out of this PR because it is a separate platform-loading issue.
