### PR TITLE
fix: move colormap scale

### DIFF
--- a/src/qibocal/protocols/flux_dependence/utils.py
+++ b/src/qibocal/protocols/flux_dependence/utils.py
@@ -66,6 +66,7 @@ def flux_dependence_plot(data, fit, qubit, fit_function=None):
             z=qubit_data.signal,
             colorbar={"title": "Signal [a.u.]"},
             colorscale="Viridis",
+            colorbar_x=1.01,
         ),
     )
 

--- a/src/qibocal/protocols/qubit_spectroscopies/qubit_power_spectroscopy.py
+++ b/src/qibocal/protocols/qubit_spectroscopies/qubit_power_spectroscopy.py
@@ -142,6 +142,7 @@ def _plot(
             z=data.normalized_signal(target).ravel(),
             colorbar={"title": "Normalized signal"},
             colorscale="Viridis",
+            colorbar_x=1.01,
         )
     )
 


### PR DESCRIPTION
A very small fix to avoid the following problem:

<img width="1120" height="362" alt="image" src="https://github.com/user-attachments/assets/5713a9f7-1b0c-4331-bbd2-b4b2b25010e2" />
