### PR TITLE
Change redirect target from action.yml to runcard.yml

### DIFF
--- a/src/qibocal/web/script.js
+++ b/src/qibocal/web/script.js
@@ -1,5 +1,5 @@
 function redirectToRuncard() {
-    window.location.href = './action.yml';
+    window.location.href = './runcard.yml';
 }
 
 function redirectToPlatform() {


### PR DESCRIPTION
The generated report points to `action.yml` when clicking on the `Runcard` button, which doesn't exist and thus returns a `ERR_FILE_NOT_FOUND`, the actual file is `runcard.yml` and this mr fixes that