### PR TITLE
Introduce range syntax for flux arcs

### DIFF
--- a/src/qibocal/protocols/flux_dependence/qubit_crosstalk.py
+++ b/src/qibocal/protocols/flux_dependence/qubit_crosstalk.py
@@ -155,7 +155,7 @@ def _acquisition(
         freq_sweepers.append(
             Sweeper(
                 parameter=Parameter.frequency,
-                values=platform.config(qd_channel).frequency + params.frequency_range,
+                range=params.frequency_range(platform.config(qd_channel).frequency),
                 channels=[qd_channel],
             )
         )
@@ -166,7 +166,7 @@ def _acquisition(
         offset_sweepers.append(
             Sweeper(
                 parameter=Parameter.offset,
-                values=offset0 + params.bias_range,
+                range=params.bias_range(offset0),
                 channels=[flux_channel],
             )
         )

--- a/src/qibocal/protocols/flux_dependence/qubit_flux_dependence.py
+++ b/src/qibocal/protocols/flux_dependence/qubit_flux_dependence.py
@@ -7,7 +7,9 @@ from qibolab import (
     AveragingMode,
     Delay,
     Parameter,
+    Pulse,
     PulseSequence,
+    Rectangular,
     Sweeper,
 )
 from scipy.signal import find_peaks
@@ -16,7 +18,6 @@ from qibocal.auto.operation import Data, Protocol, QubitId, Results
 from qibocal.calibration import CalibrationPlatform
 from qibocal.config import log
 from qibocal.result import magnitude
-from qibocal.update import replace
 
 from ... import update
 from ..utils import (
@@ -112,12 +113,14 @@ def _acquisition(
     freq_sweepers = []
     offset_sweepers = []
     for q in targets:
+        qd_channel = platform.qubits[q].drive
+        qd_pulse = Pulse(
+            amplitude=params.drive_amplitude,
+            duration=params.drive_duration,
+            envelope=Rectangular(),
+        )
         natives = platform.natives.single_qubit[q]
-        qd_channel, qd_pulse = natives.RX()[0]
         ro_channel, ro_pulse = natives.MZ()[0]
-
-        qd_pulse = replace(qd_pulse, duration=params.drive_duration)
-        qd_pulse = replace(qd_pulse, amplitude=params.drive_amplitude)
 
         qd_pulses[q] = qd_pulse
         ro_pulses[q] = ro_pulse
@@ -158,7 +161,10 @@ def _acquisition(
         [sequence],
         [offset_sweepers, freq_sweepers],
         updates=[
-            {platform.qubits[q].probe: {"frequency": readout_frequency(q, platform)}}
+            {
+                platform.qubits[q].probe: {"frequency": readout_frequency(q, platform)},
+                platform.qubits[q].flux: {"offset": 0.0},
+            }
             for q in targets
         ],
         nshots=params.nshots,

--- a/src/qibocal/protocols/flux_dependence/qubit_flux_dependence.py
+++ b/src/qibocal/protocols/flux_dependence/qubit_flux_dependence.py
@@ -131,7 +131,7 @@ def _acquisition(
         freq_sweepers.append(
             Sweeper(
                 parameter=Parameter.frequency,
-                values=frequency0 + params.frequency_range,
+                range=params.frequency_range(frequency0),
                 channels=[qd_channel],
             )
         )
@@ -141,7 +141,7 @@ def _acquisition(
         offset_sweepers.append(
             Sweeper(
                 parameter=Parameter.offset,
-                values=offset0 + params.bias_range,
+                range=params.bias_range(center=offset0),
                 channels=[flux_channel],
             )
         )

--- a/src/qibocal/protocols/flux_dependence/resonator_flux_dependence.py
+++ b/src/qibocal/protocols/flux_dependence/resonator_flux_dependence.py
@@ -149,6 +149,7 @@ def _acquisition(
     results = platform.execute(
         [sequence],
         [offset_sweepers, freq_sweepers],
+        updates=[{platform.qubits[q].flux: {"offset": 0.0}} for q in targets],
         nshots=params.nshots,
         relaxation_time=params.relaxation_time,
         acquisition_type=AcquisitionType.INTEGRATION,

--- a/src/qibocal/protocols/flux_dependence/resonator_flux_dependence.py
+++ b/src/qibocal/protocols/flux_dependence/resonator_flux_dependence.py
@@ -120,14 +120,14 @@ def _acquisition(
         freq_sweepers.append(
             Sweeper(
                 parameter=Parameter.frequency,
-                values=readout_frequency(q, platform) + params.frequency_range,
+                range=params.frequency_range(readout_frequency(q, platform)),
                 channels=[qubit.probe],
             )
         )
         offset_sweepers.append(
             Sweeper(
                 parameter=Parameter.offset,
-                values=offset0 + params.bias_range,
+                range=params.bias_range(offset0),
                 channels=[qubit.flux],
             )
         )

--- a/src/qibocal/protocols/flux_dependence/utils.py
+++ b/src/qibocal/protocols/flux_dependence/utils.py
@@ -17,11 +17,14 @@ from ..utils import (
     DISTANCE_Z,
     HZ_TO_GHZ,
     FeatExtractionError,
+    Range,
+    RangeLike,
     clustering,
     merging,
     minmax_scaling,
     peaks_finder,
     reshaping_raw_signal,
+    to_range,
     zca_whiten,
 )
 
@@ -30,22 +33,48 @@ from ..utils import (
 class FluxFrequencySweepParameters(Parameters):
     """Parameters to define flux DC sweep."""
 
-    freq_width: int
+    freq_width: int | None = None
     """Width for frequency sweep relative to the readout frequency [Hz]."""
-    freq_step: int
+    freq_step: int | None = None
     """Frequency step for sweep [Hz]."""
-    bias_width: float
+    frequency: RangeLike | None = None
+    """Frequency [Hz] range for sweep."""
+    bias_width: float | None = None
     """Width for bias sweep [a.u.]."""
-    bias_step: float
+    bias_step: float | None = None
     """Bias step for sweep [a.u.]."""
+    bias: RangeLike | None = None
+    """Bias [a.u.] range for sweep."""
 
-    @property
-    def frequency_range(self) -> np.ndarray:
-        return np.arange(-self.freq_width / 2, self.freq_width / 2, self.freq_step)
+    def frequency_range(self, center: float = 0.0) -> Range:
+        def legacy_range() -> Range:
+            assert self.freq_width is not None and self.freq_step is not None
+            return (
+                center - self.freq_width / 2,
+                center + self.freq_width / 2,
+                self.freq_step,
+            )
 
-    @property
-    def bias_range(self) -> np.ndarray:
-        return np.arange(-self.bias_width / 2, self.bias_width / 2, self.bias_step)
+        return (
+            to_range(self.frequency, center=center)
+            if self.frequency is not None
+            else legacy_range()
+        )
+
+    def bias_range(self, center: float = 0.0) -> Range:
+        def legacy_range() -> Range:
+            assert self.bias_width is not None and self.bias_step is not None
+            return (
+                center - self.bias_width / 2,
+                center + self.bias_width / 2,
+                self.bias_step,
+            )
+
+        return (
+            to_range(self.bias, center=center)
+            if self.bias is not None
+            else legacy_range()
+        )
 
 
 def create_data_array(freq, bias, signal, dtype):

--- a/src/qibocal/protocols/qubit_spectroscopies/qubit_spectroscopy.py
+++ b/src/qibocal/protocols/qubit_spectroscopies/qubit_spectroscopy.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from dataclasses import dataclass
+from typing import cast
 
 import numpy as np
 import numpy.typing as npt
@@ -11,6 +12,7 @@ from qibolab import (
     AveragingMode,
     ChannelId,
     Delay,
+    IqConfig,
     Parameter,
     Pulse,
     PulseSequence,
@@ -140,10 +142,12 @@ def _acquisition(
     # Get drive channels and LO channels for each qubit
     drive_channels: dict[QubitId, ChannelId] = {}
     lo_channels: dict[QubitId, str | None] = {}
+    f0: dict[QubitId, float] = {}
     for qubit in targets:
         drive_channel = platform.qubits[qubit].drive
         assert drive_channel is not None
         drive_channels[qubit] = drive_channel
+        f0[qubit] = params.f0(cast(IqConfig, platform.config(drive_channel)).frequency)
 
         # Get the LO channel associated with this drive channel
         channel_obj = platform.channels[drive_channels[qubit]]
@@ -185,14 +189,13 @@ def _acquisition(
             sequence.append((ro_channel, Delay(duration=qd_pulse.duration)))
             sequence.append((ro_channel, ro_pulse))
 
-            f0 = params.f0(platform.config(qd_channel).frequency)
-            frange = (f0 + start, f0 + end, step)
-            freq_ranges[qubit] = frange
+            batch_range = (f0[qubit] + start, f0[qubit] + end, step)
+            freq_ranges[qubit] = batch_range
 
             sweepers.append(
                 Sweeper(
                     parameter=Parameter.frequency,
-                    range=frange,
+                    range=batch_range,
                     channels=[qd_channel],
                 )
             )
@@ -203,15 +206,11 @@ def _acquisition(
             update_dict = {}
 
             # Update the frequency of the drive channel to avoid raising a validation an error
-            update_dict[drive_channels[qubit]] = {
-                "frequency": params.f0(platform.config(drive_channels[qubit]).frequency)
-                + lo_offset
-            }
+            update_dict[drive_channels[qubit]] = {"frequency": f0[qubit] + lo_offset}
 
             # If we're batching, update the LO
             if lo_offset != 0 and lo_channels[qubit] is not None:
-                f0 = params.f0(platform.config(drive_channels[qubit]).frequency)
-                update_dict[lo_channels[qubit]] = {"frequency": f0 + lo_offset}
+                update_dict[lo_channels[qubit]] = {"frequency": f0[qubit] + lo_offset}
 
             batch_updates.append(update_dict)
 

--- a/src/qibocal/protocols/qubit_spectroscopies/qubit_spectroscopy.py
+++ b/src/qibocal/protocols/qubit_spectroscopies/qubit_spectroscopy.py
@@ -72,6 +72,11 @@ class QubitSpectroscopyParameters(Parameters):
             else legacy_range()
         )
 
+    def f0(self, center: float = 0.0) -> float:
+        """Return the center frequency of the sweep."""
+        start, end, _ = self.frequency_range(center)
+        return (start + end) / 2
+
 
 @dataclass
 class QubitSpectroscopyResults(Results):
@@ -129,7 +134,7 @@ def _acquisition(
 
     # Calculate batches
     freq_range = params.frequency_range()
-    width = freq_range[1] - freq_range[0]
+    width, step = freq_range[1] - freq_range[0], freq_range[2]
     batches = _calculate_batches(freq_width=width)
 
     # Get drive channels and LO channels for each qubit
@@ -157,10 +162,9 @@ def _acquisition(
 
     # Execute each batch
     for start, end, lo_offset in batches:
-        delta_frequency_range = np.arange(start, end, freq_range[2])
-
         # Build the pulse sequence
         sequence = PulseSequence()
+        freq_ranges = {}
         ro_pulses = {}
         sweepers = []
 
@@ -181,11 +185,14 @@ def _acquisition(
             sequence.append((ro_channel, Delay(duration=qd_pulse.duration)))
             sequence.append((ro_channel, ro_pulse))
 
-            f0 = platform.config(qd_channel).frequency
+            f0 = params.f0(platform.config(qd_channel).frequency)
+            frange = (f0 + start, f0 + end, step)
+            freq_ranges[qubit] = frange
+
             sweepers.append(
                 Sweeper(
                     parameter=Parameter.frequency,
-                    values=f0 + delta_frequency_range,
+                    range=frange,
                     channels=[qd_channel],
                 )
             )
@@ -197,13 +204,13 @@ def _acquisition(
 
             # Update the frequency of the drive channel to avoid raising a validation an error
             update_dict[drive_channels[qubit]] = {
-                "frequency": platform.config(drive_channels[qubit]).frequency
+                "frequency": params.f0(platform.config(drive_channels[qubit]).frequency)
                 + lo_offset
             }
 
             # If we're batching, update the LO
             if lo_offset != 0 and lo_channels[qubit] is not None:
-                f0 = platform.config(drive_channels[qubit]).frequency
+                f0 = params.f0(platform.config(drive_channels[qubit]).frequency)
                 update_dict[lo_channels[qubit]] = {"frequency": f0 + lo_offset}
 
             batch_updates.append(update_dict)
@@ -222,10 +229,9 @@ def _acquisition(
         # Collect results from this batch
         for qubit in targets:
             result = results[ro_pulses[qubit].id]
-            f0 = platform.config(drive_channels[qubit]).frequency
 
             # Store results with absolute frequencies
-            values[qubit]["frequency"].append(delta_frequency_range + f0)
+            values[qubit]["frequency"].append(np.arange(*freq_ranges[qubit]))
             values[qubit]["result"].append(result)
 
     freqs: dict[QubitId, list[float]] = {}


### PR DESCRIPTION
On top of what the title says, this is also:

- migrating the qubit flux dependence (flux arc spectroscopy) to use rectangular pulses
- fixing a small mess introduced by the range syntax initial support for the qubit spectroscopy

Most likely, the second point should be described better in the documentation of the qubit spectroscopy. But that is possibly better done with a thorough refactor of the qubit spectroscopy implementation, modularizing it a bit more, and making the batching and consequent LO shifts reusable for other protocols. Primarily, for the resonator spectroscopy.

However, the algorithm is "simply" the following:
1. batches, consisting of begin-end and LO positions, are computed, just taking into account the full width of the requested interval - which can be computed independently of its center, which is allowed to be qubit dependent
2. the center is computed for each qubit, just by passing the channel frequency as "candidate center" to the usual range function - boiling down to a call to `to_range()`; this is determining the entire range, which could be specified independently of the default centering (drive channel frequency), and out of it a center is computed - which is delegated to `params.f0()`
3. on top of this center the actual range for the batch is computed, summing the extrema of the batch, computed at point 1. relative to a `0.0` center