### PR TITLE
allowing protocols to take also qubit pair for crosstalk-Rabi

### DIFF
--- a/src/qibocal/protocols/rabi/acquisition.py
+++ b/src/qibocal/protocols/rabi/acquisition.py
@@ -1,32 +1,25 @@
 from qibolab import Delay, IqChannel, PulseLike, PulseSequence
 from qibolab._core.identifier import ChannelId
 
-from qibocal.auto.operation import QubitId
+from qibocal.auto.operation import QubitId, QubitPairId
 from qibocal.calibration import CalibrationPlatform
-from qibocal.protocols.two_qubit_interaction.cross_resonance.cr_parent_classes import (
-    check_qubit_overlap,
-)
 from qibocal.update import replace
 
 
-def check_correct_drive_lines_setup(
-    targets: list[QubitId], input_drivelines: list[QubitId] | None
-) -> list[QubitId]:
-    """Validate the drive lines assigned to target qubits."""
+def define_qubits_and_drivelines(
+    targets: list[QubitId] | list[QubitPairId],
+) -> tuple[list[QubitId], list[QubitId]]:
+    """Separate target qubits from the drive lines used to address them.
 
-    if input_drivelines is None:
-        return targets
+    A single qubit target is interpreted as being driven by its own line,
+    while a ``(qubit, drive_line)`` pair specifies a potentially different
+    drive line.
+    """
 
-    if len(input_drivelines) != len(targets):
-        raise ValueError(
-            "Each qubit has to be assigned to a drive line; "
-            "If inserted, drive lines must have the same length of targets list."
-        )
+    pairs = [(t if isinstance(t, tuple) else (t, t)) for t in targets]
+    qubit_list, drive_lines = map(list, zip(*pairs))
 
-    # check if the pair overlap: not admitted if we want to execute in parallel
-    check_qubit_overlap([(q, d) for q, d in zip(targets, input_drivelines)])
-
-    return input_drivelines
+    return qubit_list, drive_lines
 
 
 def single_qubit_rabi_sequence(

--- a/src/qibocal/protocols/rabi/amplitude.py
+++ b/src/qibocal/protocols/rabi/amplitude.py
@@ -10,12 +10,12 @@ from qibolab import (
     Sweeper,
 )
 
-from qibocal.auto.operation import Protocol, QubitId
+from qibocal.auto.operation import Protocol, QubitId, QubitPairId
 from qibocal.calibration import CalibrationPlatform
 from qibocal.config import log
 
 from ..utils import chi2_reduced
-from .acquisition import check_correct_drive_lines_setup, sequence_amplitude
+from .acquisition import define_qubits_and_drivelines, sequence_amplitude
 from .parent_classes import (
     RabiAmplitudeParameters,
     RabiData,
@@ -49,7 +49,7 @@ class RabiAmplitudeClassificationData(RabiData):
 def _acquisition(
     params: RabiAmplitudeParameters,
     platform: CalibrationPlatform,
-    targets: list[QubitId],
+    targets: list[QubitId] | list[QubitPairId],
 ) -> RabiAmplitudeClassificationData:
     r"""
     Data acquisition for Rabi experiment sweeping amplitude.
@@ -57,13 +57,11 @@ def _acquisition(
     to find the drive pulse amplitude that creates a rotation of a desired angle.
     """
 
-    drive_lines = check_correct_drive_lines_setup(
-        targets=targets, input_drivelines=params.drive_lines
-    )
+    qubits_list, drive_lines = define_qubits_and_drivelines(targets)
 
     # create a sequence of pulses for the experiment
     sequence, qd_pulses, durations, updates = sequence_amplitude(
-        targets=targets,
+        targets=qubits_list,
         drive_lines=drive_lines,
         platform=platform,
         pulse_duration=params.pulse_length,
@@ -78,7 +76,6 @@ def _acquisition(
     )
 
     data = RabiAmplitudeClassificationData(
-        drive_lines={t: d for t, d in zip(targets, drive_lines)},
         rx90=params.rx90,
         durations=durations,
     )
@@ -93,7 +90,7 @@ def _acquisition(
         acquisition_type=AcquisitionType.DISCRIMINATION,
         averaging_mode=AveragingMode.CYCLIC,
     )
-    for qubit in targets:
+    for qubit in qubits_list:
         ro_pulse = list(sequence.channel(platform.qubits[qubit].acquisition))[-1]
         prob = results[ro_pulse.id]
         data.register_qubit(
@@ -147,7 +144,6 @@ def _fit(data: RabiAmplitudeClassificationData) -> RabiResults:
         except Exception as e:
             log.warning(f"Rabi fit failed for qubit {qubit} due to {e}.")
     return RabiResults(
-        drive_lines=data.drive_lines,
         length=durations,
         amplitude=pi_pulse_amplitudes,
         fitted_parameters=fitted_parameters,
@@ -156,17 +152,8 @@ def _fit(data: RabiAmplitudeClassificationData) -> RabiResults:
     )
 
 
-def _plot(
-    data: RabiAmplitudeClassificationData,
-    target: QubitId,
-    fit: RabiResults | None = None,
-):
-    """Plotting function for RabiAmplitude."""
-    return plot_probabilities(data, target, fit, data.rx90)
-
-
 def _update(
-    results: RabiResults, platform: CalibrationPlatform, target: QubitId
+    results: RabiResults, platform: CalibrationPlatform, target: QubitId | QubitPairId
 ) -> None:
     return update_rabi_ampl_params(
         results=results,
@@ -176,5 +163,5 @@ def _update(
     )
 
 
-rabi_amplitude = Protocol(_acquisition, _fit, _plot, _update)
+rabi_amplitude = Protocol(_acquisition, _fit, plot_probabilities, _update)
 """RabiAmplitude Protocol object."""

--- a/src/qibocal/protocols/rabi/amplitude_frequency.py
+++ b/src/qibocal/protocols/rabi/amplitude_frequency.py
@@ -8,12 +8,12 @@ import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 from qibolab import AcquisitionType, AveragingMode, ParallelSweepers, Parameter, Sweeper
 
-from qibocal.auto.operation import Protocol, QubitId
+from qibocal.auto.operation import Protocol, QubitId, QubitPairId
 from qibocal.calibration import CalibrationPlatform
 from qibocal.config import log
 from qibocal.protocols.utils import HZ_TO_GHZ, chi2_reduced, table_dict, table_html
 
-from .acquisition import check_correct_drive_lines_setup, sequence_amplitude
+from .acquisition import define_qubits_and_drivelines, sequence_amplitude
 from .parent_classes import (
     RabiAmplitudeFrequencyParameters,
     RabiData,
@@ -70,17 +70,15 @@ class RabiAmplitudeFreqClassificationData(RabiData):
 def _acquisition(
     params: RabiAmplitudeFrequencyParameters,
     platform: CalibrationPlatform,
-    targets: list[QubitId],
+    targets: list[QubitId] | list[QubitPairId],
 ) -> RabiAmplitudeFreqClassificationData:
     """Data acquisition for Rabi experiment sweeping amplitude."""
 
-    drive_lines = check_correct_drive_lines_setup(
-        targets=targets, input_drivelines=params.drive_lines
-    )
+    qubits_list, drive_lines = define_qubits_and_drivelines(targets)
 
     # create a sequence of pulses for the experiment
     sequence, qd_pulses, durations, updates = sequence_amplitude(
-        targets=targets,
+        targets=qubits_list,
         drive_lines=drive_lines,
         platform=platform,
         pulse_duration=params.pulse_length,
@@ -96,7 +94,7 @@ def _acquisition(
 
     frequency_values = np.arange(*params.frequency_range)
     freq_sweepers = {}
-    for qubit, drive in zip(targets, drive_lines):
+    for qubit, drive in zip(qubits_list, drive_lines):
         channel = platform.qubits[drive].drive
         freq_sweepers[qubit] = Sweeper(
             parameter=Parameter.frequency,
@@ -105,7 +103,6 @@ def _acquisition(
         )
 
     data = RabiAmplitudeFreqClassificationData(
-        drive_lines={t: d for t, d in zip(targets, drive_lines)},
         durations=durations,
         rx90=params.rx90,
     )
@@ -114,7 +111,7 @@ def _acquisition(
         [sequence],
         [
             ParallelSweepers([amp_sweeper]),
-            ParallelSweepers([freq_sweepers[q] for q in targets]),
+            ParallelSweepers([freq_sweepers[q] for q in qubits_list]),
         ],
         updates=[updates],
         nshots=params.nshots,
@@ -123,7 +120,7 @@ def _acquisition(
         averaging_mode=AveragingMode.CYCLIC,
     )
 
-    for qubit in targets:
+    for qubit in qubits_list:
         ro_pulse = list(sequence.channel(platform.qubits[qubit].acquisition))[-1]
         prob = results[ro_pulse.id]
         data.register_qubit(
@@ -191,7 +188,6 @@ def _fit(data: RabiAmplitudeFreqClassificationData) -> RabiFreqResults:
             log.warning(f"Rabi fit failed for qubit {qubit} due to {e}.")
 
     return RabiFreqResults(
-        drive_lines=data.drive_lines,
         amplitude=fitted_amplitudes,
         length={k: [v] for k, v in data.durations.items()},
         fitted_parameters=fitted_parameters,
@@ -203,10 +199,13 @@ def _fit(data: RabiAmplitudeFreqClassificationData) -> RabiFreqResults:
 
 def _plot(
     data: RabiAmplitudeFreqClassificationData,
-    target: QubitId,
-    fit: RabiFreqResults = None,
+    target: QubitId | QubitPairId,
+    fit: RabiFreqResults | None = None,
 ):
     """Plotting function for RabiAmplitudeFrequency."""
+
+    qubit, drive_line = target if isinstance(target, tuple) else (target, target)
+
     figures = []
     fitting_report = ""
     fig = make_subplots(
@@ -216,7 +215,7 @@ def _plot(
         vertical_spacing=0.2,
         subplot_titles=("Probability",),
     )
-    qubit_data = data[target]
+    qubit_data = data[qubit]
     frequencies = qubit_data.freq * HZ_TO_GHZ
     amplitudes = qubit_data.amp
 
@@ -239,7 +238,7 @@ def _plot(
         fig.add_trace(
             go.Scatter(
                 x=[min(amplitudes), max(amplitudes)],
-                y=[fit.frequency[target] * HZ_TO_GHZ] * 2,
+                y=[fit.frequency[qubit] * HZ_TO_GHZ] * 2,
                 mode="lines",
                 line={"color": "white", "width": 4, "dash": "dash"},
             ),
@@ -250,11 +249,11 @@ def _plot(
 
         fitting_report = table_html(
             table_dict(
-                target,
+                qubit,
                 ["Optimal rabi frequency", f"{pulse_name} amplitude"],
                 [
-                    fit.frequency[target],
-                    f"{fit.amplitude[target][0]:.6f} +- {fit.amplitude[target][1]:.6f} [a.u.]",
+                    fit.frequency[qubit],
+                    f"{fit.amplitude[qubit][0]:.6f} +- {fit.amplitude[qubit][1]:.6f} [a.u.]",
                 ],
             )
         )
@@ -262,12 +261,15 @@ def _plot(
     fig.update_layout(
         showlegend=False,
         legend={"orientation": "h"},
+        title=(f"Rabi experiment for qubit {qubit} with " + f"drive line {drive_line}"),
     )
     return figures, fitting_report
 
 
 def _update(
-    results: RabiFreqResults, platform: CalibrationPlatform, target: QubitId
+    results: RabiFreqResults,
+    platform: CalibrationPlatform,
+    target: QubitId | QubitPairId,
 ) -> None:
     return update_rabi_ampl_params(
         results=results,

--- a/src/qibocal/protocols/rabi/amplitude_frequency_signal.py
+++ b/src/qibocal/protocols/rabi/amplitude_frequency_signal.py
@@ -8,13 +8,13 @@ import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 from qibolab import AcquisitionType, AveragingMode, ParallelSweepers, Parameter, Sweeper
 
-from qibocal.auto.operation import Protocol, QubitId
+from qibocal.auto.operation import Protocol, QubitId, QubitPairId
 from qibocal.calibration import CalibrationPlatform
 from qibocal.config import log
 from qibocal.protocols.utils import HZ_TO_GHZ, readout_frequency, table_dict, table_html
 from qibocal.result import collect, magnitude, phase
 
-from .acquisition import check_correct_drive_lines_setup, sequence_amplitude
+from .acquisition import define_qubits_and_drivelines, sequence_amplitude
 from .amplitude_frequency import RabiAmplitudeFreqClassificationData
 from .parent_classes import (
     RabiAmplitudeFrequencyParameters,
@@ -72,17 +72,15 @@ class RabiAmplitudeFreqSignalData(RabiAmplitudeFreqClassificationData):
 def _acquisition(
     params: RabiAmplitudeFrequencyParameters,
     platform: CalibrationPlatform,
-    targets: list[QubitId],
+    targets: list[QubitId] | list[QubitPairId],
 ) -> RabiAmplitudeFreqSignalData:
     """Data acquisition for Rabi experiment sweeping amplitude."""
 
-    drive_lines = check_correct_drive_lines_setup(
-        targets=targets, input_drivelines=params.drive_lines
-    )
+    qubits_list, drive_lines = define_qubits_and_drivelines(targets)
 
     # create a sequence of pulses for the experiment
     sequence, qd_pulses, durations, updates = sequence_amplitude(
-        targets=targets,
+        targets=qubits_list,
         drive_lines=drive_lines,
         platform=platform,
         pulse_duration=params.pulse_length,
@@ -98,7 +96,7 @@ def _acquisition(
 
     frequency_values = np.arange(*params.frequency_range)
     freq_sweepers = {}
-    for qubit, drive in zip(targets, drive_lines):
+    for qubit, drive in zip(qubits_list, drive_lines):
         channel = platform.qubits[drive].drive
         freq_sweepers[qubit] = Sweeper(
             parameter=Parameter.frequency,
@@ -107,20 +105,19 @@ def _acquisition(
         )
 
     data = RabiAmplitudeFreqSignalData(
-        drive_lines={t: d for t, d in zip(targets, drive_lines)},
         durations=durations,
         rx90=params.rx90,
     )
 
     updates |= {
         platform.qubits[q].probe: {"frequency": readout_frequency(q, platform)}
-        for q in targets
+        for q in qubits_list
     }
     results = platform.execute(
         [sequence],
         [
             ParallelSweepers([amp_sweeper]),
-            ParallelSweepers([freq_sweepers[q] for q in targets]),
+            ParallelSweepers([freq_sweepers[q] for q in qubits_list]),
         ],
         updates=[updates],
         nshots=params.nshots,
@@ -129,7 +126,7 @@ def _acquisition(
         averaging_mode=AveragingMode.CYCLIC,
     )
 
-    for qubit in targets:
+    for qubit in qubits_list:
         ro_pulse = list(sequence.channel(platform.qubits[qubit].acquisition))[-1]
         result = results[ro_pulse.id]
         data.register_qubit(
@@ -187,7 +184,6 @@ def _fit(data: RabiAmplitudeFreqSignalData) -> RabiFreqResults:
             log.warning(f"Rabi fit failed for qubit {qubit} due to {e}.")
 
     return RabiFreqResults(
-        drive_lines=data.drive_lines,
         amplitude=fitted_amplitudes,
         length={k: [v] for k, v in data.durations.items()},
         fitted_parameters=fitted_parameters,
@@ -198,10 +194,12 @@ def _fit(data: RabiAmplitudeFreqSignalData) -> RabiFreqResults:
 
 def _plot(
     data: RabiAmplitudeFreqSignalData,
-    target: QubitId,
-    fit: RabiFreqResults = None,
+    target: QubitId | QubitPairId,
+    fit: RabiFreqResults | None = None,
 ):
     """Plotting function for RabiAmplitudeFrequency."""
+    qubit, drive_line = target if isinstance(target, tuple) else (target, target)
+
     figures = []
     fitting_report = ""
     fig = make_subplots(
@@ -214,7 +212,7 @@ def _plot(
             "Phase [rad]",
         ),
     )
-    qubit_data = data[target]
+    qubit_data = data[qubit]
     frequencies = qubit_data.freq * HZ_TO_GHZ
     amplitudes = qubit_data.amp
 
@@ -222,7 +220,7 @@ def _plot(
         go.Heatmap(
             x=amplitudes,
             y=frequencies,
-            z=data.sig_mag(target),
+            z=data.sig_mag(qubit),
             colorbar_x=0.46,
         ),
         row=1,
@@ -233,7 +231,7 @@ def _plot(
         go.Heatmap(
             x=amplitudes,
             y=frequencies,
-            z=data.sig_phase(target),
+            z=data.sig_phase(qubit),
             colorbar_x=1.01,
         ),
         row=1,
@@ -250,7 +248,7 @@ def _plot(
         fig.add_trace(
             go.Scatter(
                 x=[min(amplitudes), max(amplitudes)],
-                y=[fit.frequency[target] * HZ_TO_GHZ] * 2,
+                y=[fit.frequency[qubit] * HZ_TO_GHZ] * 2,
                 mode="lines",
                 line={"color": "white", "width": 4, "dash": "dash"},
             ),
@@ -260,7 +258,7 @@ def _plot(
         fig.add_trace(
             go.Scatter(
                 x=[min(amplitudes), max(amplitudes)],
-                y=[fit.frequency[target] * HZ_TO_GHZ] * 2,
+                y=[fit.frequency[qubit] * HZ_TO_GHZ] * 2,
                 mode="lines",
                 line={"color": "white", "width": 4, "dash": "dash"},
             ),
@@ -271,11 +269,11 @@ def _plot(
 
         fitting_report = table_html(
             table_dict(
-                target,
+                qubit,
                 ["Optimal rabi frequency", f"{pulse_name} amplitude"],
                 [
-                    fit.frequency[target],
-                    f"{fit.amplitude[target]:.6f} [a.u]",
+                    fit.frequency[qubit],
+                    f"{fit.amplitude[qubit]:.6f} [a.u]",
                 ],
             )
         )
@@ -283,12 +281,15 @@ def _plot(
     fig.update_layout(
         showlegend=False,
         legend={"orientation": "h"},
+        title=(f"Rabi experiment for qubit {qubit} with " + f"drive line {drive_line}"),
     )
     return figures, fitting_report
 
 
 def _update(
-    results: RabiFreqResults, platform: CalibrationPlatform, target: QubitId
+    results: RabiFreqResults,
+    platform: CalibrationPlatform,
+    target: QubitId | QubitPairId,
 ) -> None:
     return update_rabi_ampl_params(
         results=results,

--- a/src/qibocal/protocols/rabi/amplitude_signal.py
+++ b/src/qibocal/protocols/rabi/amplitude_signal.py
@@ -4,13 +4,13 @@ import numpy as np
 import numpy.typing as npt
 from qibolab import AcquisitionType, AveragingMode, ParallelSweepers, Parameter, Sweeper
 
-from qibocal.auto.operation import Protocol, QubitId
+from qibocal.auto.operation import Protocol, QubitId, QubitPairId
 from qibocal.calibration import CalibrationPlatform
 from qibocal.config import log
 from qibocal.protocols.utils import readout_frequency
 from qibocal.result import collect, magnitude
 
-from .acquisition import check_correct_drive_lines_setup, sequence_amplitude
+from .acquisition import define_qubits_and_drivelines, sequence_amplitude
 from .parent_classes import (
     RabiAmplitudeParameters,
     RabiData,
@@ -43,7 +43,7 @@ class RabiAmplitudeSignalData(RabiData):
 def _acquisition(
     params: RabiAmplitudeParameters,
     platform: CalibrationPlatform,
-    targets: list[QubitId],
+    targets: list[QubitId] | list[QubitPairId],
 ) -> RabiAmplitudeSignalData:
     r"""
     Data acquisition for Rabi experiment sweeping amplitude.
@@ -51,13 +51,11 @@ def _acquisition(
     to find the drive pulse amplitude that creates a rotation of a desired angle.
     """
 
-    drive_lines = check_correct_drive_lines_setup(
-        targets=targets, input_drivelines=params.drive_lines
-    )
+    qubits_list, drive_lines = define_qubits_and_drivelines(targets)
 
     # create a sequence of pulses for the experiment
     sequence, qd_pulses, durations, updates = sequence_amplitude(
-        targets=targets,
+        targets=qubits_list,
         drive_lines=drive_lines,
         platform=platform,
         pulse_duration=params.pulse_length,
@@ -72,7 +70,6 @@ def _acquisition(
     )
 
     data = RabiAmplitudeSignalData(
-        drive_lines={t: d for t, d in zip(targets, drive_lines)},
         rx90=params.rx90,
         durations=durations,
     )
@@ -80,7 +77,7 @@ def _acquisition(
     # for signal measurement we have to change readout
     updates |= {
         platform.qubits[q].probe: {"frequency": readout_frequency(q, platform)}
-        for q in targets
+        for q in qubits_list
     }
 
     # sweep the parameter
@@ -93,7 +90,7 @@ def _acquisition(
         acquisition_type=AcquisitionType.INTEGRATION,
         averaging_mode=AveragingMode.CYCLIC,
     )
-    for qubit in targets:
+    for qubit in qubits_list:
         ro_pulse = list(sequence.channel(platform.qubits[qubit].acquisition))[-1]
         result = results[ro_pulse.id]
         data.register_qubit(
@@ -145,7 +142,6 @@ def _fit(data: RabiAmplitudeSignalData) -> RabiResults:
             log.warning(f"Rabi fit failed for qubit {qubit} due to {e}.")
 
     return RabiResults(
-        drive_lines=data.drive_lines,
         length={k: [v] for k, v in data.durations.items()},
         amplitude=pi_pulse_amplitudes,
         fitted_parameters=fitted_parameters,
@@ -153,25 +149,16 @@ def _fit(data: RabiAmplitudeSignalData) -> RabiResults:
     )
 
 
-def _plot(
-    data: RabiAmplitudeSignalData,
-    target: QubitId,
-    fit: RabiResults | None = None,
-):
-    """Plotting function for RabiAmplitude."""
-    return plot_signal(data, target, fit, data.rx90)
-
-
 def _update(
-    results: RabiResults, platform: CalibrationPlatform, target: QubitId
+    results: RabiResults, platform: CalibrationPlatform, target: QubitId | QubitPairId
 ) -> None:
     return update_rabi_ampl_params(
         results=results,
         platform=platform,
-        target=target,
+        target=target[0] if isinstance(target, tuple) else target,
         label="signal",
     )
 
 
-rabi_amplitude_signal = Protocol(_acquisition, _fit, _plot, _update)
+rabi_amplitude_signal = Protocol(_acquisition, _fit, plot_signal, _update)
 """RabiAmplitude Protocol object."""

--- a/src/qibocal/protocols/rabi/ef.py
+++ b/src/qibocal/protocols/rabi/ef.py
@@ -11,13 +11,13 @@ from qibolab import (
     Sweeper,
 )
 
-from qibocal.auto.operation import Protocol, QubitId
+from qibocal.auto.operation import Protocol, QubitId, QubitPairId
 from qibocal.calibration import CalibrationPlatform
 from qibocal.protocols.utils import readout_frequency
 from qibocal.update import drive_12_amplitude, drive_12_duration, replace
 
-from .acquisition import check_correct_drive_lines_setup
-from .amplitude_signal import _fit
+from .acquisition import define_qubits_and_drivelines
+from .amplitude_signal import _fit as ampltidue_signal_fit
 from .parent_classes import (
     RabiAmplitudeParameters,
     RabiData,
@@ -43,7 +43,7 @@ class RabiEFSignalData(RabiData):
 def _acquisition(
     params: RabiAmplitudeParameters,
     platform: CalibrationPlatform,
-    targets: list[QubitId],
+    targets: list[QubitId] | list[QubitPairId],
 ) -> RabiEFSignalData:
     r"""
     Data acquisition for Rabi EF experiment sweeping amplitude.
@@ -54,9 +54,7 @@ def _acquisition(
 
     """
 
-    drive_lines = check_correct_drive_lines_setup(
-        targets=targets, input_drivelines=params.drive_lines
-    )
+    qubits_list, drive_lines = define_qubits_and_drivelines(targets)
 
     # create a sequence of pulses for the experiment
     sequence = PulseSequence()
@@ -64,7 +62,7 @@ def _acquisition(
     ro_pulses = {}
     durations = {}
     updates = {}
-    for q, d in zip(targets, drive_lines):
+    for q, d in zip(qubits_list, drive_lines):
         natives = platform.natives.single_qubit[q]
         qd_channel, qd_pulse = natives.RX()[0]
         qd12_channel, qd12_pulse = natives.RX12()[0]
@@ -98,13 +96,12 @@ def _acquisition(
     sweeper = Sweeper(
         parameter=Parameter.amplitude,
         range=(params.min_amp, params.max_amp, params.step_amp),
-        pulses=[qd_pulses[qubit] for qubit in targets],
+        pulses=[qd_pulses[qubit] for qubit in qubits_list],
     )
 
     assert not params.rx90, "Rabi ef available only for RX pulses."
 
     data = RabiEFSignalData(
-        drive_lines={t: d for t, d in zip(targets, drive_lines)},
         durations=durations,
         rx90=False,
     )
@@ -112,7 +109,7 @@ def _acquisition(
     # for signal measurement we have to change readout
     updates |= {
         platform.qubits[q].probe: {"frequency": readout_frequency(q, platform, state=1)}
-        for q in targets
+        for q in qubits_list
     }
 
     # sweep the parameter
@@ -125,7 +122,7 @@ def _acquisition(
         acquisition_type=AcquisitionType.INTEGRATION,
         averaging_mode=AveragingMode.CYCLIC,
     )
-    for qubit in targets:
+    for qubit in qubits_list:
         result = results[ro_pulses[qubit].id]
         data.register_qubit(
             RabiEFSignalType,
@@ -139,20 +136,28 @@ def _acquisition(
     return data
 
 
-def _plot(data: RabiEFSignalData, target: QubitId, fit: RabiResults = None):
+def _plot(
+    data: RabiEFSignalData,
+    target: QubitId | QubitPairId,
+    fit: RabiResults | None = None,
+):
     """Plotting function for RabiAmplitude."""
-    figures, report = plot_signal(data, target, fit, data.rx90)
+    figures, report = plot_signal(data=data, target=target, fit=fit, rx90=data.rx90)
     if report is not None:
         report = report.replace("Pi pulse", "Pi pulse 12")
     return figures, report
 
 
-def _update(results: RabiResults, platform: CalibrationPlatform, target: QubitId):
+def _update(
+    results: RabiResults, platform: CalibrationPlatform, target: QubitId | QubitPairId
+):
     """Update RX2 amplitude_signal"""
-    if target == results.drive_lines[target]:
-        drive_12_amplitude(results.amplitude[target][0], platform, target)
-        drive_12_duration(results.length[target][0], platform, target)
+    qubit, drive_line = target if isinstance(target, tuple) else (target, target)
+    # update only when we are driving the qubit with its associated line
+    if qubit == drive_line:
+        drive_12_amplitude(results.amplitude[qubit][0], platform, qubit)
+        drive_12_duration(results.length[qubit], platform, qubit)
 
 
-rabi_amplitude_ef = Protocol(_acquisition, _fit, _plot, _update)
+rabi_amplitude_ef = Protocol(_acquisition, ampltidue_signal_fit, _plot, _update)
 """RabiAmplitudeEF Protocol object."""

--- a/src/qibocal/protocols/rabi/length.py
+++ b/src/qibocal/protocols/rabi/length.py
@@ -10,12 +10,12 @@ from qibolab import (
     Sweeper,
 )
 
-from qibocal.auto.operation import Protocol, QubitId
+from qibocal.auto.operation import Protocol, QubitId, QubitPairId
 from qibocal.calibration import CalibrationPlatform
 from qibocal.config import log
 
 from ..utils import chi2_reduced
-from .acquisition import check_correct_drive_lines_setup, sequence_length
+from .acquisition import define_qubits_and_drivelines, sequence_length
 from .parent_classes import (
     RabiData,
     RabiLengthParameters,
@@ -49,18 +49,16 @@ class RabiLengthClassificationData(RabiData):
 def _acquisition(
     params: RabiLengthParameters,
     platform: CalibrationPlatform,
-    targets: list[QubitId],
+    targets: list[QubitId] | list[QubitPairId],
 ) -> RabiLengthClassificationData:
     r"""
     Data acquisition for RabiLength Classification Experiment.
     """
 
-    drive_lines = check_correct_drive_lines_setup(
-        targets=targets, input_drivelines=params.drive_lines
-    )
+    qubits_list, drive_lines = define_qubits_and_drivelines(targets)
 
     sequence, qd_pulses, delays, amplitudes, updates = sequence_length(
-        targets=targets,
+        targets=qubits_list,
         drive_lines=drive_lines,
         platform=platform,
         pulse_ampl=params.pulse_amplitude,
@@ -82,7 +80,6 @@ def _acquisition(
     )
 
     data = RabiLengthClassificationData(
-        drive_lines={t: d for t, d in zip(targets, drive_lines)},
         rx90=params.rx90,
         amplitudes=amplitudes,
     )
@@ -98,7 +95,7 @@ def _acquisition(
         averaging_mode=AveragingMode.CYCLIC,
     )
 
-    for q in targets:
+    for q in qubits_list:
         ro_pulse = list(sequence.channel(platform.qubits[q].acquisition))[-1]
         prob = results[ro_pulse.id]
         data.register_qubit(
@@ -156,7 +153,6 @@ def _fit(data: RabiLengthClassificationData) -> RabiResults:
             log.warning(f"Rabi fit failed for qubit {qubit} due to {e}.")
 
     return RabiResults(
-        drive_lines=data.drive_lines,
         length=durations,
         amplitude=amplitudes,
         fitted_parameters=fitted_parameters,
@@ -165,16 +161,7 @@ def _fit(data: RabiLengthClassificationData) -> RabiResults:
     )
 
 
-def _plot(
-    data: RabiLengthClassificationData,
-    target: QubitId,
-    fit: RabiResults | None = None,
-):
-    """Plotting function for RabiLength classification experiment."""
-    return plot_probabilities(data, target, fit, data.rx90)
-
-
-rabi_length = Protocol(_acquisition, _fit, _plot, update_rabi_parameters)
+rabi_length = Protocol(_acquisition, _fit, plot_probabilities, update_rabi_parameters)
 """RabiLength Routine object.
 
 In the Rabi experiment we apply a pulse at the frequency of the qubit and scan the drive pulse length

--- a/src/qibocal/protocols/rabi/length_frequency.py
+++ b/src/qibocal/protocols/rabi/length_frequency.py
@@ -8,12 +8,12 @@ import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 from qibolab import AcquisitionType, AveragingMode, ParallelSweepers, Parameter, Sweeper
 
-from qibocal.auto.operation import Protocol, QubitId
+from qibocal.auto.operation import Protocol, QubitId, QubitPairId
 from qibocal.calibration import CalibrationPlatform
 from qibocal.config import log
 from qibocal.protocols.utils import HZ_TO_GHZ, chi2_reduced, table_dict, table_html
 
-from .acquisition import check_correct_drive_lines_setup, sequence_length
+from .acquisition import define_qubits_and_drivelines, sequence_length
 from .parent_classes import (
     RabiData,
     RabiFreqResults,
@@ -70,16 +70,14 @@ class RabiLengthFreqClassificationData(RabiData):
 def _acquisition(
     params: RabiLengthFrequencyParameters,
     platform: CalibrationPlatform,
-    targets: list[QubitId],
+    targets: list[QubitId] | list[QubitPairId],
 ) -> RabiLengthFreqClassificationData:
     """Data acquisition for Rabi experiment sweeping length."""
 
-    drive_lines = check_correct_drive_lines_setup(
-        targets=targets, input_drivelines=params.drive_lines
-    )
+    qubits_list, drive_lines = define_qubits_and_drivelines(targets)
 
     sequence, qd_pulses, delays, amplitudes, updates = sequence_length(
-        targets=targets,
+        targets=qubits_list,
         drive_lines=drive_lines,
         platform=platform,
         pulse_ampl=params.pulse_amplitude,
@@ -102,7 +100,7 @@ def _acquisition(
 
     frequency_values = np.arange(*params.frequency_range)
     freq_sweepers = {}
-    for qubit, drive in zip(targets, drive_lines):
+    for qubit, drive in zip(qubits_list, drive_lines):
         channel = platform.qubits[drive].drive
         freq_sweepers[qubit] = Sweeper(
             parameter=Parameter.frequency,
@@ -111,7 +109,6 @@ def _acquisition(
         )
 
     data = RabiLengthFreqClassificationData(
-        drive_lines={t: d for t, d in zip(targets, drive_lines)},
         rx90=params.rx90,
         amplitudes=amplitudes,
     )
@@ -120,7 +117,7 @@ def _acquisition(
         [sequence],
         [
             ParallelSweepers([len_sweeper]),
-            ParallelSweepers([freq_sweepers[q] for q in targets]),
+            ParallelSweepers([freq_sweepers[q] for q in qubits_list]),
         ],
         updates=[updates],
         nshots=params.nshots,
@@ -129,7 +126,7 @@ def _acquisition(
         averaging_mode=AveragingMode.CYCLIC,
     )
 
-    for qubit in targets:
+    for qubit in qubits_list:
         ro_pulse = list(sequence.channel(platform.qubits[qubit].acquisition))[-1]
         prob = results[ro_pulse.id]
         data.register_qubit(
@@ -200,7 +197,6 @@ def _fit(data: RabiLengthFreqClassificationData) -> RabiFreqResults:
             log.warning(f"Rabi fit failed for qubit {qubit} due to {e}.")
 
     return RabiFreqResults(
-        drive_lines=data.drive_lines,
         length=fitted_durations,
         amplitude={k: [v] for k, v in data.amplitudes.items()},
         fitted_parameters=fitted_parameters,
@@ -212,10 +208,12 @@ def _fit(data: RabiLengthFreqClassificationData) -> RabiFreqResults:
 
 def _plot(
     data: RabiLengthFreqClassificationData,
-    target: QubitId,
-    fit: RabiFreqResults = None,
+    target: QubitId | QubitPairId,
+    fit: RabiFreqResults | None = None,
 ):
     """Plotting function for RabiLengthFrequency."""
+    qubit, drive_line = target if isinstance(target, tuple) else (target, target)
+
     figures = []
     fitting_report = ""
     fig = make_subplots(
@@ -225,7 +223,7 @@ def _plot(
         vertical_spacing=0.2,
         subplot_titles=("Probability",),
     )
-    qubit_data = data[target]
+    qubit_data = data[qubit]
     frequencies = qubit_data.freq * HZ_TO_GHZ
     durations = qubit_data.len
 
@@ -248,7 +246,7 @@ def _plot(
         fig.add_trace(
             go.Scatter(
                 x=[min(durations), max(durations)],
-                y=[fit.frequency[target] * HZ_TO_GHZ] * 2,
+                y=[fit.frequency[qubit] * HZ_TO_GHZ] * 2,
                 mode="lines",
                 line={"color": "white", "width": 4, "dash": "dash"},
             ),
@@ -259,11 +257,11 @@ def _plot(
 
         fitting_report = table_html(
             table_dict(
-                target,
+                qubit,
                 ["Optimal rabi frequency", f"{pulse_name} duration"],
                 [
-                    fit.frequency[target],
-                    f"{fit.length[target][0]:.2f} +- {fit.length[target][1]:.2f} ns",
+                    fit.frequency[qubit],
+                    f"{fit.length[qubit][0]:.2f} +- {fit.length[qubit][1]:.2f} ns",
                 ],
             )
         )
@@ -271,6 +269,7 @@ def _plot(
     fig.update_layout(
         showlegend=False,
         legend={"orientation": "h"},
+        title=(f"Rabi experiment for qubit {qubit} with " + f"drive line {drive_line}"),
     )
     return figures, fitting_report
 

--- a/src/qibocal/protocols/rabi/length_frequency_signal.py
+++ b/src/qibocal/protocols/rabi/length_frequency_signal.py
@@ -8,13 +8,13 @@ import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 from qibolab import AcquisitionType, AveragingMode, ParallelSweepers, Parameter, Sweeper
 
-from qibocal.auto.operation import Protocol, QubitId
+from qibocal.auto.operation import Protocol, QubitId, QubitPairId
 from qibocal.calibration import CalibrationPlatform
 from qibocal.config import log
 from qibocal.protocols.utils import HZ_TO_GHZ, readout_frequency, table_dict, table_html
 from qibocal.result import collect, magnitude, phase
 
-from .acquisition import check_correct_drive_lines_setup, sequence_length
+from .acquisition import define_qubits_and_drivelines, sequence_length
 from .length_frequency import RabiLengthFreqClassificationData
 from .parent_classes import (
     RabiFreqResults,
@@ -72,16 +72,14 @@ class RabiLengthFreqSignalData(RabiLengthFreqClassificationData):
 def _acquisition(
     params: RabiLengthFrequencyParameters,
     platform: CalibrationPlatform,
-    targets: list[QubitId],
+    targets: list[QubitId] | list[QubitPairId],
 ) -> RabiLengthFreqSignalData:
     """Data acquisition for Rabi experiment sweeping length."""
 
-    drive_lines = check_correct_drive_lines_setup(
-        targets=targets, input_drivelines=params.drive_lines
-    )
+    qubits_lines, drive_lines = define_qubits_and_drivelines(targets)
 
     sequence, qd_pulses, delays, amplitudes, updates = sequence_length(
-        targets=targets,
+        targets=qubits_lines,
         drive_lines=drive_lines,
         platform=platform,
         pulse_ampl=params.pulse_amplitude,
@@ -104,7 +102,7 @@ def _acquisition(
 
     frequency_values = np.arange(*params.frequency_range)
     freq_sweepers = {}
-    for qubit, drive in zip(targets, drive_lines):
+    for qubit, drive in zip(qubits_lines, drive_lines):
         channel = platform.qubits[drive].drive
         freq_sweepers[qubit] = Sweeper(
             parameter=Parameter.frequency,
@@ -113,21 +111,20 @@ def _acquisition(
         )
 
     data = RabiLengthFreqSignalData(
-        drive_lines={t: d for t, d in zip(targets, drive_lines)},
         rx90=params.rx90,
         amplitudes=amplitudes,
     )
 
     updates |= {
         platform.qubits[q].probe: {"frequency": readout_frequency(q, platform)}
-        for q in targets
+        for q in qubits_lines
     }
 
     results = platform.execute(
         [sequence],
         [
             ParallelSweepers([len_sweeper]),
-            ParallelSweepers([freq_sweepers[q] for q in targets]),
+            ParallelSweepers([freq_sweepers[q] for q in qubits_lines]),
         ],
         updates=[updates],
         nshots=params.nshots,
@@ -135,7 +132,7 @@ def _acquisition(
         acquisition_type=AcquisitionType.INTEGRATION,
         averaging_mode=AveragingMode.CYCLIC,
     )
-    for qubit in targets:
+    for qubit in qubits_lines:
         ro_pulse = list(sequence.channel(platform.qubits[qubit].acquisition))[-1]
         result = results[ro_pulse.id]
         data.register_qubit(
@@ -192,7 +189,6 @@ def _fit(data: RabiLengthFreqSignalData) -> RabiFreqResults:
             log.warning(f"Rabi fit failed for qubit {qubit} due to {e}.")
 
     return RabiFreqResults(
-        drive_lines=data.drive_lines,
         length=fitted_lengths,
         amplitude={k: [v] for k, v in data.amplitudes.items()},
         fitted_parameters=fitted_parameters,
@@ -203,10 +199,11 @@ def _fit(data: RabiLengthFreqSignalData) -> RabiFreqResults:
 
 def _plot(
     data: RabiLengthFreqSignalData,
-    target: QubitId,
-    fit: RabiFreqResults = None,
+    target: QubitId | QubitPairId,
+    fit: RabiFreqResults | None = None,
 ):
     """Plotting function for RabiLengthFrequency."""
+    qubit, drive_line = target if isinstance(target, tuple) else (target, target)
     figures = []
     fitting_report = ""
     fig = make_subplots(
@@ -219,7 +216,7 @@ def _plot(
             "Phase [rad]",
         ),
     )
-    qubit_data = data[target]
+    qubit_data = data[qubit]
     frequencies = qubit_data.freq * HZ_TO_GHZ
     lengths = qubit_data.len
 
@@ -227,7 +224,7 @@ def _plot(
         go.Heatmap(
             x=lengths,
             y=frequencies,
-            z=data.sig_mag(target),
+            z=data.sig_mag(qubit),
             colorbar_x=0.46,
         ),
         row=1,
@@ -238,7 +235,7 @@ def _plot(
         go.Heatmap(
             x=lengths,
             y=frequencies,
-            z=data.sig_phase(target),
+            z=data.sig_phase(qubit),
             colorbar_x=1.01,
         ),
         row=1,
@@ -255,7 +252,7 @@ def _plot(
         fig.add_trace(
             go.Scatter(
                 x=[min(lengths), max(lengths)],
-                y=[fit.frequency[target] * HZ_TO_GHZ] * 2,
+                y=[fit.frequency[qubit] * HZ_TO_GHZ] * 2,
                 mode="lines",
                 line={"color": "white", "width": 4, "dash": "dash"},
             ),
@@ -265,7 +262,7 @@ def _plot(
         fig.add_trace(
             go.Scatter(
                 x=[min(lengths), max(lengths)],
-                y=[fit.frequency[target] * HZ_TO_GHZ] * 2,
+                y=[fit.frequency[qubit] * HZ_TO_GHZ] * 2,
                 mode="lines",
                 line={"color": "white", "width": 4, "dash": "dash"},
             ),
@@ -276,11 +273,11 @@ def _plot(
 
         fitting_report = table_html(
             table_dict(
-                target,
+                qubit,
                 ["Optimal rabi frequency", f"{pulse_name} duration"],
                 [
-                    fit.frequency[target],
-                    f"{fit.length[target]:.2f} ns",
+                    fit.frequency[qubit],
+                    f"{fit.length[qubit]:.2f} ns",
                 ],
             )
         )
@@ -288,6 +285,7 @@ def _plot(
     fig.update_layout(
         showlegend=False,
         legend={"orientation": "h"},
+        title=(f"Rabi experiment for qubit {qubit} with " + f"drive line {drive_line}"),
     )
 
     return figures, fitting_report

--- a/src/qibocal/protocols/rabi/length_signal.py
+++ b/src/qibocal/protocols/rabi/length_signal.py
@@ -4,13 +4,13 @@ import numpy as np
 import numpy.typing as npt
 from qibolab import AcquisitionType, AveragingMode, ParallelSweepers, Parameter, Sweeper
 
-from qibocal.auto.operation import Protocol, QubitId
+from qibocal.auto.operation import Protocol, QubitId, QubitPairId
 from qibocal.calibration import CalibrationPlatform
 from qibocal.config import log
 from qibocal.protocols.utils import readout_frequency
 from qibocal.result import collect, magnitude
 
-from .acquisition import check_correct_drive_lines_setup, sequence_length
+from .acquisition import define_qubits_and_drivelines, sequence_length
 from .parent_classes import (
     RabiData,
     RabiLengthParameters,
@@ -43,18 +43,16 @@ class RabiLengthSignalData(RabiData):
 def _acquisition(
     params: RabiLengthParameters,
     platform: CalibrationPlatform,
-    targets: list[QubitId],
+    targets: list[QubitId] | list[QubitPairId],
 ) -> RabiLengthSignalData:
     r"""
     Data acquisition for RabiLength Signal Experiment.
     """
 
-    drive_lines = check_correct_drive_lines_setup(
-        targets=targets, input_drivelines=params.drive_lines
-    )
+    qubits_list, drive_lines = define_qubits_and_drivelines(targets)
 
     sequence, qd_pulses, delays, amplitudes, updates = sequence_length(
-        targets=targets,
+        targets=qubits_list,
         drive_lines=drive_lines,
         platform=platform,
         pulse_ampl=params.pulse_amplitude,
@@ -76,7 +74,6 @@ def _acquisition(
     )
 
     data = RabiLengthSignalData(
-        drive_lines={t: d for t, d in zip(targets, drive_lines)},
         rx90=params.rx90,
         amplitudes=amplitudes,
     )
@@ -84,7 +81,7 @@ def _acquisition(
     # for signal measurement we have to change readout
     updates |= {
         platform.qubits[q].probe: {"frequency": readout_frequency(q, platform)}
-        for q in targets
+        for q in qubits_list
     }
 
     results = platform.execute(
@@ -97,7 +94,7 @@ def _acquisition(
         averaging_mode=AveragingMode.CYCLIC,
     )
 
-    for q in targets:
+    for q in qubits_list:
         ro_pulse = list(sequence.channel(platform.qubits[q].acquisition))[-1]
         result = results[ro_pulse.id]
         data.register_qubit(
@@ -149,7 +146,6 @@ def _fit(data: RabiLengthSignalData) -> RabiResults:
             log.warning(f"Rabi fit failed for qubit {qubit} due to {e}.")
 
     return RabiResults(
-        drive_lines=data.drive_lines,
         length=durations,
         amplitude={k: [v] for k, v in data.amplitudes.items()},
         fitted_parameters=fitted_parameters,
@@ -157,12 +153,7 @@ def _fit(data: RabiLengthSignalData) -> RabiResults:
     )
 
 
-def _plot(data: RabiLengthSignalData, target: QubitId, fit: RabiResults | None = None):
-    """Plotting function for RabiLength signal experiment."""
-    return plot_signal(data, target, fit, data.rx90)
-
-
-rabi_length_signal = Protocol(_acquisition, _fit, _plot, update_rabi_parameters)
+rabi_length_signal = Protocol(_acquisition, _fit, plot_signal, update_rabi_parameters)
 """RabiLength Protocol object.
 
 In the Rabi experiment we apply a pulse at the frequency of the qubit and scan the drive pulse length

--- a/src/qibocal/protocols/rabi/parent_classes.py
+++ b/src/qibocal/protocols/rabi/parent_classes.py
@@ -17,9 +17,6 @@ class RabiLengthParameters(Parameters):
     """Step pulse duration [ns]."""
     pulse_amplitude: float | None = None
     """Pulse amplitude. Same for all qubits."""
-    drive_lines: list[QubitId] | None = None
-    """Drive lines to use for the qubits;
-    must be the same length as the qubits list."""
     rx90: bool = False
     """Calibration of native pi pulse, if true calibrates pi/2 pulse"""
     interpolated_sweeper: bool = False
@@ -57,9 +54,6 @@ class RabiAmplitudeParameters(Parameters):
     """Step pulse amplitude [a.u.]."""
     pulse_length: float | None = None
     """Pulse duration [ns]. Same for all qubits."""
-    drive_lines: list[QubitId] | None = None
-    """Drive lines to use for the qubits;
-    must be the same length as the qubits list."""
     rx90: bool = False
     """Calibration of native pi pulse, if true calibrates pi/2 pulse"""
 
@@ -139,8 +133,6 @@ class RabiAmplitudeFrequencyParameters(RabiAmplitudeParameters):
 class RabiResults(Results):
     """Results container for outputs produced by Rabi protocols."""
 
-    drive_lines: dict[QubitId, QubitId]
-    """List of drive line used for each qubit."""
     length: dict[QubitId, list[float]]
     """Pi pulse duration for each qubit."""
     amplitude: dict[QubitId, list[float]]
@@ -166,8 +158,6 @@ class RabiData(Data):
 
     rx90: bool
     """Pi or Pi_half calibration"""
-    drive_lines: dict[QubitId, QubitId] = field(default_factory=dict)
-    """List of drive line used for each qubit."""
     durations: dict[QubitId, float] = field(default_factory=dict)
     """Pulse duration for each target qubit."""
     amplitudes: dict[QubitId, float] = field(default_factory=dict)

--- a/src/qibocal/protocols/rabi/processing.py
+++ b/src/qibocal/protocols/rabi/processing.py
@@ -8,7 +8,7 @@ from plotly.subplots import make_subplots
 from scipy.optimize import curve_fit
 
 from qibocal import update
-from qibocal.auto.operation import QubitId
+from qibocal.auto.operation import QubitId, QubitPairId
 from qibocal.calibration import CalibrationPlatform
 from qibocal.protocols.utils import (
     angle_wrap,
@@ -38,28 +38,23 @@ sinusoidal oscillation.
 def update_rabi_parameters(
     results: RabiResults | RabiFreqResults,
     platform: CalibrationPlatform,
-    target: QubitId,
+    target: QubitId | QubitPairId,
 ) -> None:
     """Updating RX or RX90 parameters if the drive line is the physical line for qubit `target`"""
-    drive_line = results.drive_lines[target]
+    qubit = target[0] if isinstance(target, tuple) else target
+    drive_line = results.drive_lines[qubit]
     # checking if the parameters have been saved
-    if (
-        target == drive_line
-        and target in results.length
-        and target in results.amplitude
-    ):
-        update.drive_duration(results.length[target], results.rx90, platform, target)
-        update.drive_amplitude(
-            results.amplitude[target], results.rx90, platform, target
-        )
-        if isinstance(results, RabiFreqResults) and target in results.frequency:
-            update.drive_frequency(results.frequency[target], platform, target)
+    if qubit == drive_line and qubit in results.length and qubit in results.amplitude:
+        update.drive_duration(results.length[qubit], results.rx90, platform, qubit)
+        update.drive_amplitude(results.amplitude[qubit], results.rx90, platform, qubit)
+        if isinstance(results, RabiFreqResults) and qubit in results.frequency:
+            update.drive_frequency(results.frequency[qubit], platform, qubit)
 
 
 def update_rabi_ampl_params(
     results: RabiResults,
     platform: CalibrationPlatform,
-    target: QubitId,
+    target: QubitId | QubitPairId,
     label: Literal["signal", "classification"],
 ) -> None:
     """Update the platform with the results of the RabiAmplitude experiments."""
@@ -67,31 +62,33 @@ def update_rabi_ampl_params(
     # updating rabi parameters in the platform
     update_rabi_parameters(results, platform, target)
 
+    qubit, drive_line = target if isinstance(target, tuple) else (target, target)
+
     # saving amplitudes in the crosstalk matrix
     # from https://arxiv.org/pdf/2112.03708
     # here the first index is the qubit I want to drive and the second is the
     # drive line I want to pulse form.
-    if target not in results.amplitude:
+    if qubit not in results.amplitude:
         return
 
-    drive_line = results.drive_lines[target]
+    exp_rabi_osc = sum(results.fitted_parameters[qubit][:2])
 
-    exp_rabi_osc = sum(results.fitted_parameters[target][:2])
-
-    if drive_line == target:
-        platform.calibration.single_qubits[target].rabi_ampl_oscillation[label] = (
+    if drive_line == qubit:
+        platform.calibration.single_qubits[qubit].rabi_ampl_oscillation[label] = (
             exp_rabi_osc
         )
     else:
-        rtol = 0.5 if results.amplitude[target][0] <= 2 else 0.1
+        rtol = 0.5 if results.amplitude[qubit][0] <= 2 else 0.1
         try:
             condition = np.isclose(
                 exp_rabi_osc,
-                platform.calibration.single_qubits[target].rabi_ampl_oscillation[label],
+                platform.calibration.single_qubits[qubit].rabi_ampl_oscillation[label],
                 rtol=rtol,
             )
         except TypeError:
-            ValueError("Pi pulse calibration is needed for crosstalk calibration.")
+            raise ValueError(
+                "Pi pulse calibration is needed for crosstalk calibration."
+            )
 
         if not condition:
             print(
@@ -101,9 +98,9 @@ def update_rabi_ampl_params(
             return
 
     platform.calibration.set_microwave_crosstalk(
-        qubit=target,
+        qubit=qubit,
         microwave_line=drive_line,
-        module=results.amplitude[target][0],
+        module=results.amplitude[qubit][0],
     )
 
 
@@ -158,9 +155,11 @@ def rabi_initial_guess(
 
 
 def plot_signal(
-    data: RabiData, qubit: QubitId, fit: RabiResults | None, rx90: bool
+    data: RabiData, target: QubitId | QubitPairId, fit: RabiResults | None
 ) -> tuple[list[go.Figure], str]:
     """Create plots for a Rabi experiment signal and phase."""
+    qubit, drive_line = target if isinstance(target, tuple) else (target, target)
+
     quantity, title, fitting = extract_rabi(data)
     figures = []
     fitting_report = ""
@@ -224,7 +223,7 @@ def plot_signal(
             row=1,
             col=1,
         )
-        pulse_name = "Pi-half pulse" if rx90 else "Pi pulse"
+        pulse_name = "Pi-half pulse" if data.rx90 else "Pi pulse"
 
         fitting_report = table_html(
             table_dict(
@@ -244,8 +243,7 @@ def plot_signal(
             xaxis2_title=title,
             yaxis2_title="Phase [rad]",
             title=(
-                f"Rabi experiment for qubit {qubit} with "
-                + f"drive line {fit.drive_lines[qubit]}"
+                f"Rabi experiment for qubit {qubit} with " + f"drive line {drive_line}"
             ),
         )
 
@@ -255,11 +253,13 @@ def plot_signal(
 
 
 def plot_probabilities(
-    data: RabiData, qubit: QubitId, fit: RabiResults | None, rx90: bool
+    data: RabiData, target: QubitId | QubitPairId, fit: RabiResults | None
 ) -> tuple[list[go.Figure], str]:
     """
     Generate probability plot for Rabi experiment.
     """
+    qubit, drive_line = target if isinstance(target, tuple) else (target, target)
+
     quantity, title, fitting = extract_rabi(data)
     figures: list[go.Figure] = []
     fitting_report = ""
@@ -302,7 +302,7 @@ def plot_probabilities(
                 line=dict(color=FIT_COLOUR_LINE),
             ),
         )
-        pulse_name = "Pi-half pulse" if rx90 else "Pi pulse"
+        pulse_name = "Pi-half pulse" if data.rx90 else "Pi pulse"
 
         fitting_report = table_html(
             table_dict(
@@ -322,8 +322,7 @@ def plot_probabilities(
             xaxis_title=title,
             yaxis_title="Excited state probability",
             title=(
-                f"Rabi experiment for qubit {qubit} with "
-                + f"drive line {fit.drive_lines[qubit]}"
+                f"Rabi experiment for qubit {qubit} with " + f"drive line {drive_line}"
             ),
         )
 

--- a/src/qibocal/protocols/rabi/processing.py
+++ b/src/qibocal/protocols/rabi/processing.py
@@ -41,8 +41,7 @@ def update_rabi_parameters(
     target: QubitId | QubitPairId,
 ) -> None:
     """Updating RX or RX90 parameters if the drive line is the physical line for qubit `target`"""
-    qubit = target[0] if isinstance(target, tuple) else target
-    drive_line = results.drive_lines[qubit]
+    qubit, drive_line = target if isinstance(target, tuple) else (target, target)
     # checking if the parameters have been saved
     if qubit == drive_line and qubit in results.length and qubit in results.amplitude:
         update.drive_duration(results.length[qubit], results.rx90, platform, qubit)


### PR DESCRIPTION
In this PR I am changing the syntax of all Rabi experiments:

1. Now Rabi experiments takes as targets `Union[list[QubitId], list[QubitPairId]]`; when inserting a list of qubit pairs, we follow the convention `(qubit, drive_line)`.
2. Deleting `drive_lines` fields in Rabi `Data` and `Results` classes because useless with this new syntax
3. Small changes in plotting and updating function to align to the new syntax.