### PR TITLE
remove recommonmark

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -12,7 +12,6 @@
 #
 from pathlib import Path
 
-from recommonmark.transform import AutoStructify
 from sphinx.ext import apidoc
 
 import qibocal
@@ -48,7 +47,6 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx.ext.napoleon",
     "sphinx.ext.intersphinx",
-    "recommonmark",
     "sphinx.ext.viewcode",
     "sphinx.ext.todo",
     "sphinx_copybutton",
@@ -118,11 +116,7 @@ intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 autodoc_member_order = "bysource"
 
 
-# Adapted this from
-# https://github.com/readthedocs/recommonmark/blob/ddd56e7717e9745f11300059e4268e204138a6b1/docs/conf.py
 # app setup hook
-
-
 def run_apidoc(_):
     """Extract autodoc directives from package structure."""
     source = Path(__file__).parent
@@ -132,10 +126,7 @@ def run_apidoc(_):
 
 
 def setup(app):
-    app.add_config_value("recommonmark_config", {"enable_eval_rst": True}, True)
-    app.add_transform(AutoStructify)
     app.add_css_file("css/style.css")
-
     app.connect("builder-inited", run_apidoc)
 
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -10,7 +10,6 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
 from pathlib import Path
 
 from recommonmark.transform import AutoStructify
@@ -114,11 +113,6 @@ html_static_path = ["_static"]
 
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
-
-# -- Doctest ------------------------------------------------------------------
-#
-
-doctest_path = [os.path.abspath("../examples")]
 
 # -- Autodoc ------------------------------------------------------------------
 #

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -4,12 +4,6 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-# -- Path setup --------------------------------------------------------------
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#
 from pathlib import Path
 
 from sphinx.ext import apidoc

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -31,7 +31,6 @@ release = qibocal.__version__
 # https://stackoverflow.com/questions/56336234/build-fail-sphinx-error-contents-rst-not-found
 # master_doc = "index"
 
-autodoc_mock_imports = ["qm"]
 autodoc_default_options = {
     "members": True,
     "undoc-members": True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ docs = [
   "sphinx>=9.0.0,<10.0.0",
   "furo>=2025.7.19,<2026.0.0",
   "sphinxcontrib-bibtex>=2.6.0,<3.0.0",
-  "recommonmark>=0.7.1,<0.8.0",
   "sphinx-copybutton>=0.5.1,<0.6.0",
 ]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -300,15 +300,6 @@ wheels = [
 ]
 
 [[package]]
-name = "commonmark"
-version = "0.9.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3e/e4/0800832e530c88a8f80cb9e486879ea74257062dfe03a38c1ad535c2860e/commonmark-0.9.2.tar.gz", hash = "sha256:194d693e0c1ac49e83c26455bdeeb2483235e6280313c58b11d0b71c19f58ed1", size = 97077, upload-time = "2026-05-28T20:42:32.03Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/5f/8258106ce24cfcb92134de904905a3118574a8b205c2a135301751797ec3/commonmark-0.9.2-py2.py3-none-any.whl", hash = "sha256:cc7dfaea4557c79e32ce1ad36727185ea8cfe9c7e797cf79297c5cdffe6c7f5a", size = 51416, upload-time = "2026-05-28T20:42:31.04Z" },
-]
-
-[[package]]
 name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1788,7 +1779,6 @@ dev = [
 ]
 docs = [
     { name = "furo" },
-    { name = "recommonmark" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sphinx-copybutton" },
@@ -1826,7 +1816,6 @@ dev = [
 ]
 docs = [
     { name = "furo", specifier = ">=2025.7.19,<2026.0.0" },
-    { name = "recommonmark", specifier = ">=0.7.1,<0.8.0" },
     { name = "sphinx", specifier = ">=9.0.0,<10.0.0" },
     { name = "sphinx-copybutton", specifier = ">=0.5.1,<0.6.0" },
     { name = "sphinxcontrib-bibtex", specifier = ">=2.6.0,<3.0.0" },
@@ -1851,21 +1840,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/27/f0/db4099cfedc574a1d62e22ccdba35b315c65b5c1d1ba6b45aa4b353d94b6/qibolab-0.2.16.tar.gz", hash = "sha256:c72c13cad2ce0582819ff73fc395e685dc64dfb5bec5f475c6cd244dc2265843", size = 137518, upload-time = "2026-07-16T06:42:19.069Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/53/f8/6372af39f3f52e445237792cecf8ae1acb9113903eb7be1dda5a7e3b5421/qibolab-0.2.16-py3-none-any.whl", hash = "sha256:816b161e9d6cb6fc157cdbf3d6c7b745faeda8a98689cee3283118d67837597c", size = 187297, upload-time = "2026-07-16T06:42:17.771Z" },
-]
-
-[[package]]
-name = "recommonmark"
-version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "commonmark" },
-    { name = "docutils" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/00/3dd2bdc4184b0ce754b5b446325abf45c2e0a347e022292ddc44670f628c/recommonmark-0.7.1.tar.gz", hash = "sha256:bdb4db649f2222dcd8d2d844f0006b958d627f732415d399791ee436a3686d67", size = 34444, upload-time = "2020-12-17T19:24:56.523Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/77/ed589c75db5d02a77a1d5d2d9abc63f29676467d396c64277f98b50b79c2/recommonmark-0.7.1-py2.py3-none-any.whl", hash = "sha256:1b1db69af0231efce3fa21b94ff627ea33dee7079a01dd0a7f8482c3da148b3f", size = 10214, upload-time = "2020-12-17T19:24:55.137Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
There are no longer .md in the docs, so we don't need recommonmark (it's also not maintained so we needed to get rid of it anyway).