### PR TITLE
Correct numpification of Quinn Fernandes algorithm

### DIFF
--- a/src/qibocal/protocols/drag/drag.py
+++ b/src/qibocal/protocols/drag/drag.py
@@ -214,8 +214,8 @@ def _fit(data: DragTuningData) -> DragTuningResults:
 
         # Guessing period using fourier transform
         period_guess = fallback_period(
-            guess_period(beta_params, qubit_data["prob"]).tolist()
-        )
+            guess_period(beta_params, qubit_data["prob"])
+        ).tolist()
         pguess = [0.5, 0.5, period_guess, 0]
         try:
             popt, _ = curve_fit(

--- a/src/qibocal/protocols/drag/drag.py
+++ b/src/qibocal/protocols/drag/drag.py
@@ -213,7 +213,9 @@ def _fit(data: DragTuningData) -> DragTuningResults:
         beta_params = qubit_data["beta"]
 
         # Guessing period using fourier transform
-        period_guess = fallback_period(guess_period(beta_params, qubit_data["prob"]).tolist())
+        period_guess = fallback_period(
+            guess_period(beta_params, qubit_data["prob"]).tolist()
+        )
         pguess = [0.5, 0.5, period_guess, 0]
         try:
             popt, _ = curve_fit(

--- a/src/qibocal/protocols/drag/drag.py
+++ b/src/qibocal/protocols/drag/drag.py
@@ -213,7 +213,7 @@ def _fit(data: DragTuningData) -> DragTuningResults:
         beta_params = qubit_data["beta"]
 
         # Guessing period using fourier transform
-        period_guess = fallback_period(guess_period(beta_params, qubit_data["prob"]))
+        period_guess = fallback_period(guess_period(beta_params, qubit_data["prob"]).tolist())
         pguess = [0.5, 0.5, period_guess, 0]
         try:
             popt, _ = curve_fit(

--- a/src/qibocal/protocols/ramsey/processing.py
+++ b/src/qibocal/protocols/ramsey/processing.py
@@ -79,7 +79,7 @@ def fitting(
     if y_err is not None:
         y_err = y_err / delta_y
 
-    omega = quinn_fernandes_algorithm(y, x, speedup_flag=True)
+    omega = quinn_fernandes_algorithm(y, x, speedup_flag=True).tolist()
     median_sig = np.median(y)
     q80 = np.quantile(y, 0.8)
     q20 = np.quantile(y, 0.2)

--- a/src/qibocal/protocols/two_qubit_interaction/cross_resonance/cross_resonance_processing.py
+++ b/src/qibocal/protocols/two_qubit_interaction/cross_resonance/cross_resonance_processing.py
@@ -409,13 +409,11 @@ def tomography_cr_fit(
                 ]
             ).reshape(len(Basis), -1)
 
-            total_omega_guess = float(
-                np.median(
+            total_omega_guess = np.median(
                     quinn_fernandes_algorithm(
                         concatenated_signal, vector_x, speedup_flag=True
                     )
-                )
-            )
+                ).tolist()
 
             if fit_with_evolution:
                 popt = dynamic_evolution_optimizer(

--- a/src/qibocal/protocols/two_qubit_interaction/cross_resonance/cross_resonance_processing.py
+++ b/src/qibocal/protocols/two_qubit_interaction/cross_resonance/cross_resonance_processing.py
@@ -410,10 +410,10 @@ def tomography_cr_fit(
             ).reshape(len(Basis), -1)
 
             total_omega_guess = np.median(
-                    quinn_fernandes_algorithm(
-                        concatenated_signal, vector_x, speedup_flag=True
-                    )
-                ).tolist()
+                quinn_fernandes_algorithm(
+                    concatenated_signal, vector_x, speedup_flag=True
+                )
+            ).tolist()
 
             if fit_with_evolution:
                 popt = dynamic_evolution_optimizer(

--- a/src/qibocal/protocols/two_qubit_interaction/cross_resonance/cross_resonance_processing.py
+++ b/src/qibocal/protocols/two_qubit_interaction/cross_resonance/cross_resonance_processing.py
@@ -409,9 +409,13 @@ def tomography_cr_fit(
                 ]
             ).reshape(len(Basis), -1)
 
-            total_omega_guess = float(np.median(quinn_fernandes_algorithm(
-                concatenated_signal, vector_x, speedup_flag=True
-            )))
+            total_omega_guess = float(
+                np.median(
+                    quinn_fernandes_algorithm(
+                        concatenated_signal, vector_x, speedup_flag=True
+                    )
+                )
+            )
 
             if fit_with_evolution:
                 popt = dynamic_evolution_optimizer(

--- a/src/qibocal/protocols/two_qubit_interaction/cross_resonance/cross_resonance_processing.py
+++ b/src/qibocal/protocols/two_qubit_interaction/cross_resonance/cross_resonance_processing.py
@@ -409,9 +409,9 @@ def tomography_cr_fit(
                 ]
             ).reshape(len(Basis), -1)
 
-            total_omega_guess = quinn_fernandes_algorithm(
+            total_omega_guess = float(np.median(quinn_fernandes_algorithm(
                 concatenated_signal, vector_x, speedup_flag=True
-            )
+            )))
 
             if fit_with_evolution:
                 popt = dynamic_evolution_optimizer(

--- a/src/qibocal/protocols/two_qubit_interaction/utils.py
+++ b/src/qibocal/protocols/two_qubit_interaction/utils.py
@@ -47,7 +47,7 @@ def fit_flux_amplitude(matrix, amps, times):
     std = []
     for i in range(size_amp):
         y = matrix[i, :]
-        period = fallback_period(guess_period(times, y))
+        period = fallback_period(guess_period(times, y).tolist())
         fs.append(1 / period)
         std.append(np.std(y))
 

--- a/src/qibocal/protocols/two_qubit_interaction/utils.py
+++ b/src/qibocal/protocols/two_qubit_interaction/utils.py
@@ -47,7 +47,7 @@ def fit_flux_amplitude(matrix, amps, times):
     std = []
     for i in range(size_amp):
         y = matrix[i, :]
-        period = fallback_period(guess_period(times, y).tolist())
+        period = fallback_period(guess_period(times, y)).tolist()
         fs.append(1 / period)
         std.append(np.std(y))
 

--- a/src/qibocal/protocols/utils.py
+++ b/src/qibocal/protocols/utils.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
-from numpy.typing import NDArray
+from numpy.typing import NDArray, ArrayLike
 from plotly.subplots import make_subplots
 from pydantic import TypeAdapter
 from scipy import constants, sparse
@@ -1065,9 +1065,7 @@ def guess_frequency(x: NDArray, y: NDArray, axis: int = -1) -> NDArray:
     mags = np.abs(fft)
     mags[..., 0] = 0
 
-    selected_freqs = fft_freqs[np.argmax(mags, axis=-1)]
-
-    return selected_freqs
+    return fft_freqs[np.argmax(mags, axis=-1)]
 
 
 def fallback_frequency(frequency: NDArray) -> NDArray:
@@ -1084,13 +1082,13 @@ def fallback_frequency(frequency: NDArray) -> NDArray:
 
 
 def quinn_fernandes_algorithm(
-    signal: np.typing.ArrayLike,
-    x: np.typing.ArrayLike,
+    signal: ArrayLike,
+    x: ArrayLike,
     axis: int = -1,
     speedup_flag: bool = False,
     iterations: int = 100,
     tol: float = 1e-8,
-) -> NDArray | float:
+) -> NDArray[float]:
     """This is a custom implementation of the Quinn-Fernandes algorithm.
     We compute the signal sampling rate from :param:x, hence this function assumes x to be
     ordered.
@@ -1109,16 +1107,13 @@ def quinn_fernandes_algorithm(
 
     fs = 1 / abs(x[0] - x[1])
 
-    if signal.ndim == 1:
-        signal = np.asarray(signal[np.newaxis, :])
-
     omegas = 2 * np.pi * fallback_frequency(guess_frequency(x, signal, axis=-1))
     alpha = 2 * np.cos(omegas)
 
     null_mean_signal = signal - np.mean(signal, axis=-1, keepdims=True)
 
     sig_shape = list(null_mean_signal.shape)
-    # adding two elements in the last dimensionto be used in the algorithm below
+    # adding two elements in the last dimension to be used in the algorithm below
     sig_shape[-1] += 2
     buffer_beta = []
 
@@ -1133,7 +1128,8 @@ def quinn_fernandes_algorithm(
         beta = np.sum((xi[..., 2:] + xi[..., :-2]) * xi[..., 1:-1], axis=-1) / np.sum(
             xi[..., :-1] ** 2, axis=-1
         )
-        beta[np.isnan(beta)] = 0
+        # np.where() works with scalars as well, so there is not need to add a dimension in 1D case
+        beta = np.where(np.isfinite(beta), beta, 0)
         if len(buffer_beta) >= 5:
             buffer_beta.pop(0)
         buffer_beta.append(beta)
@@ -1146,18 +1142,15 @@ def quinn_fernandes_algorithm(
         else:
             alpha = 2 * beta - alpha
 
-    alpha = np.clip(alpha, -2, 2)
-    omega_est = np.arccos(alpha / 2)
-
-    if omega_est.size == 1:
-        return float(omega_est) * fs
+    alpha = np.asarray(np.clip(alpha, -2, 2))
+    omega_est = np.asarray(np.arccos(alpha / 2))
 
     return omega_est * fs
 
 
 def guess_period(
     x: NDArray, y: NDArray, axis: int = -1, speedup_flag: bool = True
-) -> NDArray | float:
+) -> NDArray:
     """Estimate the period(s) of a (set of) sinusoidal signal(s).
 
     This is a thin wrapper around :func:`guess_frequency` that returns the

--- a/src/qibocal/protocols/utils.py
+++ b/src/qibocal/protocols/utils.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
-from numpy.typing import NDArray, ArrayLike
+from numpy.typing import ArrayLike, NDArray
 from plotly.subplots import make_subplots
 from pydantic import TypeAdapter
 from scipy import constants, sparse

--- a/src/qibocal/protocols/utils.py
+++ b/src/qibocal/protocols/utils.py
@@ -2,7 +2,7 @@ from collections import Counter
 from collections.abc import Sequence
 from colorsys import hls_to_rgb
 from enum import Enum
-from typing import Any, Literal
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -1126,7 +1126,9 @@ def quinn_fernandes_algorithm(
         xi = np.zeros(sig_shape)
         for t in range(2, xi.shape[-1]):
             # here the 2 extra items in the last dimension is used
-            xi[..., t] = null_mean_signal[..., t - 2] + alpha * xi[..., t - 1] - xi[..., t - 2]
+            xi[..., t] = (
+                null_mean_signal[..., t - 2] + alpha * xi[..., t - 1] - xi[..., t - 2]
+            )
 
         beta = np.sum((xi[..., 2:] + xi[..., :-2]) * xi[..., 1:-1], axis=-1) / np.sum(
             xi[..., :-1] ** 2, axis=-1

--- a/src/qibocal/protocols/utils.py
+++ b/src/qibocal/protocols/utils.py
@@ -1063,11 +1063,11 @@ def guess_frequency(x: NDArray, y: NDArray, axis: int = -1) -> NDArray:
     fft = np.fft.rfft(y, axis=-1)
     fft_freqs = np.fft.rfftfreq(y.shape[-1], d=(x[1] - x[0]))
     mags = np.abs(fft)
-    mags[:, 0] = 0
+    mags[..., 0] = 0
 
     selected_freqs = fft_freqs[np.argmax(mags, axis=-1)]
 
-    return np.moveaxis(selected_freqs, -1, axis)
+    return selected_freqs
 
 
 def fallback_frequency(frequency: NDArray) -> NDArray:
@@ -1084,13 +1084,13 @@ def fallback_frequency(frequency: NDArray) -> NDArray:
 
 
 def quinn_fernandes_algorithm(
-    signal: Any,
-    x: Any,
+    signal: np.typing.ArrayLike,
+    x: np.typing.ArrayLike,
     axis: int = -1,
     speedup_flag: bool = False,
     iterations: int = 100,
-    tol: int = 1e-8,
-) -> NDArray:
+    tol: float = 1e-8,
+) -> NDArray | float:
     """This is a custom implementation of the Quinn-Fernandes algorithm.
     We compute the signal sampling rate from :param:x, hence this function assumes x to be
     ordered.
@@ -1104,32 +1104,32 @@ def quinn_fernandes_algorithm(
     Link for the original paper: https://www.jstor.org/stable/2337018?seq=3
     """
 
+    x = np.asarray(x)
+    signal = np.moveaxis(np.asarray(signal), axis, -1)
+
     fs = 1 / abs(x[0] - x[1])
 
-    if not isinstance(x, np.ndarray):
-        x = np.array(x)
-
-    if not isinstance(signal, np.ndarray):
-        signal = np.array(signal)
-
     if signal.ndim == 1:
-        signal = signal[np.newaxis, :]
+        signal = np.asarray(signal[np.newaxis, :])
 
-    omegas = 2 * np.pi * fallback_frequency(guess_frequency(x, signal, axis=axis))
+    omegas = 2 * np.pi * fallback_frequency(guess_frequency(x, signal, axis=-1))
     alpha = 2 * np.cos(omegas)
 
-    signal = signal - np.mean(signal, axis=axis, keepdims=True)
+    null_mean_signal = signal - np.mean(signal, axis=-1, keepdims=True)
 
-    sig_shape = list(signal.shape)
-    sig_shape[axis] += 2
+    sig_shape = list(null_mean_signal.shape)
+    # adding two elements in the last dimensionto be used in the algorithm below
+    sig_shape[-1] += 2
     buffer_beta = []
+
     for _ in range(iterations):
         xi = np.zeros(sig_shape)
-        for t in range(2, xi.shape[axis]):
-            xi[..., t] = signal[..., t - 2] + alpha * xi[..., t - 1] - xi[..., t - 2]
+        for t in range(2, xi.shape[-1]):
+            # here the 2 extra items in the last dimension is used
+            xi[..., t] = null_mean_signal[..., t - 2] + alpha * xi[..., t - 1] - xi[..., t - 2]
 
-        beta = np.sum((xi[..., 2:] + xi[..., :-2]) * xi[..., 1:-1], axis=axis) / np.sum(
-            xi[..., :-1] ** 2, axis=axis
+        beta = np.sum((xi[..., 2:] + xi[..., :-2]) * xi[..., 1:-1], axis=-1) / np.sum(
+            xi[..., :-1] ** 2, axis=-1
         )
         beta[np.isnan(beta)] = 0
         if len(buffer_beta) >= 5:
@@ -1146,14 +1146,16 @@ def quinn_fernandes_algorithm(
 
     alpha = np.clip(alpha, -2, 2)
     omega_est = np.arccos(alpha / 2)
-    med_omega = np.median(omega_est)
 
-    return med_omega * fs
+    if omega_est.size == 1:
+        return float(omega_est) * fs
+
+    return omega_est * fs
 
 
 def guess_period(
     x: NDArray, y: NDArray, axis: int = -1, speedup_flag: bool = True
-) -> NDArray:
+) -> NDArray | float:
     """Estimate the period(s) of a (set of) sinusoidal signal(s).
 
     This is a thin wrapper around :func:`guess_frequency` that returns the

--- a/src/qibocal/protocols/zz_interaction/jazz.py
+++ b/src/qibocal/protocols/zz_interaction/jazz.py
@@ -210,7 +210,7 @@ def _jazz_fitting_process(probs, delays, err):
     min_max_delays = (delays - d_min) / delta_delay
     err = err / delta_probs
 
-    omega = quinn_fernandes_algorithm(min_max_probs, min_max_delays, speedup_flag=True)
+    omega = quinn_fernandes_algorithm(min_max_probs, min_max_delays, speedup_flag=True).tolist()
     median_sig = np.median(min_max_probs)
     q80 = np.quantile(min_max_probs, 0.8)
     q20 = np.quantile(min_max_probs, 0.2)

--- a/src/qibocal/protocols/zz_interaction/jazz.py
+++ b/src/qibocal/protocols/zz_interaction/jazz.py
@@ -210,7 +210,9 @@ def _jazz_fitting_process(probs, delays, err):
     min_max_delays = (delays - d_min) / delta_delay
     err = err / delta_probs
 
-    omega = quinn_fernandes_algorithm(min_max_probs, min_max_delays, speedup_flag=True).tolist()
+    omega = quinn_fernandes_algorithm(
+        min_max_probs, min_max_delays, speedup_flag=True
+    ).tolist()
     median_sig = np.median(min_max_probs)
     q80 = np.quantile(min_max_probs, 0.8)
     q20 = np.quantile(min_max_probs, 0.2)


### PR DESCRIPTION
As mentioned in the title, I realized that the `quinn_fernandes` implementation in `protocols/utils.py` does not work correctly when the `axis` parameter is different from `-1`, as the axis was not being handled properly.

Additionally, at the end of the function, we were computing the `np.median` of the estimated omegas in the `ndarray`. This was originally introduced for the `cross_resonance` protocols, particularly for simultaneous fitting in Hamiltonian tomography. However, this behavior is not generally desirable, so I moved this operation to the specific module where it is needed.