### PR TITLE
adding run-workflow label mechanism

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,12 @@ on:
   workflow_dispatch:
   push:
   merge_group:
+  pull_request:
+    types: [labeled, opened]
 
 jobs:
   build:
+    if: contains(github.event.pull_request.labels.*.name, 'run-workflow') || github.event_name == 'push'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]


### PR DESCRIPTION
As discussed, this allows external collaborators to run CI tests through approval mechanism.