### PR TITLE
fixing bug raised during parallel execution in Ramsey ZZ

### DIFF
--- a/src/qibocal/protocols/zz_interaction/ramsey_zz.py
+++ b/src/qibocal/protocols/zz_interaction/ramsey_zz.py
@@ -104,6 +104,7 @@ def _acquisition(
 
     sequences: dict[Literal["I", "X"], PulseSequence] = {}
     parsweepers: dict[Literal["I", "X"], Sweeper] = {}
+    updates = {}
 
     for setup in cast(tuple[Literal["I", "X"], ...], ("I", "X")):
         setup_sequence = PulseSequence()
@@ -111,7 +112,6 @@ def _acquisition(
         for pair in targets:
             targ, spect = pair
 
-            updates = {}
             if params.detuning is not None:
                 channel = platform.qubits[targ].drive
                 f0 = platform.config(channel).frequency


### PR DESCRIPTION
detuning of drive pulse used to act only on the last qubit pair, as pointed out in #1637 (and closes it).