### PR TITLE
Ramsey: don't duplicate `target in fit.fitted_parameters` check 

### DIFF
--- a/src/qibocal/protocols/ramsey/classification.py
+++ b/src/qibocal/protocols/ramsey/classification.py
@@ -105,6 +105,7 @@ def _fit(data: RamseyData) -> RamseyResults:
         except RuntimeError as e:
             log.warning(f"Ramsey fitting failed for qubit {qubit} due to {e}.")
             continue
+
         (
             freq_measure[qubit],
             t2_measure[qubit],
@@ -112,6 +113,7 @@ def _fit(data: RamseyData) -> RamseyResults:
             delta_fitting_measure[qubit],
             popts[qubit],
         ) = process_fit(popt, perr, qubit_freq, data.detuning)
+
     return RamseyResults(
         detuning=data.detuning,
         frequency=freq_measure,

--- a/src/qibocal/protocols/ramsey/processing.py
+++ b/src/qibocal/protocols/ramsey/processing.py
@@ -231,7 +231,7 @@ def signal_plot(
         ]
     )
 
-    if fit is not None and target in fit.fitted_parameters:
+    if fit is not None:
         fitting_report = fit_plot(
             target=target,
             fit=fit,


### PR DESCRIPTION
after rebasing on main, this PR is essentially modifying the checks in ramsey fitting functions.
from the following if-condition:
`if fit is not None and target in fit.fitted_parameters`
 the second condition is already checked in `executor`, as pointed out below by @RoyStegeman.