### PR TITLE
update was missplacing iSWAP parameters

### DIFF
--- a/src/qibocal/update.py
+++ b/src/qibocal/update.py
@@ -182,14 +182,14 @@ def CZ_amplitude(amp: float, platform: Platform, pair: QubitPairId):
 def iSWAP_duration(duration: float, platform: Platform, pair: QubitPairId):
     """Update iSWAP_duration duration for specific pair."""
     platform.update(
-        {f"native_gates.two_qubit.{_dump_pair(pair)}.CZ.0.1.duration": duration}
+        {f"native_gates.two_qubit.{_dump_pair(pair)}.iSWAP.0.1.duration": duration}
     )
 
 
 def iSWAP_amplitude(amp: float, platform: Platform, pair: QubitPairId):
     """Update iSWAP_duration amplitude for specific pair."""
     platform.update(
-        {f"native_gates.two_qubit.{_dump_pair(pair)}.CZ.0.1.amplitude": amp}
+        {f"native_gates.two_qubit.{_dump_pair(pair)}.iSWAP.0.1.amplitude": amp}
     )
 
 


### PR DESCRIPTION
Simple bug fix

Now this update (and other alike) does assume that the platform is organized so mthat the first pulse in the list is the flux pulse that the experiment is sweeping. Instead we coukld look specificaly for the flux pulse with the 'q#/flux' tag. 

```json
"iSWAP": [
                    [
                        "3/flux",
                        {
                            "kind": "pulse",
                            "duration": 50,
                            "amplitude": 0.0,
                            "envelope": {
                                "kind": "rectangular"
                            },
                            "relative_phase": 0.0,
                            "chirp": null
                        }
                    ],
                    [
                        "3/drive",
                        {
                            "kind": "delay",
                            "duration": 80.0
                        }
                    ],
...
```