### PR TITLE
Bump qibolab version used in tests to v0.2.16

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3346,14 +3346,14 @@ qulacs = ["qulacs (>=0.6.4,<0.7.0) ; python_version < \"3.13\""]
 
 [[package]]
 name = "qibolab"
-version = "0.2.15"
+version = "0.2.16"
 description = "Quantum hardware module and drivers for Qibo"
 optional = false
 python-versions = "<3.14,>=3.10"
 groups = ["main", "tests"]
 files = [
-    {file = "qibolab-0.2.15-py3-none-any.whl", hash = "sha256:4dd4ae7355ab77b60a735d461c93335012570ebf8faa742e8278b97caa6c14d0"},
-    {file = "qibolab-0.2.15.tar.gz", hash = "sha256:a14816c12551354a8e75fe6187cfbdf14eff162b356c074f491cf34a75e32b17"},
+    {file = "qibolab-0.2.16-py3-none-any.whl", hash = "sha256:816b161e9d6cb6fc157cdbf3d6c7b745faeda8a98689cee3283118d67837597c"},
+    {file = "qibolab-0.2.16.tar.gz", hash = "sha256:c72c13cad2ce0582819ff73fc395e685dc64dfb5bec5f475c6cd244dc2265843"},
 ]
 
 [package.dependencies]
@@ -3363,7 +3363,7 @@ scipy = ">=1.13.0,<2.0.0"
 
 [package.extras]
 backend = ["qibo (>=0.3.0,<0.4.0)"]
-emulator = ["qutip (>=5.0.2,<6.0.0)"]
+emulator = ["dynamiqs (>=0.3.4,<0.4.0)", "qutip (>=5.0.2,<6.0.0)"]
 qrng = ["pyserial (>=3.5,<4.0)"]
 
 [[package]]
@@ -4524,4 +4524,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "1c0b808f59e7f171781c7b98c82b18844cc46bace9abee4bd8c7ba4d015e9744"
+content-hash = "34223cb678e7ca12111c261f6363a4e76a63786ca1a795ece708cad0c1f271fa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ cma = "^3.3.0"
 optional = true
 
 [tool.poetry.group.tests.dependencies]
-qibolab = "^0.2.13"        # "bounds" are not defined in the test platform but required by earlier versions of qibolab
+qibolab = "^0.2.16"        # "qibolab._core.platform.load.PLATFORMS" is renamed to "PLATFORMS_PATH", and import path for Hardware is changed https://github.com/qiboteam/qibolab/pull/1515
 pytest = ">=7.1.2,<10.0.0"
 pytest-cov = "^3.0.0"
 pytest-env = "^0.8.1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 
 import pytest
-from qibolab._core.platform.load import PLATFORMS
+from qibolab._core.platform.load import PLATFORMS_PATH
 
 from qibocal.calibration.platform import (
     CalibrationPlatform,
@@ -26,7 +26,7 @@ def cd(tmp_path_factory: pytest.TempdirFactory):
 @pytest.fixture(scope="function", params=TESTING_PLATFORM_NAMES)
 def platform(request, monkeypatch) -> CalibrationPlatform:
     """Dummy platform to be used when there is no access to QPU."""
-    monkeypatch.setenv(PLATFORMS, str(Path(__file__).parent / "platforms"))
+    monkeypatch.setenv(PLATFORMS_PATH, str(Path(__file__).parent / "platforms"))
     return create_calibration_platform(request.param)
 
 

--- a/tests/platforms/mock/platform.py
+++ b/tests/platforms/mock/platform.py
@@ -2,8 +2,7 @@ import pathlib
 
 from qibolab._core.components import AcquisitionChannel, DcChannel, IqChannel
 from qibolab._core.instruments.dummy import DummyInstrument, DummyLocalOscillator
-from qibolab._core.parameters import Hardware
-from qibolab._core.platform import Platform
+from qibolab._core.platform import Hardware, Platform
 from qibolab._core.qubits import Qubit
 
 FOLDER = pathlib.Path(__file__).parent

--- a/tests/platforms/mock1_faulty/platform.py
+++ b/tests/platforms/mock1_faulty/platform.py
@@ -2,8 +2,7 @@ import pathlib
 
 from qibolab._core.components import AcquisitionChannel, DcChannel, IqChannel
 from qibolab._core.instruments.dummy import DummyInstrument, DummyLocalOscillator
-from qibolab._core.parameters import Hardware
-from qibolab._core.platform import Platform
+from qibolab._core.platform import Hardware, Platform
 from qibolab._core.qubits import Qubit
 
 FOLDER = pathlib.Path(__file__).parent

--- a/tests/platforms/mock2/platform.py
+++ b/tests/platforms/mock2/platform.py
@@ -1,6 +1,6 @@
 from qibolab._core.components import AcquisitionChannel, DcChannel, IqChannel
 from qibolab._core.instruments.dummy import DummyInstrument, DummyLocalOscillator
-from qibolab._core.parameters import Hardware
+from qibolab._core.platform import Hardware
 from qibolab._core.qubits import Qubit
 
 

--- a/tests/test_calibration_platform.py
+++ b/tests/test_calibration_platform.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 from qibolab import create_platform
-from qibolab._core.platform.load import PLATFORMS
+from qibolab._core.platform.load import PLATFORMS_PATH
 
 from qibocal.calibration.platform import CalibrationError, CalibrationPlatform
 
@@ -10,7 +10,7 @@ from qibocal.calibration.platform import CalibrationError, CalibrationPlatform
 def test_validation_calibration_platform(monkeypatch):
     """Test for phase validation in the CalibrationPlatform initialization."""
 
-    monkeypatch.setenv(PLATFORMS, str(Path(__file__).parent / "platforms"))
+    monkeypatch.setenv(PLATFORMS_PATH, str(Path(__file__).parent / "platforms"))
 
     faulty_plat_name = "mock1_faulty"
     faulty_platform = create_platform(faulty_plat_name)


### PR DESCRIPTION
In qibocal v0.2.16 the private interface _core changed in a way that breaks the qibocal test: qiboteam/qibolab#1515. This change ensures agreement with the new private interface.