### PR TITLE
add scikit-learn dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4524,4 +4524,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "8cd8566eb4d6008313e1ba63d67d265eb211b2a628e904892d69e28efab0ed44"
+content-hash = "1c0b808f59e7f171781c7b98c82b18844cc46bace9abee4bd8c7ba4d015e9744"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ qibolab = "^0.2.8"
 qibo = "^0.3.1"
 numpy = ">=1.26.4,<3"
 scipy = "^1.10.1"
+scikit-learn = ">=1.3.0,<2"
 pandas = { version = "^2.2.2", extras = ["html"] }
 pydantic = "^2.8.0"
 click = "^8.1.3"


### PR DESCRIPTION
While sikit-learn was already a dependency through skops (which we may want to get rid of soon), it is also directly used in qibocal so should be a direct dependency as well