### PR TITLE
FIT mode now creates platform with no hardware memory.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ Documentation = "https://qibo.science/qibocal/stable/"
 qq = "qibocal:command"
 
 [tool.uv.sources]
-qibolab = { git = "https://github.com/qiboteam/qibolab", branch = "main" }
+qibolab = { git = "https://github.com/qiboteam/qibolab", branch = "dummy_hardware_input_qubits_couplers" }
 
 [dependency-groups]
 tests = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 requires-python = ">=3.11,<3.14"
 dependencies = [
-  "qibolab>=0.2.16,<0.3.0", # 0.2.16 exports ChannelId
+  "qibolab", # resolved from git main via [tool.uv.sources]
   "qibo>=0.3.1,<0.4.0",
   "numpy>=2.0.0,<3.0.0",
   "scipy>=1.10.1,<2.0.0",
@@ -36,6 +36,9 @@ Documentation = "https://qibo.science/qibocal/stable/"
 
 [project.scripts]
 qq = "qibocal:command"
+
+[tool.uv.sources]
+qibolab = { git = "https://github.com/qiboteam/qibolab", branch = "main" }
 
 [dependency-groups]
 tests = [

--- a/src/qibocal/auto/execute.py
+++ b/src/qibocal/auto/execute.py
@@ -31,7 +31,7 @@ PLATFORM_DIR = "platform"
 """Folder where platform will be dumped."""
 
 
-def check_overlap_in_input_qubits(targets: np.typing.ArrayLike):
+def check_overlap_in_input_qubits(targets: list):
     """Check that target qubits do not contain duplicates."""
 
     targ = np.asarray(targets)
@@ -77,14 +77,37 @@ class Executor(BaseModel):
         protocol: Protocol,
         parameters: Action,
         mode: ExecutionMode = AUTOCALIBRATION,
-        output: Path | None = None,
     ) -> Completed:
-        """Run single protocol in ExecutionMode mode."""
+        """Run a calibration protocol and record the completed task.
+
+        The executor preserves the execution history and chooses the platform
+        instance used for the task based on the requested mode. If acquisition is
+        requested, the current live platform is used. If only fitting or analysis
+        is required, the platform is reconstructed from the output folder so that
+        the exact experiment configuration is reused.
+        If the mode contains :class:`ExecutionMode.FIT`, and the action is
+        configured to update the platform, it is updated using the fitted parameters.
+        """
+
+        output = self.path
 
         task = Task(action=parameters, operation=protocol)
         log.info(f"Executing mode {mode} on {task.action.id}.")
         completed = task.run(
-            platform=self.platform,
+            platform=(
+                # if I need to acquire data I need to create from scratch
+                # the platform with all its hardware configurations;
+                # when executor is just fitting I need to create the exact same
+                # platform of the experiment (saved in the experiment folder), and here
+                # the hardware configuration is unnecessary.
+                self.platform
+                if ExecutionMode.ACQUIRE in mode
+                else CalibrationPlatform.from_datafolder(
+                    folder_path=output,
+                    platform_name=self.platform.name,
+                    dummy_hardware=False,
+                )
+            ),
             targets=self.targets,
             mode=mode,
             folder=self.history.task_path(
@@ -168,9 +191,7 @@ class Executor(BaseModel):
                     "parameters": params | positional | kwargs,
                 }
             )
-            return self.run_protocol(
-                protocol, parameters=action, mode=mode, output=self.path
-            )
+            return self.run_protocol(protocol, parameters=action, mode=mode)
 
         return wrapper
 

--- a/src/qibocal/auto/execute.py
+++ b/src/qibocal/auto/execute.py
@@ -31,7 +31,7 @@ PLATFORM_DIR = "platform"
 """Folder where platform will be dumped."""
 
 
-def check_overlap_in_input_qubits(targets: list):
+def check_overlap_in_input_qubits(targets: np.typing.ArrayLike):
     """Check that target qubits do not contain duplicates."""
 
     targ = np.asarray(targets)
@@ -105,7 +105,7 @@ class Executor(BaseModel):
                 else CalibrationPlatform.from_datafolder(
                     folder_path=output,
                     platform_name=self.platform.name,
-                    dummy_hardware=False,
+                    dummy_hardware=True,
                 )
             ),
             targets=self.targets,

--- a/src/qibocal/auto/execute.py
+++ b/src/qibocal/auto/execute.py
@@ -31,7 +31,7 @@ PLATFORM_DIR = "platform"
 """Folder where platform will be dumped."""
 
 
-def check_overlap_in_input_qubits(targets: np.typing.ArrayLike):
+def check_overlap_in_input_qubits(targets: list):
     """Check that target qubits do not contain duplicates."""
 
     targ = np.asarray(targets)
@@ -77,14 +77,37 @@ class Executor(BaseModel):
         protocol: Protocol,
         parameters: Action,
         mode: ExecutionMode = AUTOCALIBRATION,
-        output: Path | None = None,
     ) -> Completed:
-        """Run single protocol in ExecutionMode mode."""
+        """Run a calibration protocol and record the completed task.
+
+        The executor preserves the execution history and chooses the platform
+        instance used for the task based on the requested mode. If acquisition is
+        requested, the current live platform is used. If only fitting or analysis
+        is required, the platform is reconstructed from the output folder so that
+        the exact experiment configuration is reused.
+        If the mode contains :class:`ExecutionMode.FIT`, and the action is
+        configured to update the platform, it is updated using the fitted parameters.
+        """
+
+        output = self.path
 
         task = Task(action=parameters, operation=protocol)
         log.info(f"Executing mode {mode} on {task.action.id}.")
         completed = task.run(
-            platform=self.platform,
+            platform=(
+                # if I need to acquire data I need to create from scratch
+                # the platform with all its hardware configurations;
+                # when executor is just fitting I need to create the exact same
+                # platform of the experiment (saved in the experiment folder), and here
+                # the hardware configuration is unnecessary.
+                self.platform
+                if ExecutionMode.ACQUIRE in mode
+                else CalibrationPlatform.from_datafolder(
+                    folder_path=output,
+                    platform_name=self.platform.name,
+                    dummy_hardware=False,
+                )
+            ),
             targets=self.targets,
             mode=mode,
             folder=self.history.task_path(
@@ -167,9 +190,7 @@ class Executor(BaseModel):
                     "parameters": params | positional | kwargs,
                 }
             )
-            return self.run_protocol(
-                protocol, parameters=action, mode=mode, output=self.path
-            )
+            return self.run_protocol(protocol, parameters=action, mode=mode)
 
         return wrapper
 

--- a/src/qibocal/auto/execute.py
+++ b/src/qibocal/auto/execute.py
@@ -103,7 +103,7 @@ class Executor(BaseModel):
                 self.platform
                 if ExecutionMode.ACQUIRE in mode
                 else CalibrationPlatform.from_datafolder(
-                    folder_path=output,
+                    folder_path=output / PLATFORM_DIR,
                     platform_name=self.platform.name,
                     dummy_hardware=True,
                 )

--- a/src/qibocal/auto/history.py
+++ b/src/qibocal/auto/history.py
@@ -115,14 +115,12 @@ class History:
         self._order.append(task_id)
         return task_id
 
-    def task_path(self, task_id: TaskId, folder: Path | None) -> Path | None:
+    def task_path(self, task_id: TaskId, folder: Path) -> Path:
         """Determine the path related to a completed task given TaskId.
 
         `folder` should be usually the general output folder, used by Qibocal to store
         all the execution results. Cf. :class:`qibocal.auto.output.Output`.
         """
-        if folder is None:
-            return None
         return folder / "data" / f"{task_id}"
 
     def dump(self, output: Path):

--- a/src/qibocal/auto/output.py
+++ b/src/qibocal/auto/output.py
@@ -231,12 +231,37 @@ class Output:
         update: bool = True,
         force: bool = False,
     ):
-        """Process existing output."""
-        backend = construct_backend(
-            backend=self.meta.backend, platform=self.meta.platform
-        )
-        assert backend.platform is not None
-        self.platform = CalibrationPlatform.from_platform(backend.platform)
+        """Process an existing output directory.
+
+        Reconstruct the calibration platform from the live backend during
+        acquisition or from the saved datafolder during fitting, then rerun each
+        completed task using the requested execution mode and output folder.
+        If ``update`` is enabled and the task supports platform updates, the
+        platform is refreshed accordingly. When ``force`` is ``False``, tasks
+        that already contain fitting results raise an error to avoid
+        overwriting them.
+        """
+        # NOTE: this function in principle takes also ``ExecutionMode.ACQUIRE`` as ``mode``
+        # value, but if we want this function to be used only for offline post-processing
+        # this input is completely unnecessary (we cannot acquire offline), so we might
+        # think of removing it.
+
+        # during acquisition we need the information of the hardware
+        if ExecutionMode.ACQUIRE in mode:
+            backend = construct_backend(
+                backend=self.meta.backend, platform=self.meta.platform
+            )
+            assert backend.platform is not None
+            self.platform = CalibrationPlatform.from_platform(backend.platform)
+        else:
+            # while performing a fitting task we do not need hardware information
+            # but also we need the params saved in the datafolder, since in the
+            # platform folder might been changed.
+            self.platform = CalibrationPlatform.from_datafolder(
+                folder_path=output / "platform",
+                platform_name=self.meta.platform,
+                dummy_hardware=True,
+            )
 
         for task_id, completed in self.history.items():
             # TODO: should we drop this check as well, and just allow overwriting?

--- a/src/qibocal/auto/output.py
+++ b/src/qibocal/auto/output.py
@@ -255,8 +255,8 @@ class Output:
             self.platform = CalibrationPlatform.from_platform(backend.platform)
         else:
             # while performing a fitting task we do not need hardware information
-            # but also we need the params saved in the datafolder, since in the
-            # platform folder might been changed.
+            # Use parameters saved in the data folder because those in the live
+            # platform folder might have changed.
             self.platform = CalibrationPlatform.from_datafolder(
                 folder_path=output / "platform",
                 platform_name=self.meta.platform,

--- a/src/qibocal/auto/runcard.py
+++ b/src/qibocal/auto/runcard.py
@@ -76,7 +76,6 @@ class Runcard:
                 protocol=getattr(protocols, action.operation),
                 parameters=action,
                 mode=mode,
-                output=output,
             )
         instance.history.dump(output)
         return instance.history

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -131,10 +131,10 @@ class Task:
 
     def run(
         self,
+        mode: ExecutionMode,
+        folder: Path,
         platform: Platform | None = None,
         targets: Targets | None = None,
-        mode: ExecutionMode | None = None,
-        folder: Path | None = None,
     ) -> "Completed":
         if self.targets is None:
             self.action.targets = targets
@@ -158,7 +158,6 @@ class Task:
         except (RuntimeError, AttributeError):
             operation = dummy_operation
             parameters = DummyPars()
-
         completed.dump_parameters()
 
         if ExecutionMode.ACQUIRE in mode:
@@ -174,6 +173,8 @@ class Task:
                 )
             completed.dump_data()
         if ExecutionMode.FIT in mode:
+            if completed.data is None:
+                raise ValueError("Experiment folder does not contain data to fit.")
             completed.results, completed.results_time = operation.fit(completed.data)
             completed.dump_results()
         return completed
@@ -191,7 +192,7 @@ class Completed:
         once tasks will be immutable, a separate `iteration` attribute should
         be added
     """
-    path: Path | None = None
+    path: Path
     """Folder contaning data and results files for task."""
     _data: Data | None = None
     """Protocol data."""
@@ -231,18 +232,15 @@ class Completed:
 
     def dump_parameters(self):
         """Dump parameters."""
-        if self.path is not None:
-            self.task.dump(self.path)
+        self.task.dump(self.path)
 
     def dump_data(self):
         """Dumping data."""
-        if self.path is not None:
-            self._data.save(self.path)
+        self._data.save(self.path)
 
     def dump_results(self):
         """Dumping results."""
-        if self.path is not None:
-            self._results.save(self.path)
+        self._results.save(self.path)
 
     @classmethod
     def load(cls, path: Path):

--- a/src/qibocal/auto/task.py
+++ b/src/qibocal/auto/task.py
@@ -236,11 +236,13 @@ class Completed:
 
     def dump_data(self):
         """Dumping data."""
-        self._data.save(self.path)
+        if self._data is not None:
+            self._data.save(self.path)
 
     def dump_results(self):
         """Dumping results."""
-        self._results.save(self.path)
+        if self._results is not None:
+            self._results.save(self.path)
 
     @classmethod
     def load(cls, path: Path):

--- a/src/qibocal/calibration/platform.py
+++ b/src/qibocal/calibration/platform.py
@@ -1,7 +1,9 @@
 from dataclasses import dataclass
 from pathlib import Path
 
-from qibolab import Platform, create_platform, locate_platform
+from qibolab import Parameters, Platform, create_platform, locate_platform
+from qibolab._core.dummy.platform import create_dummy
+from qibolab._core.platform.platform import PARAMETERS
 
 from .calibration import CALIBRATION, Calibration
 
@@ -64,11 +66,47 @@ class CalibrationPlatform(Platform):
         # TODO: this is loading twice a platform
         return cls(**vars(platform), calibration=calibration)
 
+    @classmethod
+    def from_datafolder(
+        cls, folder_path: Path, platform_name: str, dummy_hardware: bool
+    ):
+        """Create a calibration platform from a serialized data folder.
+
+        The platform is rebuilt from the configuration saved in the experiment history,
+        using the ``parameters.json`` and ``calibration.json`` files stored in the data folder
+        rather than the platform definition. If a ``platform_name`` is provided, the hardware
+        configuration is loaded from that platform; otherwise, a dummy hardware
+        configuration is used so that acquisition-related fields are still present
+        without requiring a live instrument setup.
+        """
+
+        parameters = Parameters.model_validate_json(
+            (folder_path / PARAMETERS).read_text()
+        )
+
+        calibration = Calibration.model_validate_json(
+            (folder_path / CALIBRATION).read_text()
+        )
+
+        platform = (
+            create_dummy() if dummy_hardware is None else create_platform(platform_name)
+        )
+        platform.parameters = parameters
+        platform.name = platform_name
+
+        return cls(
+            calibration=calibration,
+            **vars(platform),
+        )
+
     def dump(self, path: Path):
         super().dump(path)
         self.calibration.dump(path)
 
 
 def create_calibration_platform(name: str) -> CalibrationPlatform:
+    """This function builds a ``CalibrationPlatform`` object which is sentitive of the hardware,
+    so it needs information about the clusters and its connection. Has to be used for acquisition.
+    """
     platform = create_platform(name)
     return CalibrationPlatform.from_platform(platform)

--- a/src/qibocal/calibration/platform.py
+++ b/src/qibocal/calibration/platform.py
@@ -2,12 +2,15 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from qibolab import Parameters, Platform, create_platform, locate_platform
-from qibolab._core.dummy.platform import create_dummy
-from qibolab._core.platform.platform import PARAMETERS
+from qibolab.platform import create_dummy
 
 from .calibration import CALIBRATION, Calibration
 
 __all__ = ["CalibrationPlatform", "create_calibration_platform"]
+
+
+PARAMETERS = "parameters.json"
+"""File containing information about platform parameters."""
 
 
 class CalibrationError(Exception):
@@ -19,7 +22,7 @@ class CalibrationError(Exception):
 class CalibrationPlatform(Platform):
     """Qibolab platform with calibration information."""
 
-    calibration: Calibration = None
+    calibration: Calibration | None = None
     """Calibration information."""
 
     def __post_init__(self):
@@ -74,10 +77,9 @@ class CalibrationPlatform(Platform):
 
         The platform is rebuilt from the configuration saved in the experiment history,
         using the ``parameters.json`` and ``calibration.json`` files stored in the data folder
-        rather than the platform definition. If a ``platform_name`` is provided, the hardware
-        configuration is loaded from that platform; otherwise, a dummy hardware
-        configuration is used so that acquisition-related fields are still present
-        without requiring a live instrument setup.
+        rather than the platform in ``QIBOLAB_PLATFORMS``.
+        A real platform or a dummy platform is created according to
+        ``dummy_hardware``, then populated with the data in ``folder_path``.
         """
 
         parameters = Parameters.model_validate_json(
@@ -88,9 +90,7 @@ class CalibrationPlatform(Platform):
             (folder_path / CALIBRATION).read_text()
         )
 
-        platform = (
-            create_dummy() if dummy_hardware is None else create_platform(platform_name)
-        )
+        platform = create_dummy() if dummy_hardware else create_platform(platform_name)
         platform.parameters = parameters
         platform.name = platform_name
 

--- a/src/qibocal/calibration/platform.py
+++ b/src/qibocal/calibration/platform.py
@@ -105,8 +105,9 @@ class CalibrationPlatform(Platform):
 
 
 def create_calibration_platform(name: str) -> CalibrationPlatform:
-    """This function builds a ``CalibrationPlatform`` object which is sentitive of the hardware,
-    so it needs information about the clusters and its connection. Has to be used for acquisition.
+    """Build a hardware-sensitive ``CalibrationPlatform`` for acquisition.
+
+    This requires cluster and connection information.
     """
     platform = create_platform(name)
     return CalibrationPlatform.from_platform(platform)

--- a/src/qibocal/calibration/platform.py
+++ b/src/qibocal/calibration/platform.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from qibolab import Parameters, Platform, create_platform, locate_platform
-from qibolab.platform import create_dummy
+from qibolab.platform import create_dummy_platform
 
 from .calibration import CALIBRATION, Calibration
 
@@ -90,7 +90,11 @@ class CalibrationPlatform(Platform):
             (folder_path / CALIBRATION).read_text()
         )
 
-        platform = create_dummy() if dummy_hardware else create_platform(platform_name)
+        platform = (
+            create_dummy_platform(calibration.qubits)
+            if dummy_hardware
+            else create_platform(platform_name)
+        )
         platform.parameters = parameters
         platform.name = platform_name
 

--- a/src/qibocal/cli/update.py
+++ b/src/qibocal/cli/update.py
@@ -25,7 +25,9 @@ def update(path: pathlib.Path, skip_qubits: list[QubitId] | None):
     platform_name = json.loads((path / META).read_text())["platform"]
 
     platform_path = locate_platform(platform_name)
+    # we define here the old platform, before editing the files
     old_platform = create_calibration_platform(platform_name)
+    # copying the results files in the platform folder
     for filename in os.listdir(new_platform_path):
         shutil.copy(
             new_platform_path / filename,
@@ -33,7 +35,11 @@ def update(path: pathlib.Path, skip_qubits: list[QubitId] | None):
         )
 
     if skip_qubits is not None:
-        new_platform = create_calibration_platform(platform_name)
+        new_platform = CalibrationPlatform.from_datafolder(
+            folder_path=new_platform_path,
+            platform_name=platform_name,
+            dummy_hardware=False,
+        )
         updated_platform = merge_with_skipped_qubits(
             old_platform, new_platform, skip_qubits
         )

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -41,7 +41,7 @@ def mock_output(tmp_path: Path, platform: CalibrationPlatform) -> tuple[Output, 
         path=tmp_path,
         meta=meta,
     )
-    executor.run_protocol(flipping, ACTION, mode=ExecutionMode.ACQUIRE, output=tmp_path)
+    executor.run_protocol(flipping, ACTION, mode=ExecutionMode.ACQUIRE)
     meta.end()
     platform.disconnect()
     output.history = executor.history

--- a/uv.lock
+++ b/uv.lock
@@ -1800,7 +1800,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.8.0,<3.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0,<7.0.0" },
     { name = "qibo", specifier = ">=0.3.1,<0.4.0" },
-    { name = "qibolab", specifier = ">=0.2.16,<0.3.0" },
+    { name = "qibolab", git = "https://github.com/qiboteam/qibolab?branch=main" },
     { name = "scikit-learn", specifier = ">=1.3.0,<2.0.0" },
     { name = "scipy", specifier = ">=1.10.1,<2.0.0" },
     { name = "skops", specifier = ">=0.14.0,<0.15.0" },
@@ -1828,18 +1828,16 @@ tests = [
 
 [[package]]
 name = "qibolab"
-version = "0.2.16"
-source = { registry = "https://pypi.org/simple" }
+version = "0.2.17"
+source = { git = "https://github.com/qiboteam/qibolab?branch=main#265273e3e84f0ca66f4053d193187c68d8f8c3bc" }
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/27/f0/db4099cfedc574a1d62e22ccdba35b315c65b5c1d1ba6b45aa4b353d94b6/qibolab-0.2.16.tar.gz", hash = "sha256:c72c13cad2ce0582819ff73fc395e685dc64dfb5bec5f475c6cd244dc2265843", size = 137518, upload-time = "2026-07-16T06:42:19.069Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/f8/6372af39f3f52e445237792cecf8ae1acb9113903eb7be1dda5a7e3b5421/qibolab-0.2.16-py3-none-any.whl", hash = "sha256:816b161e9d6cb6fc157cdbf3d6c7b745faeda8a98689cee3283118d67837597c", size = 187297, upload-time = "2026-07-16T06:42:17.771Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
We noticed that when executing only FIT operation (e.g. though `qq fit` command) Qibocal was building the platform using the state of `platform_folder` (e.g. the ones in `qibolab_platforms_qrc`) and not the state saved in the `experiment_data_folder`.
We fix this issue in the PR, also avoiding to construct the `Hardware` sensitive fields of the `Platform` for operations that do not include data acquisition.

Also, `Completed` object now always requires a `path:Path` input an is no more optional, as I think it should be.

> [!NOTE]
> Discuss about eventual tests to add.


linked to [Qibolab #1535](https://github.com/qiboteam/qibolab/pull/1535).