### PR TITLE
Review twpa pump calibration

### DIFF
--- a/src/qibocal/protocols/twpa/twpa.py
+++ b/src/qibocal/protocols/twpa/twpa.py
@@ -151,7 +151,8 @@ def _acquisition(
     reference_value: dict[QubitId, list[float]] = {}
     # reference value without twpas
     for twpa in twpas.values():
-        twpa.disconnect()
+        assert twpa.device is not None
+        twpa.device.off()
 
     results = platform.execute(
         [sequence],
@@ -166,7 +167,8 @@ def _acquisition(
         reference_value[q] = results[acq_handle].tolist()
 
     for twpa in twpas.values():
-        twpa.connect()
+        assert twpa.device is not None
+        twpa.device.on()
 
     updates: list[dict[str, dict[str, Any]]] = []
 

--- a/src/qibocal/protocols/twpa/twpa.py
+++ b/src/qibocal/protocols/twpa/twpa.py
@@ -25,27 +25,86 @@ from qibolab._core.instruments.oscillator import LocalOscillator
 from ...auto.operation import Data, Parameters, Protocol, QubitId, Results
 from ...calibration.platform import CalibrationPlatform
 from ...result import magnitude
-from ..utils import HZ_TO_GHZ, readout_frequency, table_dict, table_html
+from ..utils import (
+    HZ_TO_GHZ,
+    Range,
+    RangeLike,
+    readout_frequency,
+    table_dict,
+    table_html,
+    to_range,
+)
 
 
 @dataclass
 class TwpaCalibrationParameters(Parameters):
     """TwpaCalibration runcard inputs."""
 
-    freq_width: float
+    freq_width: float | None = None
     """Width for frequency sweep of readout pulse (Hz)."""
-    freq_step: float
+    freq_step: float | None = None
     """Frequency step for sweep of readout pulse (Hz)."""
-    twpa_freq_width: int
+    probe_frequency: RangeLike | None = None
+    """Frequency [Hz] range for sweep."""
+    probe_duration: float = 8e3
+    probe_amplitude: float = 0.1
+    twpa_freq_width: float | None = None
     """Width for TPWA frequency sweep (Hz)."""
-    twpa_freq_step: int
+    twpa_freq_step: float | None = None
     """TPWA frequency step (Hz)."""
-    twpa_pow_width: int
+    frequency: RangeLike | None = None
+    """TWPA pump frequency [Hz] range for sweep."""
+    twpa_pow_width: float | None = None
     """Width for TPWA power sweep (dBm)."""
-    twpa_pow_step: int
+    twpa_pow_step: float | None = None
     """TPWA power step (dBm)."""
-    duration: float = 8e3
-    amplitude: float = 0.1
+    power: RangeLike | None = None
+    """TWPA pump power [dBm] range for sweep."""
+
+    def probe_frequency_range(self, center: float = 0.0) -> Range:
+        def legacy_range() -> Range:
+            assert self.freq_width is not None and self.freq_step is not None
+            return (
+                center - self.freq_width / 2,
+                center + self.freq_width / 2,
+                self.freq_step,
+            )
+
+        return (
+            to_range(self.probe_frequency, center=center)
+            if self.probe_frequency is not None
+            else legacy_range()
+        )
+
+    def frequency_range(self, center: float = 0.0) -> Range:
+        def legacy_range() -> Range:
+            assert self.twpa_freq_width is not None and self.twpa_freq_step is not None
+            return (
+                center - self.twpa_freq_width / 2,
+                center + self.twpa_freq_width / 2,
+                self.twpa_freq_step,
+            )
+
+        return (
+            to_range(self.frequency, center=center)
+            if self.frequency is not None
+            else legacy_range()
+        )
+
+    def power_range(self, center: float = 0.0) -> Range:
+        def legacy_range() -> Range:
+            assert self.twpa_pow_width is not None and self.twpa_pow_step is not None
+            return (
+                center - self.twpa_pow_width / 2,
+                center + self.twpa_pow_width / 2,
+                self.twpa_pow_step,
+            )
+
+        return (
+            to_range(self.power, center=center)
+            if self.power is not None
+            else legacy_range()
+        )
 
 
 @dataclass

--- a/src/qibocal/protocols/twpa/twpa.py
+++ b/src/qibocal/protocols/twpa/twpa.py
@@ -268,13 +268,13 @@ def _plot(data: TwpaCalibrationData, fit: TwpaCalibrationResults, target):
             x=np.array(data.twpa_frequency[target]) * HZ_TO_GHZ,
             y=data.twpa_power[target],
             z=averaged_gain,
+            colorscale="inferno",
         ),
     )
-    fig.update_xaxes(title_text="TWPA Frequency [GHz]")
-    fig.update_yaxes(title_text="TWPA Power [dBm]")
-
     fig.update_layout(
         showlegend=False,
+        xaxis_title="TWPA Frequency [GHz]",
+        yaxis_title="TWPA Power [dBm]",
     )
 
     figures.append(fig)

--- a/src/qibocal/protocols/twpa/twpa.py
+++ b/src/qibocal/protocols/twpa/twpa.py
@@ -127,11 +127,11 @@ class TwpaCalibrationData(Data):
 
     data: dict[QubitId, npt.NDArray[np.float64]] = field(default_factory=dict)
     """Raw data acquired."""
-    twpa_frequency: dict[QubitId, list[float]] = field(default=dict)
+    twpa_frequency: dict[QubitId, list[float]] = field(default_factory=dict)
     """List with twpa frequency values swept."""
-    twpa_power: dict[QubitId, list[float]] = field(default=dict)
+    twpa_power: dict[QubitId, list[float]] = field(default_factory=dict)
     """List with twpa power values swept."""
-    reference_value: dict[QubitId, list[float]] = field(default=dict)
+    reference_value: dict[QubitId, list[float]] = field(default_factory=dict)
     """Values for readout frequency sweep with TWPA off."""
 
     def reference_value_array(self, qubit: QubitId) -> npt.NDArray[np.float64]:
@@ -320,10 +320,12 @@ def _fit(data: TwpaCalibrationData) -> TwpaCalibrationResults:
     )
 
 
-def _plot(data: TwpaCalibrationData, fit: TwpaCalibrationResults, target):
+def _plot(
+    data: TwpaCalibrationData, fit: TwpaCalibrationResults | None, target: QubitId
+) -> tuple[list[go.Figure], str]:
     """Plotting for TwpaCalibration."""
 
-    figures = []
+    figures: list[go.Figure] = []
     fig = go.Figure()
     if fit is not None:
         fitting_report = table_html(

--- a/src/qibocal/protocols/twpa/twpa.py
+++ b/src/qibocal/protocols/twpa/twpa.py
@@ -1,20 +1,29 @@
 """Protocol to calibrate TWPA power and frequency for a specific probe frequency."""
 
 from dataclasses import dataclass, field
+from typing import Any, cast
 
 import numpy as np
 import numpy.typing as npt
 import plotly.graph_objects as go
 from qibolab import (
+    Acquisition,
+    AcquisitionChannel,
     AcquisitionType,
     AveragingMode,
+    OscillatorConfig,
     Parameter,
-    Platform,
+    Pulse,
     PulseSequence,
+    Qubit,
+    Readout,
+    Rectangular,
     Sweeper,
 )
+from qibolab._core.instruments.oscillator import LocalOscillator
 
 from ...auto.operation import Data, Parameters, Protocol, QubitId, Results
+from ...calibration.platform import CalibrationPlatform
 from ...result import magnitude
 from ..utils import HZ_TO_GHZ, readout_frequency, table_dict, table_html
 
@@ -71,7 +80,7 @@ class TwpaCalibrationData(Data):
 
 def _acquisition(
     params: TwpaCalibrationParameters,
-    platform: Platform,
+    platform: CalibrationPlatform,
     targets: list[QubitId],
 ) -> TwpaCalibrationData:
     """Acquisition function for TwpaCalibration.
@@ -79,6 +88,20 @@ def _acquisition(
     First perform a scan over the readout probe with the TWPA off, then we sweep the TWPA power and frequency.
     The gain is computed as the norm of the complex readout signal divided the norm of the complex readout signal without TWPA.
     """
+
+    qubits: list[Qubit] = [platform.qubits[qubit] for qubit in targets]
+    acquisition_channels: list[str] = []
+    pumps: list[str] = []
+    for qubit in qubits:
+        assert qubit.acquisition is not None
+        acquisition_channels.append(qubit.acquisition)
+        pump = cast(AcquisitionChannel, platform.channels[qubit.acquisition]).twpa_pump
+        assert pump is not None
+        pumps.append(pump)
+    twpas = {pump: cast(LocalOscillator, platform.instruments[pump]) for pump in pumps}
+    twpa_configs = {
+        pump: cast(OscillatorConfig, platform.config(pump)) for pump in pumps
+    }
 
     sequence = PulseSequence()
     for ch in acquisition_channels:
@@ -99,7 +122,6 @@ def _acquisition(
     frequency_range = np.arange(
         -params.freq_width / 2, params.freq_width / 2, params.freq_step
     )
-
     twpa_frequency_range = np.arange(
         -params.twpa_freq_width / 2,
         params.twpa_freq_width / 2,
@@ -108,34 +130,25 @@ def _acquisition(
     twpa_power_range = np.arange(
         -params.twpa_pow_width / 2, params.twpa_pow_width / 2, params.twpa_pow_step
     )
-
     twpa_power_ranges = {
-        qubit: (
-            twpa_power_range
-            + platform.config(
-                platform.channels[platform.qubits[qubit].acquisition].twpa_pump
-            ).power
-        ).tolist()
-        for qubit in targets
+        q: (twpa_power_range + twpa.power).tolist()
+        for q, twpa in zip(targets, twpa_configs.values())
     }
     twpa_frequency_ranges = {
-        qubit: (
-            twpa_frequency_range
-            + platform.config(
-                platform.channels[platform.qubits[qubit].acquisition].twpa_pump
-            ).frequency
-        ).tolist()
-        for qubit in targets
+        q: (twpa_frequency_range + twpa.frequency).tolist()
+        for q, twpa in zip(targets, twpa_configs.values())
     }
+
     sweepers = [
         Sweeper(
             parameter=Parameter.frequency,
             values=readout_frequency(q, platform) + frequency_range,
-            channels=[platform.qubits[q].probe],
+            channels=[qubit.probe],
         )
-        for q in targets
+        for q, qubit in zip(targets, qubits)
     ]
-    reference_value = {}
+
+    reference_value: dict[QubitId, list[float]] = {}
     # reference value without twpas
     for twpa in twpas.values():
         twpa.disconnect()
@@ -148,29 +161,31 @@ def _acquisition(
         acquisition_type=AcquisitionType.INTEGRATION,
         averaging_mode=AveragingMode.CYCLIC,
     )
-    for qubit in targets:
-        acq_handle = list(sequence.channel(platform.qubits[qubit].acquisition))[-1].id
-        reference_value[qubit] = results[acq_handle].tolist()
+    for q, ch in zip(targets, acquisition_channels):
+        acq_handle = list(sequence.channel(ch))[-1].id
+        reference_value[q] = results[acq_handle].tolist()
 
     for twpa in twpas.values():
         twpa.connect()
 
-    updates = []
+    updates: list[dict[str, dict[str, Any]]] = []
 
     data = TwpaCalibrationData(
         twpa_power=twpa_power_ranges,
         twpa_frequency=twpa_frequency_ranges,
         reference_value=reference_value,
     )
-    data_ = {qubit: [] for qubit in targets}
+    data_: dict[QubitId, list[npt.NDArray[np.float64]]] = {
+        qubit: [] for qubit in targets
+    }
     for _pow in twpa_power_range:
-        for twpa_channel in twpas:
-            power = _pow + platform.config(twpa_channel).power
-            updates.append({twpa_channel: {"power": power}})
+        for twpa, cfg in twpa_configs.items():
+            power = _pow + cfg.power
+            updates.append({twpa: {"power": power}})
         for freq in twpa_frequency_range:
-            for twpa_channel in twpas:
-                frequency = freq + platform.config(twpa_channel).frequency
-                updates.append({twpa_channel: {"frequency": frequency}})
+            for twpa, cfg in twpa_configs.items():
+                frequency = freq + cfg.frequency
+                updates.append({twpa: {"frequency": frequency}})
             results = platform.execute(
                 [sequence],
                 [sweepers],
@@ -180,14 +195,12 @@ def _acquisition(
                 averaging_mode=AveragingMode.CYCLIC,
                 updates=updates,
             )
-            for qubit in targets:
-                acq_handle = list(sequence.channel(platform.qubits[qubit].acquisition))[
-                    -1
-                ].id
+            for qubit, ch in zip(targets, acquisition_channels):
+                acq_handle = list(sequence.channel(ch))[-1].id
                 data_[qubit].append(results[acq_handle])
-            for _ in twpas:
+            for _ in twpa_configs:
                 updates.pop()
-        for _ in twpas:
+        for _ in twpa_configs:
             updates.pop()
     data.data = {
         qubit: np.stack(data_[qubit], axis=0).reshape(

--- a/src/qibocal/protocols/twpa/twpa.py
+++ b/src/qibocal/protocols/twpa/twpa.py
@@ -1,5 +1,7 @@
 """Protocol to calibrate TWPA power and frequency for a specific probe frequency."""
 
+from collections import defaultdict
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, cast
 
@@ -137,6 +139,99 @@ class TwpaCalibrationData(Data):
         return np.array(self.reference_value[qubit]).reshape(-1, 2)
 
 
+def _reference_scan(
+    platform: CalibrationPlatform,
+    sequence: PulseSequence,
+    sweepers: list[Sweeper],
+    nshots: int,
+    relaxation_time: float,
+    acquisition_channels: Sequence[str],
+    twpas: Sequence[LocalOscillator],
+) -> list[list[float]]:
+    """Reference scan with TWPA off to compute the gain later on."""
+    reference_value: list[list[float]] = []
+    # reference value without twpas
+    for twpa in twpas:
+        assert twpa.device is not None
+        twpa.device.off()
+
+    results = platform.execute(
+        [sequence],
+        [sweepers],
+        nshots=nshots,
+        relaxation_time=relaxation_time,
+        acquisition_type=AcquisitionType.INTEGRATION,
+        averaging_mode=AveragingMode.CYCLIC,
+    )
+    for ch in acquisition_channels:
+        acq_handle = list(sequence.channel(ch))[-1].id
+        reference_value.append(results[acq_handle].tolist())
+
+    for twpa in twpas:
+        assert twpa.device is not None
+        twpa.device.on()
+    return reference_value
+
+
+def _twpa_scan(
+    platform: CalibrationPlatform,
+    sequence: PulseSequence,
+    sweepers: list[Sweeper],
+    qubits: Sequence[QubitId],
+    pumps: Sequence[str],
+    acquisition_channels: Sequence[str],
+    params: TwpaCalibrationParameters,
+) -> TwpaCalibrationData:
+    """TWPA scan to compute the gain."""
+    twpa_configs = {
+        pump: cast(OscillatorConfig, platform.config(pump)) for pump in pumps
+    }
+    power_ranges: dict[QubitId, list[float]] = {
+        q: np.arange(*params.power_range(twpa.power)).tolist()
+        for q, twpa in zip(qubits, twpa_configs.values())
+    }
+    frequency_ranges: dict[QubitId, list[float]] = {
+        q: np.arange(*params.frequency_range(twpa.frequency)).tolist()
+        for q, twpa in zip(qubits, twpa_configs.values())
+    }
+
+    data = TwpaCalibrationData(
+        twpa_power=power_ranges,
+        twpa_frequency=frequency_ranges,
+    )
+
+    data_: dict[QubitId, list[npt.NDArray[np.float64]]] = defaultdict(list)
+    for powers in zip(*power_ranges.values()):
+        for frequencies in zip(*frequency_ranges.values()):
+            updates: list[dict[str, dict[str, Any]]] = []
+            for twpa, power, frequency in zip(twpa_configs.keys(), powers, frequencies):
+                updates.append({twpa: {"power": power, "frequency": frequency}})
+            results = platform.execute(
+                [sequence],
+                [sweepers],
+                nshots=params.nshots,
+                relaxation_time=params.relaxation_time,
+                acquisition_type=AcquisitionType.INTEGRATION,
+                averaging_mode=AveragingMode.CYCLIC,
+                updates=updates,
+            )
+            for qubit, ch in zip(qubits, acquisition_channels):
+                acq_handle = list(sequence.channel(ch))[-1].id
+                data_[qubit].append(results[acq_handle])
+
+    data.data = {
+        qubit: np.stack(data_[qubit], axis=0).reshape(
+            len(np.arange(*params.power_range())),
+            len(np.arange(*params.frequency_range())),
+            len(np.arange(*params.probe_frequency_range())),
+            2,
+        )
+        for qubit in qubits
+    }
+
+    return data
+
+
 def _acquisition(
     params: TwpaCalibrationParameters,
     platform: CalibrationPlatform,
@@ -157,10 +252,6 @@ def _acquisition(
         pump = cast(AcquisitionChannel, platform.channels[qubit.acquisition]).twpa_pump
         assert pump is not None
         pumps.append(pump)
-    twpas = {pump: cast(LocalOscillator, platform.instruments[pump]) for pump in pumps}
-    twpa_configs = {
-        pump: cast(OscillatorConfig, platform.config(pump)) for pump in pumps
-    }
 
     sequence = PulseSequence()
     for ch in acquisition_channels:
@@ -168,107 +259,38 @@ def _acquisition(
             (
                 ch,
                 Readout(
-                    acquisition=Acquisition(duration=params.duration),
+                    acquisition=Acquisition(duration=params.probe_duration),
                     probe=Pulse(
-                        duration=params.duration,
-                        amplitude=params.amplitude,
+                        duration=params.probe_duration,
+                        amplitude=params.probe_amplitude,
                         envelope=Rectangular(),
                     ),
                 ),
             )
         ]
 
-    frequency_range = np.arange(
-        -params.freq_width / 2, params.freq_width / 2, params.freq_step
-    )
-    twpa_frequency_range = np.arange(
-        -params.twpa_freq_width / 2,
-        params.twpa_freq_width / 2,
-        params.twpa_freq_step,
-    )
-    twpa_power_range = np.arange(
-        -params.twpa_pow_width / 2, params.twpa_pow_width / 2, params.twpa_pow_step
-    )
-    twpa_power_ranges = {
-        q: (twpa_power_range + twpa.power).tolist()
-        for q, twpa in zip(targets, twpa_configs.values())
-    }
-    twpa_frequency_ranges = {
-        q: (twpa_frequency_range + twpa.frequency).tolist()
-        for q, twpa in zip(targets, twpa_configs.values())
-    }
-
     sweepers = [
         Sweeper(
             parameter=Parameter.frequency,
-            values=readout_frequency(q, platform) + frequency_range,
+            range=params.probe_frequency_range(readout_frequency(q, platform)),
             channels=[qubit.probe],
         )
         for q, qubit in zip(targets, qubits)
     ]
-
-    reference_value: dict[QubitId, list[float]] = {}
-    # reference value without twpas
-    for twpa in twpas.values():
-        assert twpa.device is not None
-        twpa.device.off()
-
-    results = platform.execute(
-        [sequence],
-        [sweepers],
-        nshots=params.nshots,
-        relaxation_time=params.relaxation_time,
-        acquisition_type=AcquisitionType.INTEGRATION,
-        averaging_mode=AveragingMode.CYCLIC,
+    reference_value = _reference_scan(
+        platform,
+        sequence,
+        sweepers,
+        params.nshots,
+        params.relaxation_time,
+        acquisition_channels,
+        [cast(LocalOscillator, platform.instruments[pump]) for pump in pumps],
     )
-    for q, ch in zip(targets, acquisition_channels):
-        acq_handle = list(sequence.channel(ch))[-1].id
-        reference_value[q] = results[acq_handle].tolist()
 
-    for twpa in twpas.values():
-        assert twpa.device is not None
-        twpa.device.on()
-
-    updates: list[dict[str, dict[str, Any]]] = []
-
-    data = TwpaCalibrationData(
-        twpa_power=twpa_power_ranges,
-        twpa_frequency=twpa_frequency_ranges,
-        reference_value=reference_value,
+    data = _twpa_scan(
+        platform, sequence, sweepers, targets, pumps, acquisition_channels, params
     )
-    data_: dict[QubitId, list[npt.NDArray[np.float64]]] = {
-        qubit: [] for qubit in targets
-    }
-    for _pow in twpa_power_range:
-        for twpa, cfg in twpa_configs.items():
-            power = _pow + cfg.power
-            updates.append({twpa: {"power": power}})
-        for freq in twpa_frequency_range:
-            for twpa, cfg in twpa_configs.items():
-                frequency = freq + cfg.frequency
-                updates.append({twpa: {"frequency": frequency}})
-            results = platform.execute(
-                [sequence],
-                [sweepers],
-                nshots=params.nshots,
-                relaxation_time=params.relaxation_time,
-                acquisition_type=AcquisitionType.INTEGRATION,
-                averaging_mode=AveragingMode.CYCLIC,
-                updates=updates,
-            )
-            for qubit, ch in zip(targets, acquisition_channels):
-                acq_handle = list(sequence.channel(ch))[-1].id
-                data_[qubit].append(results[acq_handle])
-            for _ in twpa_configs:
-                updates.pop()
-        for _ in twpa_configs:
-            updates.pop()
-    data.data = {
-        qubit: np.stack(data_[qubit], axis=0).reshape(
-            len(twpa_power_range), len(twpa_frequency_range), len(frequency_range), 2
-        )
-        for qubit in targets
-    }
+    data.reference_value = dict(zip(targets, reference_value))
     return data
 
 

--- a/src/qibocal/protocols/twpa/twpa.py
+++ b/src/qibocal/protocols/twpa/twpa.py
@@ -35,10 +35,8 @@ class TwpaCalibrationParameters(Parameters):
     """Width for TPWA power sweep (dBm)."""
     twpa_pow_step: int
     """TPWA power step (dBm)."""
-    nshots: int | None = None
-    """Number of shots."""
-    relaxation_time: int | None = None
-    """Relaxation time (ns)."""
+    duration: float = 8e3
+    amplitude: float = 0.1
 
 
 @dataclass
@@ -83,17 +81,20 @@ def _acquisition(
     """
 
     sequence = PulseSequence()
-    for qubit in targets:
-        sequence += platform.natives.single_qubit[qubit].MZ()
-
-    twpas = {
-        platform.channels[
-            platform.qubits[qubit].acquisition
-        ].twpa_pump: platform.instruments[
-            platform.channels[platform.qubits[qubit].acquisition].twpa_pump
+    for ch in acquisition_channels:
+        sequence += [
+            (
+                ch,
+                Readout(
+                    acquisition=Acquisition(duration=params.duration),
+                    probe=Pulse(
+                        duration=params.duration,
+                        amplitude=params.amplitude,
+                        envelope=Rectangular(),
+                    ),
+                ),
+            )
         ]
-        for qubit in targets
-    }
 
     frequency_range = np.arange(
         -params.freq_width / 2, params.freq_width / 2, params.freq_step

--- a/src/qibocal/protocols/twpa/twpa.py
+++ b/src/qibocal/protocols/twpa/twpa.py
@@ -52,7 +52,7 @@ class TwpaCalibrationParameters(Parameters):
 class TwpaCalibrationResults(Results):
     """TwpaCalibration outputs."""
 
-    data: dict[QubitId, npt.NDArray]
+    data: dict[QubitId, npt.NDArray[np.float64]]
     """Array with average gain for each qubit."""
     twpa_frequency: dict[QubitId, float]
     """TWPA frequency [GHz]."""
@@ -64,16 +64,16 @@ class TwpaCalibrationResults(Results):
 class TwpaCalibrationData(Data):
     """TwpaCalibration data acquisition."""
 
-    data: dict[QubitId, npt.NDArray] = field(default_factory=dict)
+    data: dict[QubitId, npt.NDArray[np.float64]] = field(default_factory=dict)
     """Raw data acquired."""
-    twpa_frequency: dict[QubitId, list[float]] = field(default=list)
+    twpa_frequency: dict[QubitId, list[float]] = field(default=dict)
     """List with twpa frequency values swept."""
-    twpa_power: dict[QubitId, list[float]] = field(default=list)
+    twpa_power: dict[QubitId, list[float]] = field(default=dict)
     """List with twpa power values swept."""
-    reference_value: dict[QubitId, list[float]] = field(default=list)
+    reference_value: dict[QubitId, list[float]] = field(default=dict)
     """Values for readout frequency sweep with TWPA off."""
 
-    def reference_value_array(self, qubit: QubitId) -> npt.NDArray:
+    def reference_value_array(self, qubit: QubitId) -> npt.NDArray[np.float64]:
         """Return reference value as a numpy array."""
         return np.array(self.reference_value[qubit]).reshape(-1, 2)
 
@@ -217,9 +217,9 @@ def _fit(data: TwpaCalibrationData) -> TwpaCalibrationResults:
     After computing the averaged gain we select the corresponding twpa frequency and power
     that maximizes the gain for each qubit.
     """
-    gains = {}
-    twpa_frequency = {}
-    twpa_power = {}
+    gains: dict[QubitId, npt.NDArray[np.float64]] = {}
+    twpa_frequency: dict[QubitId, float] = {}
+    twpa_power: dict[QubitId, float] = {}
     for qubit in data.qubits:
         averaged_gain = 20 * np.log10(
             np.mean(magnitude(data[qubit]), axis=2)
@@ -228,8 +228,8 @@ def _fit(data: TwpaCalibrationData) -> TwpaCalibrationResults:
         gains[qubit] = averaged_gain
         flat_index = np.argmax(averaged_gain)
         i, j = np.unravel_index(flat_index, averaged_gain.shape)
-        twpa_frequency[qubit] = float(data.twpa_frequency[qubit][j])
-        twpa_power[qubit] = float(data.twpa_power[qubit][i])
+        twpa_frequency[qubit] = data.twpa_frequency[qubit][j]
+        twpa_power[qubit] = data.twpa_power[qubit][i]
     return TwpaCalibrationResults(
         data=gains,
         twpa_frequency=twpa_frequency,


### PR DESCRIPTION
Notable changes:

- the probe and acquisition performed were taken from the calibrated measurement; now, they are independent, and the probe is set to a rectangular pulse, whose amplitude and duration are exposed as parameters; the same duration is also used by the acquisition
- the TWPA pump (RF source) was disconnected in the reference, relying on the automated shutdown; this is not any longer true, since https://github.com/qiboteam/qibolab/pull/1348; in this PR, it has been replaced by an explicit shutdown