### PR TITLE
Require numpy >=2, drop 1.x dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -430,7 +430,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "sys_platform != \"emscripten\" and (platform_system == \"Windows\" or sys_platform == \"win32\")", docs = "sys_platform == \"win32\"", tests = "sys_platform == \"win32\""}
+markers = {main = "sys_platform == \"win32\" or platform_system == \"Windows\"", dev = "sys_platform != \"emscripten\" and (platform_system == \"Windows\" or sys_platform == \"win32\")", docs = "sys_platform == \"win32\"", tests = "sys_platform == \"win32\""}
 
 [[package]]
 name = "colorlog"
@@ -4180,4 +4180,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "8679fc22f713f537d7c30a6a9b1e6e1f4170eeabb874e064450da1e3ce676e0c"
+content-hash = "f90d17d797dd363847b82adff7f849a41d522e6ae5fbd08ae7e89503fb628117"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 python = ">=3.10,<3.14"
 qibolab = "^0.2.8"
 qibo = "^0.3.1"
-numpy = ">=1.26.4,<3"
+numpy = "^2.0.0"
 scipy = "^1.10.1"
 scikit-learn = ">=1.3.0,<2"
 pandas = { version = "^2.2.2", extras = ["html"] }


### PR DESCRIPTION
In practice this does not change how the environment is resolved (see also the lock file)