### PR TITLE
adding input tuple overlap at executor level

### DIFF
--- a/src/qibocal/auto/execute.py
+++ b/src/qibocal/auto/execute.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import fields
 from functools import cached_property, reduce
+from itertools import combinations
 from pathlib import Path
 from typing import Any
 
@@ -22,12 +23,18 @@ from qibocal.config import log
 from ..calibration import CalibrationPlatform, create_calibration_platform
 from .history import History
 from .mode import AUTOCALIBRATION, ExecutionMode
-from .operation import Protocol, ProtocolsCollection
+from .operation import Protocol, ProtocolsCollection, QubitPairId, QubitTupleId
 from .output import Metadata, Output
 from .task import Action, Completed, Targets, Task
 
 PLATFORM_DIR = "platform"
 """Folder where platform will be dumped."""
+
+
+def check_qubit_tuples_overlap(targets: list[QubitPairId] | list[QubitTupleId]) -> None:
+    """This function checks if the input qubit tuples are independent, i.e. they don't share any qubit."""
+    if any(set(t1) & set(t2) for t1, t2 in combinations(targets, 2)):
+        raise ValueError("Target tuples must be independent, but are overlapping.")
 
 
 class Executor(BaseModel):
@@ -140,6 +147,10 @@ class Executor(BaseModel):
             # casting targest to be of type Targets if not None
             if targets is not None:
                 targets = TypeAdapter(Targets).validate_python(targets)
+
+            if all(isinstance(t, tuple) for t in targets):
+                # check if input was given correctly
+                check_qubit_tuples_overlap(targets)
 
             positional = dict(
                 zip((f.name for f in fields(protocol.parameters_type)), args)

--- a/src/qibocal/auto/execute.py
+++ b/src/qibocal/auto/execute.py
@@ -31,6 +31,12 @@ PLATFORM_DIR = "platform"
 """Folder where platform will be dumped."""
 
 
+def check_overlap_in_input_qubits(targets: np.typing.ArrayLike):
+    # check if input was given correctly
+    targ = np.asarray(targets)
+    assert np.unique(targ).size == targ.size, "One or more target qubits were repeated"
+
+
 class Executor(BaseModel):
     """Execute a tasks' graph and tracks its history."""
 
@@ -58,6 +64,8 @@ class Executor(BaseModel):
         for name, protocol in self.protocols.items():
             object.__setattr__(self, name, self._wrapped_protocol(protocol, name))
 
+        check_overlap_in_input_qubits(self.targets)
+
     @cached_property
     def protocols(self) -> ProtocolsCollection:
         return reduce(operator.or_, [protocols.PROTOCOLS] + self.sources)
@@ -70,12 +78,6 @@ class Executor(BaseModel):
         output: Path | None = None,
     ) -> Completed:
         """Run single protocol in ExecutionMode mode."""
-
-        # check if input was given correctly
-        targ = np.asarray(self.targets)
-        assert np.unique(targ).size == targ.size, (
-            "One or more target qubits were repeated"
-        )
 
         task = Task(action=parameters, operation=protocol)
         log.info(f"Executing mode {mode} on {task.action.id}.")
@@ -148,6 +150,8 @@ class Executor(BaseModel):
             # casting targest to be of type Targets if not None
             if targets is not None:
                 targets = TypeAdapter(Targets).validate_python(targets)
+                # check if input is correct
+                check_overlap_in_input_qubits(targets)
 
             positional = dict(
                 zip((f.name for f in fields(protocol.parameters_type)), args)

--- a/src/qibocal/auto/execute.py
+++ b/src/qibocal/auto/execute.py
@@ -18,12 +18,13 @@ from qibo.backends import construct_backend
 from qibolab import Platform
 
 from qibocal import protocols
+from qibocal.calibration.calibration import QubitPairId, QubitTupleId
 from qibocal.config import log
 
 from ..calibration import CalibrationPlatform, create_calibration_platform
 from .history import History
 from .mode import AUTOCALIBRATION, ExecutionMode
-from .operation import Protocol, ProtocolsCollection, QubitPairId, QubitTupleId
+from .operation import Protocol, ProtocolsCollection
 from .output import Metadata, Output
 from .task import Action, Completed, Targets, Task
 
@@ -148,9 +149,9 @@ class Executor(BaseModel):
             if targets is not None:
                 targets = TypeAdapter(Targets).validate_python(targets)
 
-            if all(isinstance(t, tuple) for t in targets):
-                # check if input was given correctly
-                check_qubit_tuples_overlap(targets)
+                if all(isinstance(t, tuple) for t in targets):
+                    # check if input was given correctly
+                    check_qubit_tuples_overlap(targets)
 
             positional = dict(
                 zip((f.name for f in fields(protocol.parameters_type)), args)

--- a/src/qibocal/auto/execute.py
+++ b/src/qibocal/auto/execute.py
@@ -9,16 +9,15 @@ from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import fields
 from functools import cached_property, reduce
-from itertools import combinations
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 from qibo.backends import construct_backend
 from qibolab import Platform
 
 from qibocal import protocols
-from qibocal.calibration.calibration import QubitPairId, QubitTupleId
 from qibocal.config import log
 
 from ..calibration import CalibrationPlatform, create_calibration_platform
@@ -30,12 +29,6 @@ from .task import Action, Completed, Targets, Task
 
 PLATFORM_DIR = "platform"
 """Folder where platform will be dumped."""
-
-
-def check_qubit_tuples_overlap(targets: list[QubitPairId] | list[QubitTupleId]) -> None:
-    """This function checks if the input qubit tuples are independent, i.e. they don't share any qubit."""
-    if any(set(t1) & set(t2) for t1, t2 in combinations(targets, 2)):
-        raise ValueError("Target tuples must be independent, but are overlapping.")
 
 
 class Executor(BaseModel):
@@ -77,6 +70,13 @@ class Executor(BaseModel):
         output: Path | None = None,
     ) -> Completed:
         """Run single protocol in ExecutionMode mode."""
+
+        # check if input was given correctly
+        targ = np.asarray(self.targets)
+        assert np.unique(targ).size == targ.size, (
+            "One or more target qubits were repeated"
+        )
+
         task = Task(action=parameters, operation=protocol)
         log.info(f"Executing mode {mode} on {task.action.id}.")
         completed = task.run(
@@ -148,10 +148,6 @@ class Executor(BaseModel):
             # casting targest to be of type Targets if not None
             if targets is not None:
                 targets = TypeAdapter(Targets).validate_python(targets)
-
-                if all(isinstance(t, tuple) for t in targets):
-                    # check if input was given correctly
-                    check_qubit_tuples_overlap(targets)
 
             positional = dict(
                 zip((f.name for f in fields(protocol.parameters_type)), args)

--- a/src/qibocal/auto/execute.py
+++ b/src/qibocal/auto/execute.py
@@ -32,9 +32,11 @@ PLATFORM_DIR = "platform"
 
 
 def check_overlap_in_input_qubits(targets: np.typing.ArrayLike):
-    # check if input was given correctly
+    """Check that target qubits do not contain duplicates."""
+
     targ = np.asarray(targets)
-    assert np.unique(targ).size == targ.size, "One or more target qubits were repeated"
+    if np.unique(targ).size != targ.size:
+        raise ValueError("One or more target qubits were repeated.")
 
 
 class Executor(BaseModel):

--- a/src/qibocal/auto/operation.py
+++ b/src/qibocal/auto/operation.py
@@ -12,9 +12,9 @@ import numpy as np
 import numpy.typing as npt
 from qibolab import Platform, Qubit
 
+from qibocal.calibration.calibration import QubitId, QubitPairId
 from qibocal.config import log
 
-from ..calibration.calibration import QubitId, QubitPairId
 from .serialize import deserialize, load, serialize
 
 __all__ = ["ProtocolsCollection", "Protocol"]

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -10,8 +10,8 @@ import yaml
 from qibo import Circuit
 from qibolab import Platform
 
-from qibocal.auto.operation import QubitId, QubitPairId, QubitTupleId
 from qibocal.auto.serialize import _nested_list_to_tuples
+from qibocal.calibration.calibration import QubitId, QubitPairId, QubitTupleId
 
 from .. import protocols
 from ..config import log

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -11,7 +11,7 @@ from qibo import Circuit
 from qibolab import Platform
 
 from qibocal.auto.serialize import _nested_list_to_tuples
-from qibocal.calibration.calibration import QubitId, QubitPairId, QubitTupleId
+from qibocal.calibration.calibration import QubitId, QubitPairId
 
 from .. import protocols
 from ..config import log
@@ -21,7 +21,7 @@ from .operation import Data, DummyPars, OperationId, Protocol, Results, dummy_op
 Id = NewType("Id", str)
 """Action identifiers type."""
 
-Targets = Union[list[QubitId], list[QubitPairId], list[QubitTupleId]]
+Targets = Union[list[QubitId], list[QubitPairId], list[tuple[QubitId, ...]]]
 """Elements to be calibrated by a single protocol."""
 
 SINGLE_ACTION = "action.yml"

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -10,7 +10,7 @@ import yaml
 from qibo import Circuit
 from qibolab import Platform
 
-from qibocal.auto.operation import QubitId, QubitPairId
+from qibocal.auto.operation import QubitId, QubitPairId, QubitTupleId
 from qibocal.auto.serialize import _nested_list_to_tuples
 
 from .. import protocols
@@ -21,7 +21,7 @@ from .operation import Data, DummyPars, OperationId, Protocol, Results, dummy_op
 Id = NewType("Id", str)
 """Action identifiers type."""
 
-Targets = Union[list[QubitId], list[QubitPairId], list[tuple[QubitId, ...]]]
+Targets = Union[list[QubitId], list[QubitPairId], list[QubitTupleId]]
 """Elements to be calibrated by a single protocol."""
 
 SINGLE_ACTION = "action.yml"

--- a/src/qibocal/calibration/calibration.py
+++ b/src/qibocal/calibration/calibration.py
@@ -18,9 +18,6 @@ QubitPairId = Annotated[
 ]
 """Qubit pair name."""
 
-QubitTupleId = tuple[QubitId, ...]
-"""Qubit tuple name."""
-
 CALIBRATION = "calibration.json"
 """Calibration file."""
 

--- a/src/qibocal/calibration/calibration.py
+++ b/src/qibocal/calibration/calibration.py
@@ -18,6 +18,9 @@ QubitPairId = Annotated[
 ]
 """Qubit pair name."""
 
+QubitTupleId = tuple[QubitId, ...]
+"""Qubit tuple name."""
+
 CALIBRATION = "calibration.json"
 """Calibration file."""
 

--- a/src/qibocal/protocols/two_qubit_interaction/cross_resonance/cancellation_amplitude.py
+++ b/src/qibocal/protocols/two_qubit_interaction/cross_resonance/cancellation_amplitude.py
@@ -32,7 +32,6 @@ from .cr_parent_classes import (
     HamiltonianTomographyParameters,
     HamiltonianTomographyResults,
     SetControl,
-    check_qubit_overlap,
 )
 from .cross_resonance_processing import (
     cancellation_amplitude_fit,
@@ -175,9 +174,6 @@ def _acquisition(
         echo=params.echo,
         verbose_plot=params.verbose_plot,
     )
-
-    # check validity of input
-    check_qubit_overlap(targets)
 
     updates = []
     control_ampls: dict[QubitPairId, float] = {}

--- a/src/qibocal/protocols/two_qubit_interaction/cross_resonance/cancellation_phase.py
+++ b/src/qibocal/protocols/two_qubit_interaction/cross_resonance/cancellation_phase.py
@@ -32,7 +32,6 @@ from .cr_parent_classes import (
     HamiltonianTomographyParameters,
     HamiltonianTomographyResults,
     SetControl,
-    check_qubit_overlap,
 )
 from .cross_resonance_processing import (
     cancellation_phase_fit,
@@ -173,9 +172,6 @@ def _acquisition(
         echo=params.echo,
         verbose_plot=params.verbose_plot,
     )
-
-    # check validity of input
-    check_qubit_overlap(targets)
 
     updates = []
     control_ampls: dict[QubitPairId, float] = {}

--- a/src/qibocal/protocols/two_qubit_interaction/cross_resonance/cr_parent_classes.py
+++ b/src/qibocal/protocols/two_qubit_interaction/cross_resonance/cr_parent_classes.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass, field
 from enum import Enum
-from itertools import combinations
 from typing import Any
 
 import numpy as np
@@ -23,20 +22,6 @@ HamiltonianTomographyType = np.dtype(
     ]
 )
 """Custom dtype for Hamiltonian Tomography."""
-
-
-class OverlappingQubitPairError(Exception):
-    """Raised when the target qubit pairs are not independent."""
-
-    pass
-
-
-def check_qubit_overlap(targets: list[QubitPairId]) -> None:
-    """This function checks if the input qubit pairs are independent, i.e. they don't share any qubit."""
-    if any(set(t1) & set(t2) for t1, t2 in combinations(targets, 2)):
-        raise OverlappingQubitPairError(
-            "Target pairs must be independent, but are overlapping."
-        )
 
 
 class SetControl(str, Enum):

--- a/src/qibocal/protocols/two_qubit_interaction/cross_resonance/cross_resonance_amplitude.py
+++ b/src/qibocal/protocols/two_qubit_interaction/cross_resonance/cross_resonance_amplitude.py
@@ -26,7 +26,6 @@ from .cr_parent_classes import (
     HamiltonianTomographyResults,
     HamiltonianTomographyType,
     SetControl,
-    check_qubit_overlap,
 )
 from .cross_resonance_processing import (
     extract_hamiltonian_terms,
@@ -109,9 +108,6 @@ def _acquisition(
         target_amplitude=params.target_amplitude,
         target_phase=params.target_phase,
     )
-
-    # check validity of input
-    check_qubit_overlap(targets)
 
     # update the CR channel with the target qubit frequency.
     updates = [

--- a/src/qibocal/protocols/two_qubit_interaction/cross_resonance/cross_resonance_length.py
+++ b/src/qibocal/protocols/two_qubit_interaction/cross_resonance/cross_resonance_length.py
@@ -31,7 +31,6 @@ from .cr_parent_classes import (
     HamiltonianTomographyResults,
     HamiltonianTomographyType,
     SetControl,
-    check_qubit_overlap,
 )
 from .cross_resonance_processing import (
     extract_hamiltonian_terms,
@@ -104,9 +103,6 @@ def _acquisition(
         target_amplitude=params.target_amplitude,
         target_phase=params.target_phase,
     )
-
-    # check validity of input
-    check_qubit_overlap(targets)
 
     # update the CR channel with the target qubit frequency.
     updates = [

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -9,6 +9,7 @@ from qibolab import Platform
 import qibocal
 import qibocal.protocols
 from qibocal import Executor
+from qibocal.auto.execute import check_overlap_in_input_qubits
 from qibocal.auto.mode import ExecutionMode
 from qibocal.auto.operation import Data, Parameters, Protocol, QubitId, Results
 from qibocal.auto.runcard import Action
@@ -155,3 +156,35 @@ def test_single_shot(tmp_path: Path, platform: CalibrationPlatform):
 def test_rx_calibration(tmp_path: Path, platform: CalibrationPlatform):
     globals_ = {"platform": platform, "target": 0, "path": tmp_path}
     exec((CALIBRATION_SCRIPTS / "rx_calibration.py").read_text(), globals_)
+
+
+def test_check_input_qubit_overlap():
+    """Verify input qubit overlap validation for single qubits and qubit pairs."""
+
+    # list of unrepeated qubit, check passes
+    inputs = ["B0", 1, "B2", 3]
+    check_overlap_in_input_qubits(inputs)
+
+    # list of repeated qubits, check raises a ValuError
+    inputs = ["B0", 1, "B0", 3]
+    with pytest.raises(ValueError, match="One or more target qubits were repeated."):
+        check_overlap_in_input_qubits(inputs)
+
+    # list of unrepeated qubit pairs and unrepeated qubits, check passes
+    inputs = [(0, 1), (2, 3), (4, 5), (6, 7)]
+    check_overlap_in_input_qubits(inputs)
+
+    # list of repeated pairs, check raises ValueError
+    inputs = [(0, 1), (2, 3), (0, 1)]
+    with pytest.raises(ValueError, match="One or more target qubits were repeated."):
+        check_overlap_in_input_qubits(inputs)
+
+    # list of unrepeated pairs but repeated qubit, check raises ValueError
+    inputs = [(0, 1), (1, 2)]
+    with pytest.raises(ValueError, match="One or more target qubits were repeated."):
+        check_overlap_in_input_qubits(inputs)
+
+    # list of unrepeated pair but same qubit in one pair, check raises ValueError
+    inputs = [(0, 1), (2, 2)]
+    with pytest.raises(ValueError, match="One or more target qubits were repeated."):
+        check_overlap_in_input_qubits(inputs)


### PR DESCRIPTION
I am adding in `_wrapped_protocol` in `Executor` class an additional check (`check_qubit_tuples_overlap`) for the input targets in case this is a list of qubit tuples: `list[QubitPairId | QubitTuplesId]`.
This check asserts whether there in no overlap between different qubit tuples in the list and was first implemented in cross resonance protocols, but I think it can be generalized for all two-qubit protocols.