### PR TITLE
fixing bugs in `zz_coupling` protocol

### DIFF
--- a/src/qibocal/auto/execute.py
+++ b/src/qibocal/auto/execute.py
@@ -137,8 +137,9 @@ class Executor(BaseModel):
             targets: Targets | None = None,
             **kwargs: Any,
         ):
-            # casting targest to be of type Targets
-            targets = TypeAdapter(Targets).validate_python(targets)
+            # casting targest to be of type Targets if not None
+            if targets is not None:
+                targets = TypeAdapter(Targets | None).validate_python(targets)
 
             positional = dict(
                 zip((f.name for f in fields(protocol.parameters_type)), args)

--- a/src/qibocal/auto/execute.py
+++ b/src/qibocal/auto/execute.py
@@ -12,7 +12,7 @@ from functools import cached_property, reduce
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 from qibo.backends import construct_backend
 from qibolab import Platform
 
@@ -137,6 +137,9 @@ class Executor(BaseModel):
             targets: Targets | None = None,
             **kwargs: Any,
         ):
+            # casting targest to be of type Targets
+            targets = TypeAdapter(Targets).validate_python(targets)
+
             positional = dict(
                 zip((f.name for f in fields(protocol.parameters_type)), args)
             )

--- a/src/qibocal/auto/execute.py
+++ b/src/qibocal/auto/execute.py
@@ -139,7 +139,7 @@ class Executor(BaseModel):
         ):
             # casting targest to be of type Targets if not None
             if targets is not None:
-                targets = TypeAdapter(Targets | None).validate_python(targets)
+                targets = TypeAdapter(Targets).validate_python(targets)
 
             positional = dict(
                 zip((f.name for f in fields(protocol.parameters_type)), args)

--- a/src/qibocal/protocols/ramsey/zz_coupling.py
+++ b/src/qibocal/protocols/ramsey/zz_coupling.py
@@ -233,9 +233,6 @@ def _acquisition(
     In the second execution one qubit is brought to the excited state.
     """
 
-    # casting targets into tuples
-    targets = [tuple(pair) for pair in targets]
-
     qubits_list = list(chain.from_iterable(targets))
     qubits_set = set(qubits_list)
 
@@ -414,9 +411,6 @@ def _plot(
 ) -> tuple[list[go.Figure], str]:
     """Plotting function for Ramsey Experiment."""
 
-    # casting target as a tuple
-    target = tuple(target)
-
     fitting_report = ""
 
     fig = make_subplots(
@@ -501,8 +495,6 @@ def _update(
     results: RamseyZZResults, platform: CalibrationPlatform, target: QubitPairId
 ) -> None:
     """Update the platform calibration with the results of the Ramsey ZZ experiment."""
-    # casting target as a tuple
-    target = tuple(target)
     update.pair_coupling(results.coupling[target], platform, target)
 
 

--- a/src/qibocal/protocols/ramsey/zz_coupling.py
+++ b/src/qibocal/protocols/ramsey/zz_coupling.py
@@ -212,11 +212,7 @@ def _execute_ramsey_zz(
                 RamseyZZType,
                 (pair, setup),
                 dict(
-                    wait=np.arange(
-                        params.delay_between_pulses_start,
-                        params.delay_between_pulses_end,
-                        params.delay_between_pulses_step,
-                    ),
+                    wait=np.arange(*params.delay_range),
                     targ_prob=targ_probs,
                     spect_prob=spect_probs,
                 ),
@@ -236,6 +232,9 @@ def _acquisition(
     Standard Ramsey experiment repeated twice.
     In the second execution one qubit is brought to the excited state.
     """
+
+    # casting targets into tuples
+    targets = [tuple(pair) for pair in targets]
 
     qubits_list = list(chain.from_iterable(targets))
     qubits_set = set(qubits_list)
@@ -415,6 +414,9 @@ def _plot(
 ) -> tuple[list[go.Figure], str]:
     """Plotting function for Ramsey Experiment."""
 
+    # casting target as a tuple
+    target = tuple(target)
+
     fitting_report = ""
 
     fig = make_subplots(
@@ -499,7 +501,8 @@ def _update(
     results: RamseyZZResults, platform: CalibrationPlatform, target: QubitPairId
 ) -> None:
     """Update the platform calibration with the results of the Ramsey ZZ experiment."""
-
+    # casting target as a tuple
+    target = tuple(target)
     update.pair_coupling(results.coupling[target], platform, target)
 
 


### PR DESCRIPTION
@alecandido pointed out two small bugs in `zz_coupling` module.
In particular the code crashes when qubit pair is a `list` object, this since it is used as a jey in the data dictionary, resulting in an error.
Also it uses some initial parameters that are optional, hence when those values are not set the error raises.