### PR TITLE
Introduce range syntax in resonator spectroscopy

### DIFF
--- a/src/qibocal/protocols/resonator_spectroscopies/resonator_spectroscopy.py
+++ b/src/qibocal/protocols/resonator_spectroscopies/resonator_spectroscopy.py
@@ -11,9 +11,12 @@ from qibocal.auto.operation import Data, Parameters, Protocol, QubitId, Results
 from qibocal.calibration import CalibrationPlatform
 from qibocal.protocols.utils import (
     PowerLevel,
+    Range,
+    RangeLike,
     lorentzian_fit,
     lorentzian_with_linear_background,
     readout_frequency,
+    to_range,
 )
 from qibocal.result import magnitude, phase
 from qibocal.update import replace
@@ -67,11 +70,21 @@ FITS = {
 class ResonatorSpectroscopyParameters(Parameters):
     """ResonatorSpectroscopy runcard inputs."""
 
-    freq_width: int
-    """Width for frequency sweep relative  to the readout frequency [Hz]."""
-    freq_step: int
-    """Frequency step for sweep [Hz]."""
-    power_level: PowerLevel | str
+    frequency: RangeLike | None = None
+    """Frequency range for sweep [Hz]."""
+    freq_width: int | None = None
+    """Width for frequency sweep relative  to the readout frequency [Hz].
+
+    .. deprecated:: 0.2.6
+        Use :attr:`frequency` instead.
+    """
+    freq_step: int | None = None
+    """Frequency step for sweep [Hz].
+
+    .. deprecated:: 0.2.6
+        Use :attr:`frequency` instead.
+    """
+    power_level: PowerLevel | str = PowerLevel.low
     """Power regime (low or high). If low the readout frequency will be updated.
     If high both the readout frequency and the bare resonator frequency will be updated."""
     fit_function: str = "lorentzian"
@@ -86,6 +99,21 @@ class ResonatorSpectroscopyParameters(Parameters):
     def __post_init__(self):
         if isinstance(self.power_level, str):
             self.power_level = PowerLevel(self.power_level)
+
+    def frequency_range(self, q: QubitId, platform: CalibrationPlatform) -> Range:
+        try:
+            center = readout_frequency(q, platform, self.power_level)
+        except KeyError:
+            center = 0.0
+        return (
+            to_range(self.frequency, center=center)
+            if self.frequency is not None
+            else (
+                center - self.freq_width / 2,
+                center + self.freq_width / 2,
+                self.freq_step,
+            )
+        )
 
 
 @dataclass
@@ -160,16 +188,10 @@ def _acquisition(
         ro_pulses[q] = pulse
         sequence.append((channel, pulse))
 
-    # define the parameter to sweep and its range:
-    delta_frequency_range = np.arange(
-        -params.freq_width / 2, params.freq_width / 2, params.freq_step
-    )
-
     sweepers = [
         Sweeper(
             parameter=Parameter.frequency,
-            values=readout_frequency(q, platform, params.power_level)
-            + delta_frequency_range,
+            range=params.frequency_range(q, platform),
             channels=[platform.qubits[q].probe],
         )
         for q in targets
@@ -196,16 +218,15 @@ def _acquisition(
     for q in targets:
         result = results[ro_pulses[q].id]
         # store the results
-        ro_frequency = readout_frequency(q, platform, params.power_level)
         signal = magnitude(result)
         phase_ = phase(result)
         data.register_qubit(
             ResSpecType,
-            (q),
+            q,
             dict(
                 signal=signal,
                 phase=phase_,
-                freq=delta_frequency_range + ro_frequency,
+                freq=np.arange(*params.frequency_range(q, platform)).tolist(),
             ),
         )
     return data

--- a/src/qibocal/protocols/utils.py
+++ b/src/qibocal/protocols/utils.py
@@ -1187,6 +1187,9 @@ def fallback_period(period: NDArray) -> NDArray:
     return np.where(np.isnan(period), 4, period)
 
 
+Range = tuple[float, float, float]
+"""Value range, corresponding to ``(start, stop, step)``."""
+
 RangeLike = (
     tuple[float, float, float]
     | tuple[Literal["linspace"], float, float, int]
@@ -1224,9 +1227,7 @@ The other variants are the following:
 """
 
 
-def to_range(
-    spec: RangeLike, center: float | None = None
-) -> tuple[float, float, float]:
+def to_range(spec: RangeLike, center: float | None = None) -> Range:
     """Convert any range specification into the default representation."""
 
     if not isinstance(spec[0], str):

--- a/src/qibocal/protocols/utils.py
+++ b/src/qibocal/protocols/utils.py
@@ -10,6 +10,7 @@ import plotly.express as px
 import plotly.graph_objects as go
 from numpy.typing import NDArray
 from plotly.subplots import make_subplots
+from pydantic import TypeAdapter
 from scipy import constants, sparse
 from scipy.optimize import curve_fit
 from scipy.signal import find_peaks
@@ -1226,32 +1227,36 @@ The other variants are the following:
   asymmetric interval around it, i.e. ``("asim", (left-shift, right-shift), step)``
 """
 
+_RangeLike = TypeAdapter(RangeLike)
+
 
 def to_range(spec: RangeLike, center: float | None = None) -> Range:
     """Convert any range specification into the default representation."""
 
-    if not isinstance(spec[0], str):
-        # Default case: assume it's a tuple of (start, stop, step)
-        return spec
+    spec_ = _RangeLike.validate_python(spec)
 
-    if any(lab in spec[0] for lab in {"center", "asym"}) and center is None:
+    if not isinstance(spec_[0], str):
+        # Default case: assume it's a tuple of (start, stop, step)
+        return spec_
+
+    if any(lab in spec_[0] for lab in {"center", "asym"}) and center is None:
         raise ValueError(
-            f"Center must be provided for '{spec[0]}' range specification."
+            f"Center must be provided for '{spec_[0]}' range specification."
         )
 
-    if spec[0] == "linspace":
-        start, stop = spec[1:3]
-    elif spec[0].endswith("window"):
-        center_, width = spec[1:3]
+    if spec_[0] == "linspace":
+        start, stop = spec_[1:3]
+    elif spec_[0].endswith("window"):
+        center_, width = spec_[1:3]
         start, stop = center_ - width / 2, center_ + width / 2
-    elif spec[0].endswith("center"):
-        width = spec[1]
+    elif spec_[0].endswith("center"):
+        width = spec_[1]
         start, stop = center - width / 2, center + width / 2
-    elif spec[0].endswith("asym"):
-        left_shift, right_shift = spec[1]
+    elif spec_[0].endswith("asym"):
+        left_shift, right_shift = spec_[1]
         start, stop = center - left_shift, center + right_shift
 
-    if spec[0].startswith("lin"):
-        step = (stop - start) / (spec[-1] - 1)
+    if spec_[0].startswith("lin"):
+        step = (stop - start) / (spec_[-1] - 1)
         return start, stop, step
-    return start, stop, spec[-1]
+    return start, stop, spec_[-1]

--- a/src/qibocal/protocols/utils.py
+++ b/src/qibocal/protocols/utils.py
@@ -1203,7 +1203,7 @@ RangeLike = (
 """Range specification.
 
 The alternative options allow for multiple representations of a range, which could all
-be reconducted to a sequence of evenly spaced values.
+be mapped to a sequence of evenly spaced values.
 
 The semantics of the default one is equivalent to that of the built-in :func:`range`, in
 which the three values correspond to ``(start, stop, step)``. Unlike :func:`range`, all
@@ -1214,7 +1214,7 @@ The other variants are unambiguously discriminated by a starting label, e.g.
 
 In the ``linspace`` variant, the ``step`` element is replaced with the number of steps.
 Since the step specification is always mandatory, for each of the other variants a
-further ``lin<...>`` version is also avaialble, making the same substitution.
+further ``lin<...>`` version is also available, making the same substitution.
 
 The other variants are the following:
 

--- a/src/qibocal/protocols/utils.py
+++ b/src/qibocal/protocols/utils.py
@@ -2,7 +2,7 @@ from collections import Counter
 from collections.abc import Sequence
 from colorsys import hls_to_rgb
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -1185,3 +1185,72 @@ def fallback_period(period: NDArray) -> NDArray:
     )
 
     return np.where(np.isnan(period), 4, period)
+
+
+RangeLike = (
+    tuple[float, float, float]
+    | tuple[Literal["linspace"], float, float, int]
+    | tuple[Literal["window"], float, float, float]
+    | tuple[Literal["linwindow"], float, float, int]
+    | tuple[Literal["center"], float, float]
+    | tuple[Literal["lincenter"], float, int]
+    | tuple[Literal["asym"], tuple[float, float], float]
+    | tuple[Literal["linasym"], tuple[float, float], int]
+)
+"""Range specification.
+
+The alternative options allow for multiple representations of a range, which could all
+be reconducted to a sequence of evenly spaced values.
+
+The semantics of the default one is equivalent to that of the built-in :func:`range`, in
+which the three values correspond to ``(start, stop, step)``. Unlike :func:`range`, all
+values are mandatory, since the usual defaults are often unsuitable.
+
+The other variants are unambiguously discriminated by a starting label, e.g.
+``("linspace", 1.2, 1.5, 70)``.
+
+In the ``linspace`` variant, the ``step`` element is replaced with the number of steps.
+Since the step specification is always mandatory, for each of the other variants a
+further ``lin<...>`` version is also avaialble, making the same substitution.
+
+The other variants are the following:
+
+- ``window``, which allows to specify the center and width of the window, instead of its
+  extremes, i.e. ``("window", center, width, step)``
+- ``center``, similar to the former, but assuming a default for the center, which
+  depends the chosen protocol, i.e. ``("center", width, step)``
+- ``asym``, which is also a way to build upon an implicit center, but with specifying an
+  asymmetric interval around it, i.e. ``("asim", (left-shift, right-shift), step)``
+"""
+
+
+def to_range(
+    spec: RangeLike, center: float | None = None
+) -> tuple[float, float, float]:
+    """Convert any range specification into the default representation."""
+
+    if not isinstance(spec[0], str):
+        # Default case: assume it's a tuple of (start, stop, step)
+        return spec
+
+    if any(lab in spec[0] for lab in {"center", "asym"}) and center is None:
+        raise ValueError(
+            f"Center must be provided for '{spec[0]}' range specification."
+        )
+
+    if spec[0] == "linspace":
+        start, stop = spec[1:3]
+    elif spec[0].endswith("window"):
+        center_, width = spec[1:3]
+        start, stop = center_ - width / 2, center_ + width / 2
+    elif spec[0].endswith("center"):
+        width = spec[1]
+        start, stop = center - width / 2, center + width / 2
+    elif spec[0].endswith("asym"):
+        left_shift, right_shift = spec[1]
+        start, stop = center - left_shift, center + right_shift
+
+    if spec[0].startswith("lin"):
+        step = (stop - start) / (spec[-1] - 1)
+        return start, stop, step
+    return start, stop, spec[-1]

--- a/src/qibocal/protocols/utils.py
+++ b/src/qibocal/protocols/utils.py
@@ -1234,29 +1234,31 @@ def to_range(spec: RangeLike, center: float | None = None) -> Range:
     """Convert any range specification into the default representation."""
 
     spec_ = _RangeLike.validate_python(spec)
+    mode = spec_[0]
 
-    if not isinstance(spec_[0], str):
+    if not isinstance(mode, str):
         # Default case: assume it's a tuple of (start, stop, step)
         return spec_
 
-    if any(lab in spec_[0] for lab in {"center", "asym"}) and center is None:
-        raise ValueError(
-            f"Center must be provided for '{spec_[0]}' range specification."
-        )
+    if any(lab in mode for lab in {"center", "asym"}) and center is None:
+        raise ValueError(f"Center must be provided for '{mode}' range specification.")
 
-    if spec_[0] == "linspace":
+    if mode == "linspace":
         start, stop = spec_[1:3]
-    elif spec_[0].endswith("window"):
+    elif mode.endswith("window"):
         center_, width = spec_[1:3]
         start, stop = center_ - width / 2, center_ + width / 2
-    elif spec_[0].endswith("center"):
+    elif mode.endswith("center"):
         width = spec_[1]
         start, stop = center - width / 2, center + width / 2
-    elif spec_[0].endswith("asym"):
+    elif mode.endswith("asym"):
         left_shift, right_shift = spec_[1]
         start, stop = center - left_shift, center + right_shift
 
-    if spec_[0].startswith("lin"):
-        step = (stop - start) / (spec_[-1] - 1)
+    if mode.startswith("lin"):
+        n = spec_[-1]
+        if n <= 1:
+            raise ValueError(f"At least 2 steps required for {mode}, passed {n}")
+        step = (stop - start) / (n - 1)
         return start, stop, step
     return start, stop, spec_[-1]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from pydantic import ValidationError
 
 from qibocal.protocols.utils import cumulative, eval_magnitude, to_range
 
@@ -30,3 +31,10 @@ def test_range_conversion():
 
     with pytest.raises(ValueError, match="center"):
         to_range(("center", 1e6, 10))
+
+    with pytest.raises(ValidationError):
+        to_range(("linwindow", 50, 10))
+    with pytest.raises(ValidationError):
+        to_range(("center", 50, 10, 20))
+    with pytest.raises(ValidationError):
+        to_range(("asym", -10, 10, 20))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import numpy as np
+import pytest
 
-from qibocal.protocols.utils import cumulative, eval_magnitude
+from qibocal.protocols.utils import cumulative, eval_magnitude, to_range
 
 
 def test_cumulative():
@@ -12,3 +13,20 @@ def test_eval_magnitude():
     assert 0 == eval_magnitude(0)
     assert 0 == eval_magnitude(np.inf)
     assert 3 == eval_magnitude(2000)
+
+
+def test_range_conversion():
+    assert to_range((0, 100, 2)) == (0, 100, 2)
+    assert to_range(("linspace", 0, 100, int(1e3)))[:2] == (0, 100)
+    assert pytest.approx(to_range(("window", 50, 10, 1e-1))) == (45, 55, 1e-1)
+    assert pytest.approx(to_range(("linwindow", 50, 10, int(5e2)))[:2]) == (45, 55)
+    assert pytest.approx(to_range(("center", 1e5, 1e-1), center=1e6)[0]) == 1e6 - 5e4
+    assert pytest.approx(to_range(("lincenter", 1e5, 1234), center=1e6)[1]) == 1e6 + 5e4
+    assert pytest.approx(to_range(("asym", (1e5, -2e4), 1e-1), center=1e6)[0]) == 0.9e6
+    assert (
+        pytest.approx(to_range(("linasym", (1e5, -2e4), 987), center=1e6)[1])
+        == 1e6 - 2e4
+    )
+
+    with pytest.raises(ValueError, match="center"):
+        to_range(("center", 1e6, 10))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,6 +31,8 @@ def test_range_conversion():
 
     with pytest.raises(ValueError, match="center"):
         to_range(("center", 1e6, 10))
+    with pytest.raises(ValueError, match="2 steps"):
+        to_range(("lincenter", 1e6, 1), center=5e9)
 
     with pytest.raises(ValidationError):
         to_range(("linwindow", 50, 10))


### PR DESCRIPTION
E.g.:
```py
e.resonator_spectroscopy(
    frequency=("linwindow", 7.2e9, 1e8, 100),
    power_level="high",
    amplitude=0.2,
    nshots=100,
    relaxation_time=500,
)
```